### PR TITLE
MVP For Chainlink PPROF

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -528,9 +528,7 @@ func (e *EthereumMultinodeClient) GetChainID() *big.Int {
 // GetClients gets clients for all nodes connected
 func (e *EthereumMultinodeClient) GetClients() []EVMClient {
 	cl := make([]EVMClient, 0)
-	for _, c := range e.Clients {
-		cl = append(cl, c)
-	}
+	cl = append(cl, e.Clients...)
 	return cl
 }
 

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -116,7 +117,7 @@ func (c *chainlink) URL() string {
 func (c *chainlink) CreateJobRaw(spec string) (*Job, error) {
 	job := &Job{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Job Body", spec).Msg("Creating Job")
-	_, err := c.do(http.MethodPost, "/v2/jobs", &JobForm{
+	err := c.do(http.MethodPost, "/v2/jobs", &JobForm{
 		TOML: spec,
 	}, &job, http.StatusOK)
 	return job, err
@@ -130,7 +131,7 @@ func (c *chainlink) CreateJob(spec JobSpec) (*Job, error) {
 		return nil, err
 	}
 	log.Info().Str("Node URL", c.Config.URL).Str("Type", spec.Type()).Msg("Creating Job")
-	_, err = c.do(http.MethodPost, "/v2/jobs", &JobForm{
+	err = c.do(http.MethodPost, "/v2/jobs", &JobForm{
 		TOML: specString,
 	}, &job, http.StatusOK)
 	return job, err
@@ -140,23 +141,20 @@ func (c *chainlink) CreateJob(spec JobSpec) (*Job, error) {
 func (c *chainlink) ReadJobs() (*ResponseSlice, error) {
 	specObj := &ResponseSlice{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Getting Jobs")
-	_, err := c.do(http.MethodGet, "/v2/jobs", nil, specObj, http.StatusOK)
-	return specObj, err
+	return specObj, c.do(http.MethodGet, "/v2/jobs", nil, specObj, http.StatusOK)
 }
 
 // ReadJob reads a job with the provided ID from the Chainlink node
 func (c *chainlink) ReadJob(id string) (*Response, error) {
 	specObj := &Response{}
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Reading Job")
-	_, err := c.do(http.MethodGet, fmt.Sprintf("/v2/jobs/%s", id), nil, specObj, http.StatusOK)
-	return specObj, err
+	return specObj, c.do(http.MethodGet, fmt.Sprintf("/v2/jobs/%s", id), nil, specObj, http.StatusOK)
 }
 
 // DeleteJob deletes a job with a provided ID from the Chainlink node
 func (c *chainlink) DeleteJob(id string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Deleting Job")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/jobs/%s", id), nil, nil, http.StatusNoContent)
-	return err
+	return c.do(http.MethodDelete, fmt.Sprintf("/v2/jobs/%s", id), nil, nil, http.StatusNoContent)
 }
 
 // CreateSpec creates a job spec on the Chainlink node
@@ -164,68 +162,60 @@ func (c *chainlink) CreateSpec(spec string) (*Spec, error) {
 	s := &Spec{}
 	r := strings.NewReplacer("\n", "", " ", "", "\\", "") // Makes it more compact and readable for logging
 	log.Info().Str("Node URL", c.Config.URL).Str("Spec", r.Replace(spec)).Msg("Creating Spec")
-	_, err := c.doRaw(http.MethodPost, "/v2/specs", []byte(spec), s, http.StatusOK)
-	return s, err
+	return s, c.doRaw(http.MethodPost, "/v2/specs", []byte(spec), s, http.StatusOK)
 }
 
 // ReadSpec reads a job spec with the provided ID on the Chainlink node
 func (c *chainlink) ReadSpec(id string) (*Response, error) {
 	specObj := &Response{}
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Reading Spec")
-	_, err := c.do(http.MethodGet, fmt.Sprintf("/v2/specs/%s", id), nil, specObj, http.StatusOK)
-	return specObj, err
+	return specObj, c.do(http.MethodGet, fmt.Sprintf("/v2/specs/%s", id), nil, specObj, http.StatusOK)
 }
 
 // ReadRunsByJob reads all runs for a job
 func (c *chainlink) ReadRunsByJob(jobID string) (*JobRunsResponse, error) {
 	runsObj := &JobRunsResponse{}
 	log.Debug().Str("Node URL", c.Config.URL).Str("JobID", jobID).Msg("Reading runs for a job")
-	_, err := c.do(http.MethodGet, fmt.Sprintf("/v2/jobs/%s/runs", jobID), nil, runsObj, http.StatusOK)
-	return runsObj, err
+	return runsObj, c.do(http.MethodGet, fmt.Sprintf("/v2/jobs/%s/runs", jobID), nil, runsObj, http.StatusOK)
 }
 
 // DeleteSpec deletes a job spec with the provided ID from the Chainlink node
 func (c *chainlink) DeleteSpec(id string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Deleting Spec")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/specs/%s", id), nil, nil, http.StatusNoContent)
-	return err
+	return c.do(http.MethodDelete, fmt.Sprintf("/v2/specs/%s", id), nil, nil, http.StatusNoContent)
 }
 
 // CreateBridge creates a bridge on the Chainlink node based on the provided attributes
 func (c *chainlink) CreateBridge(bta *BridgeTypeAttributes) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", bta.Name).Msg("Creating Bridge")
-	_, err := c.do(http.MethodPost, "/v2/bridge_types", bta, nil, http.StatusOK)
-	return err
+	return c.do(http.MethodPost, "/v2/bridge_types", bta, nil, http.StatusOK)
 }
 
 // ReadBridge reads a bridge from the Chainlink node based on the provided name
 func (c *chainlink) ReadBridge(name string) (*BridgeType, error) {
 	bt := BridgeType{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", name).Msg("Reading Bridge")
-	_, err := c.do(http.MethodGet, fmt.Sprintf("/v2/bridge_types/%s", name), nil, &bt, http.StatusOK)
-	return &bt, err
+	return &bt, c.do(http.MethodGet, fmt.Sprintf("/v2/bridge_types/%s", name), nil, &bt, http.StatusOK)
 }
 
 // DeleteBridge deletes a bridge on the Chainlink node based on the provided name
 func (c *chainlink) DeleteBridge(name string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", name).Msg("Deleting Bridge")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/bridge_types/%s", name), nil, nil, http.StatusOK)
-	return err
+	return c.do(http.MethodDelete, fmt.Sprintf("/v2/bridge_types/%s", name), nil, nil, http.StatusOK)
 }
 
 // CreateOCRKey creates an OCRKey on the Chainlink node
 func (c *chainlink) CreateOCRKey() (*OCRKey, error) {
 	ocrKey := &OCRKey{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating OCR Key")
-	_, err := c.do(http.MethodPost, "/v2/keys/ocr", nil, ocrKey, http.StatusOK)
-	return ocrKey, err
+	return ocrKey, c.do(http.MethodPost, "/v2/keys/ocr", nil, ocrKey, http.StatusOK)
 }
 
 // ReadOCRKeys reads all OCRKeys from the Chainlink node
 func (c *chainlink) ReadOCRKeys() (*OCRKeys, error) {
 	ocrKeys := &OCRKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading OCR Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/ocr", nil, ocrKeys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/ocr", nil, ocrKeys, http.StatusOK)
 	for index := range ocrKeys.Data {
 		ocrKeys.Data[index].Attributes.ConfigPublicKey = strings.TrimPrefix(
 			ocrKeys.Data[index].Attributes.ConfigPublicKey, "ocrcfg_")
@@ -240,7 +230,7 @@ func (c *chainlink) ReadOCRKeys() (*OCRKeys, error) {
 // DeleteOCRKey deletes an OCRKey based on the provided ID
 func (c *chainlink) DeleteOCRKey(id string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Deleting OCR Key")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/ocr/%s", id), nil, nil, http.StatusOK)
+	err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/ocr/%s", id), nil, nil, http.StatusOK)
 	return err
 }
 
@@ -248,7 +238,7 @@ func (c *chainlink) DeleteOCRKey(id string) error {
 func (c *chainlink) CreateOCR2Key(chain string) (*OCR2Key, error) {
 	ocr2Key := &OCR2Key{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating OCR2 Key")
-	_, err := c.do(http.MethodPost, fmt.Sprintf("/v2/keys/ocr2/%s", chain), nil, ocr2Key, http.StatusOK)
+	err := c.do(http.MethodPost, fmt.Sprintf("/v2/keys/ocr2/%s", chain), nil, ocr2Key, http.StatusOK)
 	return ocr2Key, err
 }
 
@@ -256,14 +246,14 @@ func (c *chainlink) CreateOCR2Key(chain string) (*OCR2Key, error) {
 func (c *chainlink) ReadOCR2Keys() (*OCR2Keys, error) {
 	ocr2Keys := &OCR2Keys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading OCR2 Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/ocr2", nil, ocr2Keys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/ocr2", nil, ocr2Keys, http.StatusOK)
 	return ocr2Keys, err
 }
 
 // DeleteOCR2Key deletes an OCR2Key based on the provided ID
 func (c *chainlink) DeleteOCR2Key(id string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Deleting OCR2 Key")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/ocr2/%s", id), nil, nil, http.StatusOK)
+	err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/ocr2/%s", id), nil, nil, http.StatusOK)
 	return err
 }
 
@@ -271,7 +261,7 @@ func (c *chainlink) DeleteOCR2Key(id string) error {
 func (c *chainlink) CreateP2PKey() (*P2PKey, error) {
 	p2pKey := &P2PKey{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating P2P Key")
-	_, err := c.do(http.MethodPost, "/v2/keys/p2p", nil, p2pKey, http.StatusOK)
+	err := c.do(http.MethodPost, "/v2/keys/p2p", nil, p2pKey, http.StatusOK)
 	return p2pKey, err
 }
 
@@ -279,7 +269,7 @@ func (c *chainlink) CreateP2PKey() (*P2PKey, error) {
 func (c *chainlink) ReadP2PKeys() (*P2PKeys, error) {
 	p2pKeys := &P2PKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading P2P Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/p2p", nil, p2pKeys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/p2p", nil, p2pKeys, http.StatusOK)
 	if len(p2pKeys.Data) == 0 {
 		err = fmt.Errorf("Found no P2P Keys on the chainlink node. Node URL: %s", c.Config.URL)
 		log.Err(err).Msg("Error getting P2P keys")
@@ -294,7 +284,7 @@ func (c *chainlink) ReadP2PKeys() (*P2PKeys, error) {
 // DeleteP2PKey deletes a P2PKey on the Chainlink node based on the provided ID
 func (c *chainlink) DeleteP2PKey(id int) error {
 	log.Info().Str("Node URL", c.Config.URL).Int("ID", id).Msg("Deleting P2P Key")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/p2p/%d", id), nil, nil, http.StatusOK)
+	err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/p2p/%d", id), nil, nil, http.StatusOK)
 	return err
 }
 
@@ -302,7 +292,7 @@ func (c *chainlink) DeleteP2PKey(id int) error {
 func (c *chainlink) ReadETHKeys() (*ETHKeys, error) {
 	ethKeys := &ETHKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading ETH Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/eth", nil, ethKeys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/eth", nil, ethKeys, http.StatusOK)
 	if len(ethKeys.Data) == 0 {
 		log.Warn().Str("Node URL", c.Config.URL).Msg("Found no ETH Keys on the node")
 	}
@@ -313,7 +303,7 @@ func (c *chainlink) ReadETHKeys() (*ETHKeys, error) {
 func (c *chainlink) UpdateEthKeyMaxGasPriceGWei(keyId string, gWei int) (*ETHKey, error) {
 	ethKey := &ETHKey{}
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", keyId).Int("maxGasPriceGWei", gWei).Msg("Update maxGasPriceGWei for eth key")
-	_, err := c.do(http.MethodPut, fmt.Sprintf("/v2/keys/eth/%s?maxGasPriceGWei=%d", keyId, gWei), nil, ethKey, http.StatusOK)
+	err := c.do(http.MethodPut, fmt.Sprintf("/v2/keys/eth/%s?maxGasPriceGWei=%d", keyId, gWei), nil, ethKey, http.StatusOK)
 	return ethKey, err
 }
 
@@ -345,7 +335,7 @@ func (c *chainlink) PrimaryEthAddress() (string, error) {
 func (c *chainlink) CreateTxKey(chain string) (*TxKey, error) {
 	txKey := &TxKey{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating Tx Key")
-	_, err := c.do(http.MethodPost, fmt.Sprintf("/v2/keys/%s", chain), nil, txKey, http.StatusOK)
+	err := c.do(http.MethodPost, fmt.Sprintf("/v2/keys/%s", chain), nil, txKey, http.StatusOK)
 	return txKey, err
 }
 
@@ -353,14 +343,14 @@ func (c *chainlink) CreateTxKey(chain string) (*TxKey, error) {
 func (c *chainlink) ReadTxKeys(chain string) (*TxKeys, error) {
 	txKeys := &TxKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading Tx Keys")
-	_, err := c.do(http.MethodGet, fmt.Sprintf("/v2/keys/%s", chain), nil, txKeys, http.StatusOK)
+	err := c.do(http.MethodGet, fmt.Sprintf("/v2/keys/%s", chain), nil, txKeys, http.StatusOK)
 	return txKeys, err
 }
 
 // DeleteTxKey deletes an tx key based on the provided ID
 func (c *chainlink) DeleteTxKey(chain string, id string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("ID", id).Msg("Deleting Tx Key")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/%s/%s", chain, id), nil, nil, http.StatusOK)
+	err := c.do(http.MethodDelete, fmt.Sprintf("/v2/keys/%s/%s", chain, id), nil, nil, http.StatusOK)
 	return err
 }
 
@@ -368,7 +358,7 @@ func (c *chainlink) DeleteTxKey(chain string, id string) error {
 func (c *chainlink) ReadTransactionAttempts() (*TransactionsData, error) {
 	txsData := &TransactionsData{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading Transaction Attempts")
-	_, err := c.do(http.MethodGet, "/v2/tx_attempts", nil, txsData, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/tx_attempts", nil, txsData, http.StatusOK)
 	return txsData, err
 }
 
@@ -376,8 +366,7 @@ func (c *chainlink) ReadTransactionAttempts() (*TransactionsData, error) {
 func (c *chainlink) ReadTransactions() (*TransactionsData, error) {
 	txsData := &TransactionsData{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading Transactions")
-	_, err := c.do(http.MethodGet, "/v2/transactions", nil, txsData, http.StatusOK)
-	return txsData, err
+	return txsData, c.do(http.MethodGet, "/v2/transactions", nil, txsData, http.StatusOK)
 }
 
 // SendNativeToken sends native token (ETH usually) of a specified amount from one of its addresses to the target address
@@ -390,7 +379,7 @@ func (c *chainlink) SendNativeToken(amount *big.Int, fromAddress, toAddress stri
 		AllowHigherAmounts: true,
 	}
 	txData := SingleTransactionDataWrapper{}
-	_, err := c.do(http.MethodPost, "/v2/transfers", request, txData, http.StatusOK)
+	err := c.do(http.MethodPost, "/v2/transfers", request, txData, http.StatusOK)
 	log.Info().
 		Str("Node URL", c.Config.URL).
 		Str("From", fromAddress).
@@ -404,7 +393,7 @@ func (c *chainlink) SendNativeToken(amount *big.Int, fromAddress, toAddress stri
 func (c *chainlink) ReadVRFKeys() (*VRFKeys, error) {
 	vrfKeys := &VRFKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading VRF Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/vrf", nil, vrfKeys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/vrf", nil, vrfKeys, http.StatusOK)
 	if len(vrfKeys.Data) == 0 {
 		log.Warn().Str("Node URL", c.Config.URL).Msg("Found no VRF Keys on the node")
 	}
@@ -415,23 +404,21 @@ func (c *chainlink) ReadVRFKeys() (*VRFKeys, error) {
 func (c *chainlink) CreateVRFKey() (*VRFKey, error) {
 	vrfKey := &VRFKey{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating VRF Key")
-	_, err := c.do(http.MethodPost, "/v2/keys/vrf", nil, vrfKey, http.StatusOK)
-	return vrfKey, err
+	return vrfKey, c.do(http.MethodPost, "/v2/keys/vrf", nil, vrfKey, http.StatusOK)
 }
 
 // CreateCSAKey creates a CSA key on the Chainlink node, only 1 CSA key per noe
 func (c *chainlink) CreateCSAKey() (*CSAKey, error) {
 	csaKey := &CSAKey{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Creating CSA Key")
-	_, err := c.do(http.MethodPost, "/v2/keys/csa", nil, csaKey, http.StatusOK)
-	return csaKey, err
+	return csaKey, c.do(http.MethodPost, "/v2/keys/csa", nil, csaKey, http.StatusOK)
 }
 
 // ReadCSAKeys reads CSA keys from the Chainlink node
 func (c *chainlink) ReadCSAKeys() (*CSAKeys, error) {
 	csaKeys := &CSAKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading CSA Keys")
-	_, err := c.do(http.MethodGet, "/v2/keys/csa", nil, csaKeys, http.StatusOK)
+	err := c.do(http.MethodGet, "/v2/keys/csa", nil, csaKeys, http.StatusOK)
 	if len(csaKeys.Data) == 0 {
 		log.Warn().Str("Node URL", c.Config.URL).Msg("Found no CSA Keys on the node")
 	}
@@ -442,55 +429,48 @@ func (c *chainlink) ReadCSAKeys() (*CSAKeys, error) {
 func (c *chainlink) CreateEI(eia *EIAttributes) (*EIKeyCreate, error) {
 	ei := EIKeyCreate{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", eia.Name).Msg("Creating External Initiator")
-	_, err := c.do(http.MethodPost, "/v2/external_initiators", eia, &ei, http.StatusCreated)
-	return &ei, err
+	return &ei, c.do(http.MethodPost, "/v2/external_initiators", eia, &ei, http.StatusCreated)
 }
 
 // ReadEIs reads all of the configured EIs from the chainlink node
 func (c *chainlink) ReadEIs() (*EIKeys, error) {
 	ei := EIKeys{}
 	log.Info().Str("Node URL", c.Config.URL).Msg("Reading EI Keys")
-	_, err := c.do(http.MethodGet, "/v2/external_initiators", nil, &ei, http.StatusOK)
-	return &ei, err
+	return &ei, c.do(http.MethodGet, "/v2/external_initiators", nil, &ei, http.StatusOK)
 }
 
 // DeleteEI deletes an external initiator in the Chainlink node based on the provided name
 func (c *chainlink) DeleteEI(name string) error {
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", name).Msg("Deleting EI")
-	_, err := c.do(http.MethodDelete, fmt.Sprintf("/v2/external_initiators/%s", name), nil, nil, http.StatusNoContent)
-	return err
+	return c.do(http.MethodDelete, fmt.Sprintf("/v2/external_initiators/%s", name), nil, nil, http.StatusNoContent)
 }
 
 // CreateTerraChain creates a terra chain
 func (c *chainlink) CreateTerraChain(chain *TerraChainAttributes) (*TerraChainCreate, error) {
 	response := TerraChainCreate{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Chain ID", chain.ChainID).Msg("Creating Terra Chain")
-	_, err := c.do(http.MethodPost, "/v2/chains/terra", chain, &response, http.StatusCreated)
-	return &response, err
+	return &response, c.do(http.MethodPost, "/v2/chains/terra", chain, &response, http.StatusCreated)
 }
 
 // CreateTerraNode creates a terra node
 func (c *chainlink) CreateTerraNode(node *TerraNodeAttributes) (*TerraNodeCreate, error) {
 	response := TerraNodeCreate{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", node.Name).Msg("Creating Terra Node")
-	_, err := c.do(http.MethodPost, "/v2/nodes/terra", node, &response, http.StatusOK)
-	return &response, err
+	return &response, c.do(http.MethodPost, "/v2/nodes/terra", node, &response, http.StatusOK)
 }
 
 // CreateSolana creates a solana chain
 func (c *chainlink) CreateSolanaChain(chain *SolanaChainAttributes) (*SolanaChainCreate, error) {
 	response := SolanaChainCreate{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Chain ID", chain.ChainID).Msg("Creating Solana Chain")
-	_, err := c.do(http.MethodPost, "/v2/chains/solana", chain, &response, http.StatusCreated)
-	return &response, err
+	return &response, c.do(http.MethodPost, "/v2/chains/solana", chain, &response, http.StatusCreated)
 }
 
 // CreateSolanaNode creates a solana node
 func (c *chainlink) CreateSolanaNode(node *SolanaNodeAttributes) (*SolanaNodeCreate, error) {
 	response := SolanaNodeCreate{}
 	log.Info().Str("Node URL", c.Config.URL).Str("Name", node.Name).Msg("Creating Solana Node")
-	_, err := c.do(http.MethodPost, "/v2/nodes/solana", node, &response, http.StatusOK)
-	return &response, err
+	return &response, c.do(http.MethodPost, "/v2/nodes/solana", node, &response, http.StatusOK)
 }
 
 // RemoteIP retrieves the inter-cluster IP of the chainlink node, for use with inter-node communications
@@ -553,15 +533,18 @@ func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chai
 	profileSeconds := int(profileTime.Seconds())
 	profileResults := NewBlankChainlinkProfileResults()
 	profileErrorGroup := new(errgroup.Group)
+	var profileExecutedGroup sync.WaitGroup
 	log.Info().Int("Seconds to Profile", profileSeconds).Str("Node URL", c.Config.URL).Msg("Starting Node PPROF session")
 	for _, rep := range profileResults.Reports {
+		profileExecutedGroup.Add(1)
 		profileReport := rep
 		// The profile function returns with the profile results after the profile time frame has concluded
 		// e.g. a profile API call of 5 seconds will start profiling, wait for 5 seconds, then send back results
 		profileErrorGroup.Go(func() error {
 			log.Warn().Str("Type", profileReport.Type).Msg("PROFILING")
 			uri := fmt.Sprintf("/v2/debug/pprof/%s?seconds=%d", profileReport.Type, profileSeconds)
-			rawBytes, err := c.doRawBytes(http.MethodGet, uri, nil, http.StatusOK)
+			profileExecutedGroup.Done()
+			rawBytes, err := c.doRawBytes(http.MethodGet, uri, nil, nil, http.StatusOK)
 			if err != nil {
 				return err
 			}
@@ -570,6 +553,9 @@ func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chai
 			return nil
 		})
 	}
+	// Wait for the profiling to actually get triggered on the node before running the function to profile
+	// An imperfect solution, but an effective one.
+	profileExecutedGroup.Wait()
 
 	funcStart := time.Now()
 	// Feed this chainlink node into the profiling function
@@ -603,12 +589,12 @@ func (c *chainlink) SetClient(client *http.Client) {
 	c.HttpClient = client
 }
 
-func (c *chainlink) doRawBase(
+func (c *chainlink) doRawBytes(
 	method,
 	endpoint string,
 	body []byte, obj interface{},
 	expectedStatusCode int,
-) (*http.Response, error) {
+) ([]byte, error) {
 	client := c.HttpClient
 
 	req, err := http.NewRequest(
@@ -629,7 +615,7 @@ func (c *chainlink) doRawBase(
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return resp, err
+		return []byte{}, err
 	}
 
 	b, err := ioutil.ReadAll(resp.Body)
@@ -642,11 +628,11 @@ func (c *chainlink) doRawBase(
 		)
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		return resp, ErrNotFound
+		return b, ErrNotFound
 	} else if resp.StatusCode == http.StatusUnprocessableEntity {
-		return resp, ErrUnprocessableEntity
+		return b, ErrUnprocessableEntity
 	} else if resp.StatusCode != expectedStatusCode {
-		return resp, fmt.Errorf(
+		return b, fmt.Errorf(
 			"unexpected response code, got %d, expected %d\nURL: %s\nresponse received: %s",
 			resp.StatusCode,
 			expectedStatusCode,
@@ -654,21 +640,6 @@ func (c *chainlink) doRawBase(
 			string(b),
 		)
 	}
-	return resp, err
-}
-
-func (c *chainlink) doRawBytes(
-	method,
-	endpoint string,
-	body []byte,
-	expectedStatusCode int,
-) ([]byte, error) {
-	resp, err := c.doRawBase(method, endpoint, body, nil, expectedStatusCode)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
 	return b, err
 }
 
@@ -677,26 +648,22 @@ func (c *chainlink) doRaw(
 	endpoint string,
 	body []byte, obj interface{},
 	expectedStatusCode int,
-) (*http.Response, error) {
-	resp, err := c.doRawBase(method, endpoint, body, obj, expectedStatusCode)
+) error {
+	respBody, err := c.doRawBytes(method, endpoint, body, obj, expectedStatusCode)
 	if obj == nil || err != nil {
-		return resp, err
+		return err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	err = json.Unmarshal(respBody, &obj)
 	if err != nil {
-		return resp, err
-	}
-	err = json.Unmarshal(b, &obj)
-	if err != nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"error while unmarshaling response to JSON: %v\nURL: %s\nresponse received: %s",
 			err,
 			c.Config.URL,
-			string(b),
+			string(respBody),
 		)
 	}
-	return resp, err
+	return err
 }
 
 func (c *chainlink) do(
@@ -705,10 +672,10 @@ func (c *chainlink) do(
 	body interface{},
 	obj interface{},
 	expectedStatusCode int,
-) (*http.Response, error) {
+) error {
 	b, err := json.Marshal(body)
 	if body != nil && err != nil {
-		return nil, err
+		return err
 	}
 	return c.doRaw(method, endpoint, b, obj, expectedStatusCode)
 }

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -541,14 +541,12 @@ func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chai
 		// The profile function returns with the profile results after the profile time frame has concluded
 		// e.g. a profile API call of 5 seconds will start profiling, wait for 5 seconds, then send back results
 		profileErrorGroup.Go(func() error {
-			log.Warn().Str("Type", profileReport.Type).Msg("PROFILING")
 			uri := fmt.Sprintf("/v2/debug/pprof/%s?seconds=%d", profileReport.Type, profileSeconds)
 			profileExecutedGroup.Done()
 			rawBytes, err := c.doRawBytes(http.MethodGet, uri, nil, nil, http.StatusOK)
 			if err != nil {
 				return err
 			}
-			log.Warn().Str("Type", profileReport.Type).Msg("DONE PROFILING")
 			profileReport.Data = rawBytes
 			return nil
 		})

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -527,8 +527,8 @@ func (c *chainlink) SetSessionCookie() error {
 	return nil
 }
 
-// Profile runs the provided function once to gauge roughly how long it takes. It will then trigger a time-blocked
-// profiling session on the Chainlink node and run the functions again.
+// Profile starts a profile session on the Chainlink node for a pre-determined length, then runs the provided function
+// to profile it.
 func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chainlink)) (*ChainlinkProfileResults, error) {
 	profileSeconds := int(profileTime.Seconds())
 	profileResults := NewBlankChainlinkProfileResults()

--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -541,12 +541,14 @@ func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chai
 		// The profile function returns with the profile results after the profile time frame has concluded
 		// e.g. a profile API call of 5 seconds will start profiling, wait for 5 seconds, then send back results
 		profileErrorGroup.Go(func() error {
+			log.Debug().Str("Type", profileReport.Type).Msg("PROFILING")
 			uri := fmt.Sprintf("/v2/debug/pprof/%s?seconds=%d", profileReport.Type, profileSeconds)
 			profileExecutedGroup.Done()
 			rawBytes, err := c.doRawBytes(http.MethodGet, uri, nil, nil, http.StatusOK)
 			if err != nil {
 				return err
 			}
+			log.Debug().Str("Type", profileReport.Type).Msg("DONE PROFILING")
 			profileReport.Data = rawBytes
 			return nil
 		})

--- a/client/chainlink_models.go
+++ b/client/chainlink_models.go
@@ -22,6 +22,42 @@ type ChainlinkConfig struct {
 	RemoteIP string
 }
 
+// ChainlinkProfileResults holds the results of asking the Chainlink node to run a PPROF session
+type ChainlinkProfileResults struct {
+	Reports                 []*ChainlinkProfileResult
+	ScheduledProfileSeconds int // How long the profile was scheduled to last
+	ActualRunSeconds        int // How long the target function to profile actually took to execute
+	NodeIndex               int
+}
+
+// ChainlinkProfileResult contains the result of a single PPROF run
+type ChainlinkProfileResult struct {
+	Type string
+	Data []byte
+}
+
+// NewBlankChainlinkProfileResults returns all the standard types of profile results with blank data
+func NewBlankChainlinkProfileResults() *ChainlinkProfileResults {
+	results := &ChainlinkProfileResults{
+		Reports: make([]*ChainlinkProfileResult, 0),
+	}
+	profileStrings := []string{
+		"allocs", // A sampling of all past memory allocations
+		"block",  // Stack traces that led to blocking on synchronization primitives
+		// "cmdline",      // The command line invocation of the current program
+		"goroutine",    // Stack traces of all current goroutines
+		"heap",         // A sampling of memory allocations of live objects.
+		"mutex",        // Stack traces of holders of contended mutexes
+		"profile",      // CPU profile.
+		"threadcreate", // Stack traces that led to the creation of new OS threads
+		"trace",        // A trace of execution of the current program.
+	}
+	for _, profile := range profileStrings {
+		results.Reports = append(results.Reports, &ChainlinkProfileResult{Type: profile})
+	}
+	return results
+}
+
 // ResponseSlice is the generic model that can be used for all Chainlink API responses that are an slice
 type ResponseSlice struct {
 	Data []map[string]interface{}

--- a/framework.yaml
+++ b/framework.yaml
@@ -2,7 +2,7 @@
 #
 # All configuration can be set at runtime with environment variables, for example:
 # KEEP_ENVIRONMENTS=OnFail
-keep_environments: Never # Options: Always, OnFail, Never
+keep_environments: Always # Options: Always, OnFail, Never
 logging:
     write_pod_logs: OnFail # Options: Always, OnFail
     # panic=5, fatal=4, error=3, warn=2, info=1, debug=0, trace=-1

--- a/framework.yaml
+++ b/framework.yaml
@@ -2,7 +2,7 @@
 #
 # All configuration can be set at runtime with environment variables, for example:
 # KEEP_ENVIRONMENTS=OnFail
-keep_environments: Always # Options: Always, OnFail, Never
+keep_environments: Never # Options: Always, OnFail, Never
 logging:
     write_pod_logs: OnFail # Options: Always, OnFail
     # panic=5, fatal=4, error=3, warn=2, info=1, debug=0, trace=-1

--- a/suite/performance/basic_test.go
+++ b/suite/performance/basic_test.go
@@ -1,0 +1,94 @@
+package performance
+
+//revive:disable:dot-imports
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	uuid "github.com/satori/go.uuid"
+	"github.com/smartcontractkit/chainlink-testing-framework/actions"
+	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/client"
+	"github.com/smartcontractkit/chainlink-testing-framework/config"
+	"github.com/smartcontractkit/chainlink-testing-framework/testsetups"
+	"github.com/smartcontractkit/chainlink-testing-framework/utils"
+	"github.com/smartcontractkit/helmenv/environment"
+	"github.com/smartcontractkit/helmenv/tools"
+)
+
+var _ = Describe("VRF suite @vrf", func() {
+	var (
+		err             error
+		nets            *blockchain.Networks
+		chainlinkNodes  []client.Chainlink
+		mockserver      *client.MockserverClient
+		testEnvironment *environment.Environment
+		profileTest     *testsetups.ChainlinkProfileTest
+	)
+
+	BeforeEach(func() {
+		By("Deploying the environment", func() {
+			testEnvironment, err = environment.DeployOrLoadEnvironment(
+				environment.NewChainlinkConfig(
+					config.ChainlinkVals(),
+					"chainlink-profiling",
+					config.GethNetworks()...,
+				),
+				tools.ChartsRoot,
+			)
+			Expect(err).ShouldNot(HaveOccurred(), "Environment deployment shouldn't fail")
+			err = testEnvironment.ConnectAll()
+			Expect(err).ShouldNot(HaveOccurred(), "Connecting to all nodes shouldn't fail")
+		})
+
+		By("Setting up the test", func() {
+			chainlinkNodes, err = client.ConnectChainlinkNodes(testEnvironment)
+			Expect(err).ShouldNot(HaveOccurred(), "Connecting to chainlink nodes shouldn't fail")
+			mockserver, err = client.ConnectMockServer(testEnvironment)
+			Expect(err).ShouldNot(HaveOccurred(), "Creating mockserver clients shouldn't fail")
+
+			profileFunction := func(chainlinkNode client.Chainlink) {
+				defer GinkgoRecover()
+				bta := client.BridgeTypeAttributes{
+					Name:        fmt.Sprintf("variable-%s", uuid.NewV4().String()),
+					URL:         fmt.Sprintf("%s/variable", mockserver.Config.ClusterURL),
+					RequestData: "{}",
+				}
+				err = chainlinkNode.CreateBridge(&bta)
+				Expect(err).ShouldNot(HaveOccurred(), "Creating bridge in chainlink node shouldn't fail")
+
+				_, err = chainlinkNode.CreateJob(&client.CronJobSpec{
+					Schedule:          "CRON_TZ=UTC * * * * * *",
+					ObservationSource: client.ObservationSourceSpecBridge(bta),
+				})
+				Expect(err).ShouldNot(HaveOccurred(), "Creating Cron Job in chainlink node shouldn't fail")
+			}
+
+			profileTest = testsetups.NewChainlinkProfileTest(testsetups.ChainlinkProfileTestInputs{
+				ProfileFunction:       profileFunction,
+				ProfileDuration:       time.Second,
+				ProfileFolderLocation: "../../logs",
+				ChainlinkNodes:        chainlinkNodes,
+			})
+			profileTest.Setup(testEnvironment)
+		})
+	})
+
+	Describe("checking Chainlink node's PPROF", func() {
+		It("queries PPROF on node", func() {
+			err = mockserver.SetValuePath("/variable", 5)
+			Expect(err).ShouldNot(HaveOccurred(), "Setting value path in mockserver shouldn't fail")
+
+			profileTest.Run()
+		})
+	})
+
+	AfterEach(func() {
+		By("Tearing down the environment", func() {
+			err = actions.TeardownSuite(testEnvironment, nets, utils.ProjectRoot, chainlinkNodes, nil)
+			Expect(err).ShouldNot(HaveOccurred(), "Environment teardown shouldn't fail")
+		})
+	})
+})

--- a/suite/performance/basic_test.go
+++ b/suite/performance/basic_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/smartcontractkit/helmenv/tools"
 )
 
-var _ = Describe("VRF suite @vrf", func() {
+var _ = Describe("Profiling suite @profile", func() {
 	var (
 		err             error
 		nets            *blockchain.Networks
@@ -67,10 +67,9 @@ var _ = Describe("VRF suite @vrf", func() {
 			}
 
 			profileTest = testsetups.NewChainlinkProfileTest(testsetups.ChainlinkProfileTestInputs{
-				ProfileFunction:       profileFunction,
-				ProfileDuration:       time.Second,
-				ProfileFolderLocation: "../../logs",
-				ChainlinkNodes:        chainlinkNodes,
+				ProfileFunction: profileFunction,
+				ProfileDuration: time.Second,
+				ChainlinkNodes:  chainlinkNodes,
 			})
 			profileTest.Setup(testEnvironment)
 		})
@@ -87,7 +86,7 @@ var _ = Describe("VRF suite @vrf", func() {
 
 	AfterEach(func() {
 		By("Tearing down the environment", func() {
-			err = actions.TeardownSuite(testEnvironment, nets, utils.ProjectRoot, chainlinkNodes, nil)
+			err = actions.TeardownSuite(testEnvironment, nets, utils.ProjectRoot, chainlinkNodes, &profileTest.TestReporter)
 			Expect(err).ShouldNot(HaveOccurred(), "Environment teardown shouldn't fail")
 		})
 	})

--- a/suite/performance/suite_test.go
+++ b/suite/performance/suite_test.go
@@ -1,0 +1,16 @@
+package performance_test
+
+//revive:disable:dot-imports
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/actions"
+	"github.com/smartcontractkit/chainlink-testing-framework/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func Test_Suite(t *testing.T) {
+	actions.GinkgoSuite(utils.ProjectRoot)
+	RunSpecs(t, "Profiling")
+}

--- a/testreporters/profile.go
+++ b/testreporters/profile.go
@@ -27,9 +27,11 @@ func (c *ChainlinkProfileTestReporter) WriteReport(folderLocation string) error 
 	for _, res := range c.Results {
 		result := res
 		profFiles.Go(func() error {
+			filePath := filepath.Join(folderLocation, fmt.Sprintf("chainlink-node-%d-profiles", result.NodeIndex))
+			mkdirIfNotExists(filePath)
 			for _, rep := range result.Reports {
 				report := rep
-				reportFile, err := os.Create(filepath.Join(folderLocation, fmt.Sprintf("chainlink-%d-%s", result.NodeIndex, report.Type)))
+				reportFile, err := os.Create(filepath.Join(filePath, report.Type))
 				if err != nil {
 					return err
 				}

--- a/testreporters/profile.go
+++ b/testreporters/profile.go
@@ -28,7 +28,9 @@ func (c *ChainlinkProfileTestReporter) WriteReport(folderLocation string) error 
 		result := res
 		profFiles.Go(func() error {
 			filePath := filepath.Join(folderLocation, fmt.Sprintf("chainlink-node-%d-profiles", result.NodeIndex))
-			mkdirIfNotExists(filePath)
+			if err := mkdirIfNotExists(filePath); err != nil {
+				return err
+			}
 			for _, rep := range result.Reports {
 				report := rep
 				reportFile, err := os.Create(filepath.Join(filePath, report.Type))

--- a/testreporters/profile.go
+++ b/testreporters/profile.go
@@ -1,0 +1,53 @@
+package testreporters
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"github.com/slack-go/slack"
+	"github.com/smartcontractkit/chainlink-testing-framework/client"
+	"golang.org/x/sync/errgroup"
+)
+
+type ChainlinkProfileTestReporter struct {
+	Results   []*client.ChainlinkProfileResults
+	namespace string
+}
+
+// SetNamespace sets the namespace of the report for clean reports
+func (c *ChainlinkProfileTestReporter) SetNamespace(namespace string) {
+	c.namespace = namespace
+}
+
+// WriteReport create the profile files
+func (c *ChainlinkProfileTestReporter) WriteReport(folderLocation string) error {
+	profFiles := new(errgroup.Group)
+	for _, res := range c.Results {
+		result := res
+		profFiles.Go(func() error {
+			for _, rep := range result.Reports {
+				report := rep
+				reportFile, err := os.Create(filepath.Join(folderLocation, fmt.Sprintf("chainlink-%d-%s", result.NodeIndex, report.Type)))
+				if err != nil {
+					return err
+				}
+				if _, err = reportFile.Write(report.Data); err != nil {
+					return err
+				}
+				if err = reportFile.Close(); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	return profFiles.Wait()
+}
+
+// SendNotification hasn't been implemented for this test
+func (c *ChainlinkProfileTestReporter) SendSlackNotification(slackClient *slack.Client) error {
+	log.Warn().Msg("No Slack notification integration for Chainlink profile tests")
+	return nil
+}

--- a/testreporters/reporter_models.go
+++ b/testreporters/reporter_models.go
@@ -2,10 +2,10 @@
 package testreporters
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 )
@@ -77,4 +77,14 @@ func sendSlackMessage(slackClient *slack.Client, msgOptions ...slack.MsgOption) 
 	msgOptions = append(msgOptions, slack.MsgOptionAsUser(true))
 	_, timeStamp, err := slackClient.PostMessage(slackChannel, msgOptions...)
 	return timeStamp, err
+}
+
+// creates a directory if it doesn't already exist
+func mkdirIfNotExists(dirName string) error {
+	if _, err := os.Stat(dirName); os.IsNotExist(err) {
+		if err = os.MkdirAll(dirName, os.ModePerm); err != nil {
+			return errors.Wrapf(err, "failed to create directory: %s", dirName)
+		}
+	}
+	return nil
 }

--- a/testsetups/profile.go
+++ b/testsetups/profile.go
@@ -12,8 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// KeeperBlockTimeTest builds a test to check that chainlink nodes are able to upkeep a specified amount of Upkeep
-// contracts within a certain block time
+// ChainlinkProfileTest runs a piece of code on Chainlink nodes with PPROF enabled, then downloads the PPROF results
 type ChainlinkProfileTest struct {
 	Inputs       ChainlinkProfileTestInputs
 	TestReporter testreporters.ChainlinkProfileTestReporter
@@ -23,14 +22,14 @@ type ChainlinkProfileTest struct {
 	defaultNetwork blockchain.EVMClient
 }
 
-// KeeperBlockTimeTestInputs are all the required inputs for a Keeper Block Time Test
+// ChainlinkProfileTestInputs are the inputs necessary to run a profiling tests
 type ChainlinkProfileTestInputs struct {
 	ProfileFunction func(client.Chainlink)
 	ProfileDuration time.Duration
 	ChainlinkNodes  []client.Chainlink
 }
 
-// NewKeeperBlockTimeTest prepares a new keeper block time test to be run
+// NewChainlinkProfileTest prepares a new keeper Chainlink profiling test to be run
 func NewChainlinkProfileTest(inputs ChainlinkProfileTestInputs) *ChainlinkProfileTest {
 	return &ChainlinkProfileTest{
 		Inputs: inputs,
@@ -43,7 +42,7 @@ func (c *ChainlinkProfileTest) Setup(env *environment.Environment) {
 	c.env = env
 }
 
-// Run runs the keeper block time test
+// Run runs the profiling test
 func (c *ChainlinkProfileTest) Run() {
 	profileGroup := new(errgroup.Group)
 	for ni, cl := range c.Inputs.ChainlinkNodes {

--- a/testsetups/profile.go
+++ b/testsetups/profile.go
@@ -1,0 +1,82 @@
+package testsetups
+
+//revive:disable:dot-imports
+import (
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/client"
+	"github.com/smartcontractkit/chainlink-testing-framework/testreporters"
+	"github.com/smartcontractkit/helmenv/environment"
+	"golang.org/x/sync/errgroup"
+)
+
+// KeeperBlockTimeTest builds a test to check that chainlink nodes are able to upkeep a specified amount of Upkeep
+// contracts within a certain block time
+type ChainlinkProfileTest struct {
+	Inputs       ChainlinkProfileTestInputs
+	TestReporter testreporters.ChainlinkProfileTestReporter
+
+	env            *environment.Environment
+	networks       *blockchain.Networks
+	defaultNetwork blockchain.EVMClient
+}
+
+// KeeperBlockTimeTestInputs are all the required inputs for a Keeper Block Time Test
+type ChainlinkProfileTestInputs struct {
+	ProfileFunction       func(client.Chainlink)
+	ProfileDuration       time.Duration
+	ProfileFolderLocation string
+	ChainlinkNodes        []client.Chainlink
+}
+
+// NewKeeperBlockTimeTest prepares a new keeper block time test to be run
+func NewChainlinkProfileTest(inputs ChainlinkProfileTestInputs) *ChainlinkProfileTest {
+	return &ChainlinkProfileTest{
+		Inputs: inputs,
+	}
+}
+
+// Setup prepares contracts for the test
+func (c *ChainlinkProfileTest) Setup(env *environment.Environment) {
+	c.ensureInputValues()
+	c.env = env
+}
+
+// Run runs the keeper block time test
+func (c *ChainlinkProfileTest) Run() {
+	profileGroup := new(errgroup.Group)
+	for ni, cl := range c.Inputs.ChainlinkNodes {
+		chainlinkNode := cl
+		nodeIndex := ni
+		profileGroup.Go(func() error {
+			profileResults, err := chainlinkNode.Profile(c.Inputs.ProfileDuration, c.Inputs.ProfileFunction)
+			profileResults.NodeIndex = nodeIndex
+			if err != nil {
+				return err
+			}
+			c.TestReporter.Results = append(c.TestReporter.Results, profileResults)
+			return nil
+		})
+	}
+	Expect(profileGroup.Wait()).ShouldNot(HaveOccurred(), "Error while gathering chainlink Profile tests")
+}
+
+// Networks returns the networks that the test is running on
+func (c *ChainlinkProfileTest) TearDownVals() (*environment.Environment, *blockchain.Networks, []client.Chainlink, testreporters.TestReporter) {
+	return c.env, c.networks, c.Inputs.ChainlinkNodes, &c.TestReporter
+}
+
+// ensureValues ensures that all values needed to run the test are present
+func (c *ChainlinkProfileTest) ensureInputValues() {
+	Expect(c.Inputs.ProfileFunction).ShouldNot(BeNil(), "Forgot to provide a function to profile")
+	Expect(c.Inputs.ProfileDuration.Seconds()).Should(BeNumerically(">=", 1), "Time to profile should be at least 1 second")
+	var err error
+	c.Inputs.ProfileFolderLocation, err = filepath.Abs(c.Inputs.ProfileFolderLocation)
+	Expect(err).ShouldNot(HaveOccurred(), "Error marshalling file path '%s' to absolute path", c.Inputs.ProfileFolderLocation)
+	Expect(c.Inputs.ProfileFolderLocation).Should(BeADirectory(), "Provided folder location %s is not a valid directory", c.Inputs.ProfileFolderLocation)
+	Expect(c.Inputs.ChainlinkNodes).ShouldNot(BeNil(), "Chainlink nodes you want to profile should be provided")
+	Expect(len(c.Inputs.ChainlinkNodes)).Should(BeNumerically(">", 0), "No Chainlink nodes provided to profile")
+}

--- a/testsetups/profile.go
+++ b/testsetups/profile.go
@@ -2,7 +2,6 @@ package testsetups
 
 //revive:disable:dot-imports
 import (
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -26,10 +25,9 @@ type ChainlinkProfileTest struct {
 
 // KeeperBlockTimeTestInputs are all the required inputs for a Keeper Block Time Test
 type ChainlinkProfileTestInputs struct {
-	ProfileFunction       func(client.Chainlink)
-	ProfileDuration       time.Duration
-	ProfileFolderLocation string
-	ChainlinkNodes        []client.Chainlink
+	ProfileFunction func(client.Chainlink)
+	ProfileDuration time.Duration
+	ChainlinkNodes  []client.Chainlink
 }
 
 // NewKeeperBlockTimeTest prepares a new keeper block time test to be run
@@ -73,10 +71,6 @@ func (c *ChainlinkProfileTest) TearDownVals() (*environment.Environment, *blockc
 func (c *ChainlinkProfileTest) ensureInputValues() {
 	Expect(c.Inputs.ProfileFunction).ShouldNot(BeNil(), "Forgot to provide a function to profile")
 	Expect(c.Inputs.ProfileDuration.Seconds()).Should(BeNumerically(">=", 1), "Time to profile should be at least 1 second")
-	var err error
-	c.Inputs.ProfileFolderLocation, err = filepath.Abs(c.Inputs.ProfileFolderLocation)
-	Expect(err).ShouldNot(HaveOccurred(), "Error marshalling file path '%s' to absolute path", c.Inputs.ProfileFolderLocation)
-	Expect(c.Inputs.ProfileFolderLocation).Should(BeADirectory(), "Provided folder location %s is not a valid directory", c.Inputs.ProfileFolderLocation)
 	Expect(c.Inputs.ChainlinkNodes).ShouldNot(BeNil(), "Chainlink nodes you want to profile should be provided")
 	Expect(len(c.Inputs.ChainlinkNodes)).Should(BeNumerically(">", 0), "No Chainlink nodes provided to profile")
 }


### PR DESCRIPTION
A request was made by @essamhassan to add the ability to profile Chainlink nodes with our tests. It turned out to be a quick ask.

## Profiling

The meat of this PR resides in the new `Profile` function for Chainlink nodes. It makes API calls to the Chainlink node that starts the profiling, then runs a supplied function. See the full code at the bottom. The weird bit is immediately below. I can't decide if this is slick or dirty?

```go
func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chainlink)) (*ChainlinkProfileResults, error) {
  // Execute profile
  profileFunction(c) // Pass the node itself into this function
  // Gather results
  return profileResults, profileErrorGroup.Wait() // return results
}
```

After the reports are collected, they are written to the logs folder.

## How to Use

We utilize the `testsetups` and testreporters` style to run this cleanly.

```go
profileTest = testsetups.NewChainlinkProfileTest(testsetups.ChainlinkProfileTestInputs{
  ProfileFunction: profileFunction,
  ProfileDuration: time.Second,
  ChainlinkNodes:  chainlinkNodes,
})
profileTest.Setup(testEnvironment)
profileTest.Run()
```

### Full `Profile` function

```go
// Profile runs the provided function once to gauge roughly how long it takes. It will then trigger a time-blocked
// profiling session on the Chainlink node and run the functions again.
func (c *chainlink) Profile(profileTime time.Duration, profileFunction func(Chainlink)) (*ChainlinkProfileResults, error) {
	profileSeconds := int(profileTime.Seconds())
	profileResults := NewBlankChainlinkProfileResults()
	profileErrorGroup := new(errgroup.Group)
	var profileExecutedGroup sync.WaitGroup
	log.Info().Int("Seconds to Profile", profileSeconds).Str("Node URL", c.Config.URL).Msg("Starting Node PPROF session")
	for _, rep := range profileResults.Reports {
		profileExecutedGroup.Add(1)
		profileReport := rep
		// The profile function returns with the profile results after the profile time frame has concluded
		// e.g. a profile API call of 5 seconds will start profiling, wait for 5 seconds, then send back results
		profileErrorGroup.Go(func() error {
			log.Warn().Str("Type", profileReport.Type).Msg("PROFILING")
			uri := fmt.Sprintf("/v2/debug/pprof/%s?seconds=%d", profileReport.Type, profileSeconds)
			profileExecutedGroup.Done()
			rawBytes, err := c.doRawBytes(http.MethodGet, uri, nil, nil, http.StatusOK)
			if err != nil {
				return err
			}
			log.Warn().Str("Type", profileReport.Type).Msg("DONE PROFILING")
			profileReport.Data = rawBytes
			return nil
		})
	}
	// Wait for the profiling to actually get triggered on the node before running the function to profile
	// An imperfect solution, but an effective one.
	profileExecutedGroup.Wait()

	funcStart := time.Now()
	// Feed this chainlink node into the profiling function
	profileFunction(c)
	actualRunTime := time.Since(funcStart)
	actualSeconds := int(actualRunTime.Seconds())

	if actualSeconds > profileSeconds {
		log.Warn().
			Int("Actual Seconds", actualSeconds).
			Int("Profile Seconds", profileSeconds).
			Msg("Your profile function took longer than expected to run, increase profileTime")
	} else if actualSeconds < profileSeconds && actualSeconds > 0 {
		log.Warn().
			Int("Actual Seconds", actualSeconds).
			Int("Profile Seconds", profileSeconds).
			Msg("Your profile function took shorter than expected to run, you can decrease profileTime")
	}
	profileResults.ActualRunSeconds = actualSeconds
	profileResults.ScheduledProfileSeconds = profileSeconds
	return profileResults, profileErrorGroup.Wait() // Wait for all the results of the profiled function to come in
}
```

