### PR TITLE
Remote Test Controller

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -528,9 +528,7 @@ func (e *EthereumMultinodeClient) GetChainID() *big.Int {
 // GetClients gets clients for all nodes connected
 func (e *EthereumMultinodeClient) GetClients() []EVMClient {
 	cl := make([]EVMClient, 0)
-	for _, c := range e.Clients {
-		cl = append(cl, c)
-	}
+	cl = append(cl, e.Clients...)
 	return cl
 }
 

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -161,11 +162,19 @@ func (e *EthereumClient) subscribeToNewHeaders() error {
 
 // receiveHeader
 func (e *EthereumClient) receiveHeader(header *types.Header) {
+	suggestedPrice, err := e.Client.SuggestGasPrice(context.Background())
+	if err != nil {
+		suggestedPrice = big.NewInt(0)
+		log.Err(err).
+			Str("Block Hash", header.Hash().String()).
+			Msg("Error retrieving Suggested Gas Price for new block header")
+	}
 	log.Debug().
 		Str("NetworkName", e.NetworkConfig.Name).
 		Int("Node", e.ID).
 		Str("Hash", header.Hash().String()).
 		Str("Number", header.Number.String()).
+		Str("Gas Price", suggestedPrice.String()).
 		Msg("Received block header")
 
 	subs := e.GetHeaderSubscriptions()

--- a/framework.yaml
+++ b/framework.yaml
@@ -10,7 +10,7 @@ logging:
 
 # Specify the image and version of the chainlink image you want to run tests against. Leave blank for default.
 chainlink_image: public.ecr.aws/chainlink/chainlink
-chainlink_version: 1.3.0
+chainlink_version: 1.4.1
 chainlink_env_values:
 
 # Setting an environment file allows for persistent, not ephemeral environments on test execution

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/smartcontractkit/chainlink-testing-framework
 
 go 1.18
 
-replace github.com/smartcontractkit/helmenv => /Users/adamhamrick/Projects/helmenv
-
 require (
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/julienschmidt/httprouter v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,11 @@ module github.com/smartcontractkit/chainlink-testing-framework
 
 go 1.18
 
+replace github.com/smartcontractkit/helmenv => /Users/adamhamrick/Projects/helmenv
+
 require (
 	github.com/ethereum/go-ethereum v1.10.16
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1083,6 +1083,7 @@ github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
@@ -1810,8 +1811,6 @@ github.com/slack-go/slack v0.10.2 h1:KMN/h2sgUninHXvQI8PrR/PHBUuWp2NPvz2Kr66tki4
 github.com/slack-go/slack v0.10.2/go.mod h1:5FLdBRv7VW/d9EBxx/eEktOptWygbA9K2QK/KW7ds1s=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
-github.com/smartcontractkit/helmenv v1.0.67 h1:2AlDrY0dFF3/p/6iHlJDWNGWCVLYSu/kXlN5+dN25k4=
-github.com/smartcontractkit/helmenv v1.0.67/go.mod h1:VbfetB06uItvuxJKdZ6AftpbATYCnT40IaKRr75ebcs=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=
 github.com/smartcontractkit/libocr v0.0.0-20220121130134-5d2b1d5f424b h1:9xEvwk6fHqL9Fp/u8bLd7kbEQKrDSzwuDsH1ptHjE9g=
 github.com/smartcontractkit/libocr v0.0.0-20220121130134-5d2b1d5f424b/go.mod h1:nq3crM3wVqnyMlM/4ZydTuJ/WyCapAsOt7P94oRgSPg=

--- a/go.sum
+++ b/go.sum
@@ -1811,6 +1811,8 @@ github.com/slack-go/slack v0.10.2 h1:KMN/h2sgUninHXvQI8PrR/PHBUuWp2NPvz2Kr66tki4
 github.com/slack-go/slack v0.10.2/go.mod h1:5FLdBRv7VW/d9EBxx/eEktOptWygbA9K2QK/KW7ds1s=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
+github.com/smartcontractkit/helmenv v1.0.67 h1:2AlDrY0dFF3/p/6iHlJDWNGWCVLYSu/kXlN5+dN25k4=
+github.com/smartcontractkit/helmenv v1.0.67/go.mod h1:VbfetB06uItvuxJKdZ6AftpbATYCnT40IaKRr75ebcs=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=
 github.com/smartcontractkit/libocr v0.0.0-20220121130134-5d2b1d5f424b h1:9xEvwk6fHqL9Fp/u8bLd7kbEQKrDSzwuDsH1ptHjE9g=
 github.com/smartcontractkit/libocr v0.0.0-20220121130134-5d2b1d5f424b/go.mod h1:nq3crM3wVqnyMlM/4ZydTuJ/WyCapAsOt7P94oRgSPg=

--- a/networks.yaml
+++ b/networks.yaml
@@ -187,10 +187,10 @@ networks:
             - klaytn_key
     metis_testnet:
         <<: *common_ethereum_testnet
-        name: "Metis testnet"
+        name: "Metis mainnet"
         type: "metis_testnet"
         chain_id: 588
         urls:
-            - wss://stardust-ws.metis.io/
+            - wss://stardust-ws.metis.io
         private_keys:
             - metis_key

--- a/suite/soak/soak_runner_test.go
+++ b/suite/soak/soak_runner_test.go
@@ -25,7 +25,7 @@ func TestSoak(t *testing.T) {
 	env, err := environment.DeployLongTestEnvironment(
 		environment.NewChainlinkConfig(
 			environment.ChainlinkReplicas(6, config.ChainlinkVals()),
-			"chainlink-soak",
+			"shutdown-test",
 			config.GethNetworks()...,
 		),
 		tools.ChartsRoot,

--- a/suite/soak/soak_runner_test.go
+++ b/suite/soak/soak_runner_test.go
@@ -25,7 +25,7 @@ func TestSoak(t *testing.T) {
 	env, err := environment.DeployLongTestEnvironment(
 		environment.NewChainlinkConfig(
 			environment.ChainlinkReplicas(6, config.ChainlinkVals()),
-			"shutdown-test",
+			"chainlink-soak",
 			config.GethNetworks()...,
 		),
 		tools.ChartsRoot,

--- a/suite/soak/tests/keeper_test.go
+++ b/suite/soak/tests/keeper_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Keeper performance suite @block-time-keeper", func() {
 					PerformGasToBurn:     2400000,
 					BlockRange:           2000,
 					BlockInterval:        200,
-					ChainlinkNodeFunding: big.NewFloat(1000),
+					ChainlinkNodeFunding: big.NewFloat(10),
 				},
 			)
 			keeperBlockTimeTest.Setup(env)

--- a/suite/soak/tests/ocr_test.go
+++ b/suite/soak/tests/ocr_test.go
@@ -38,7 +38,7 @@ var _ = Describe("OCR Soak Test @soak-ocr", func() {
 				ChainlinkNodeFunding: big.NewFloat(10),
 				ExpectedRoundTime:    time.Minute,
 				RoundTimeout:         time.Minute * 10,
-				TimeBetweenRounds:    time.Minute * 10,
+				TimeBetweenRounds:    time.Minute * 1,
 				StartingAdapterValue: 5,
 			})
 			ocrSoakTest.Setup(env)

--- a/testreporters/ocr.go
+++ b/testreporters/ocr.go
@@ -13,10 +13,12 @@ import (
 )
 
 type OCRSoakTestReporter struct {
-	Reports           map[string]*OCRSoakTestReport // contractAddress: Report
-	ExpectedRoundTime time.Duration
-	namespace         string
-	csvLocation       string
+	Reports            map[string]*OCRSoakTestReport // contractAddress: Report
+	ExpectedRoundTime  time.Duration
+	UnexpectedShutdown bool
+
+	namespace   string
+	csvLocation string
 }
 
 type OCRSoakTestReport struct {
@@ -93,6 +95,8 @@ func (o *OCRSoakTestReporter) SendSlackNotification(slackClient *slack.Client) e
 	messageBlocks := []slack.Block{}
 	if testFailed {
 		headerText = ":x: OCR Soak Test FAILED :x:"
+	} else if o.UnexpectedShutdown {
+		headerText = ":warning: OCR Soak Test was Unexpectedly Shut Down :warning:"
 	}
 	messageBlocks = append(messageBlocks,
 		slack.NewHeaderBlock(slack.NewTextBlockObject("plain_text", headerText, true, false)))

--- a/testsetups/remote_control.go
+++ b/testsetups/remote_control.go
@@ -1,0 +1,88 @@
+package testsetups
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	started         bool
+	testName        string
+	confirmCode     int
+	stopChannel     chan struct{}
+	shutDownStarted bool
+)
+
+// StartRemoteControlServer starts a server to control soak test shut downs. Shutdown signal is sent to the stopChan
+func StartRemoteControlServer(name string, stopChan chan struct{}) {
+	accessPort := os.Getenv("ACCESS_PORT")
+	if accessPort == "" {
+		accessPort = "8080"
+	}
+	if started {
+		log.Warn().Str("Port", accessPort).Msg("Already started remote control server")
+		return
+	}
+	started = true
+	testName = name
+	stopChannel = stopChan
+
+	router := httprouter.New()
+	router.GET("/", Index)
+	router.GET("/shutdown", ShutDown)
+	router.GET("/shutdown/:confirmCode", ShutDownConfirm)
+
+	log.Info().Str("Port", accessPort).Msg("Remote control server listening")
+
+	// Start listening for shutdown calls
+	go func() {
+		log.Error().Err(http.ListenAndServe(fmt.Sprintf(":%s", accessPort), router)).Msg("Error running remote control server")
+	}()
+
+	// TODO: Enable this shutdown to happen on SIGTERMs as well (I messed around with signal.Notify and couldn't get it to work for some reason)
+}
+
+// Index to see barbones running statistics
+func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if shutDownStarted {
+		fmt.Fprint(w, "Shut down is in progress")
+		return
+	}
+	fmt.Fprint(w, "Remote Control Server is Running!\nUse /shutdown to initiate a graceful test shutdown")
+}
+
+// ShutDown attempts to gracefully shut down the running test
+func ShutDown(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	if shutDownStarted {
+		fmt.Fprint(w, "Shut down already in progress")
+		return
+	}
+	confirmCode = 1000 + rand.Intn(9999-1000) // #nosec G404 | 4 digit random number
+	fmt.Fprintf(w, "Are you sure you want to shut down '%s'? Call /shutdown/%d to confirm.", testName, confirmCode)
+}
+
+// ShutDownConfirm requires the user to enter a randomly generated code to shut down the test
+func ShutDownConfirm(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	if shutDownStarted {
+		fmt.Fprint(w, "Shut down already in progress")
+		return
+	}
+	enteredCode := ps.ByName("confirmCode")
+	if enteredCode == fmt.Sprint(confirmCode) {
+		fmt.Fprintf(w, "Shutting down '%s'", testName)
+		shutdown()
+	} else {
+		fmt.Fprintf(w, "Incorrect confirmation code '%s'", enteredCode)
+	}
+}
+
+func shutdown() {
+	shutDownStarted = true
+	stopChannel <- struct{}{}
+	close(stopChannel)
+}


### PR DESCRIPTION
Adds a basic endpoint that can be called on a soak test to shut it down gracefully. Sometimes we get into situations where we need to kill a soak test before it can complete, but would still like to get info from it; this enables such a thing.

You can access an endpoint on the `remote-test-runner`, `/shutdown` that will ask you to confirm you want a shut down with a random code. Calling `/shutdown/<code>` will gracefully shutdown the test and give you a truncated report.