### PR TITLE
Removed observation source injection from Keepers-related tests

### DIFF
--- a/actions/keeper_helpers.go
+++ b/actions/keeper_helpers.go
@@ -39,7 +39,6 @@ func CreateKeeperJobs(chainlinkNodes []client.Chainlink, keeperRegistry contract
 			ContractAddress:          keeperRegistry.Address(),
 			FromAddress:              chainlinkNodeAddress,
 			MinIncomingConfirmations: 1,
-			ObservationSource:        client.ObservationSourceKeeperDefault(),
 		})
 		Expect(err).ShouldNot(HaveOccurred(), "Creating KeeperV2 Job shouldn't fail")
 	}

--- a/client/chainlink_models.go
+++ b/client/chainlink_models.go
@@ -738,7 +738,6 @@ type KeeperJobSpec struct {
 	ContractAddress          string `toml:"contractAddress"`
 	FromAddress              string `toml:"fromAddress"` // Hex representation of the from address
 	MinIncomingConfirmations int    `toml:"minIncomingConfirmations"`
-	ObservationSource        string `toml:"observationSource"`
 }
 
 // Type returns the type of the job
@@ -753,10 +752,7 @@ name                     = "{{.Name}}"
 contractAddress          = "{{.ContractAddress}}"
 fromAddress              = "{{.FromAddress}}"
 minIncomingConfirmations = {{.MinIncomingConfirmations}}
-
-observationSource        = """
-{{.ObservationSource}}
-"""`
+`
 	return marshallTemplate(k, "Keeper Job", keeperTemplateString)
 }
 
@@ -1100,48 +1096,6 @@ func ObservationSourceSpecBridge(bta BridgeTypeAttributes) string {
 		fetch [type=bridge name="%s" requestData="%s"];
 		parse [type=jsonparse path="data,result"];
 		fetch -> parse;`, bta.Name, bta.RequestData)
-}
-
-// ObservationSourceKeeperDefault is a basic keeper default that checks and performs upkeep of the contract address
-func ObservationSourceKeeperDefault() string {
-	return `encode_check_upkeep_tx   [type=ethabiencode abi="checkUpkeep(uint256 id, address from)"
-                          data="{\\"id\\":$(jobSpec.upkeepID),\\"from\\":$(jobSpec.fromAddress)}"]
-check_upkeep_tx          [type=ethcall
-                          failEarly=true
-                          extractRevertReason=true
-                          evmChainID="$(jobSpec.evmChainID)"
-                          contract="$(jobSpec.contractAddress)"
-                          gas="$(jobSpec.checkUpkeepGasLimit)"
-                          gasPrice="$(jobSpec.gasPrice)"
-                          gasTipCap="$(jobSpec.gasTipCap)"
-                          gasFeeCap="$(jobSpec.gasFeeCap)"
-                          data="$(encode_check_upkeep_tx)"]
-decode_check_upkeep_tx   [type=ethabidecode
-                          abi="bytes memory performData, uint256 maxLinkPayment, uint256 gasLimit, uint256 adjustedGasWei, uint256 linkEth"]
-encode_perform_upkeep_tx [type=ethabiencode
-                          abi="performUpkeep(uint256 id, bytes calldata performData)"
-                          data="{\\"id\\": $(jobSpec.upkeepID),\\"performData\\":$(decode_check_upkeep_tx.performData)}"]
-simulate_perform_upkeep_tx  [type=ethcall
-                          extractRevertReason=true
-                          evmChainID="$(jobSpec.evmChainID)"
-                          contract="$(jobSpec.contractAddress)"
-                          from="$(jobSpec.fromAddress)"
-                          gas="$(jobSpec.performUpkeepGasLimit)"
-                          data="$(encode_perform_upkeep_tx)"]
-decode_check_perform_tx  [type=ethabidecode
-                          abi="bool success"]
-check_success            [type=conditional
-                          failEarly=true
-                          data="$(decode_check_perform_tx.success)"]
-perform_upkeep_tx        [type=ethtx
-                          minConfirmations=0
-                          to="$(jobSpec.contractAddress)"
-                          from="[$(jobSpec.fromAddress)]"
-                          evmChainID="$(jobSpec.evmChainID)"
-                          data="$(encode_perform_upkeep_tx)"
-                          gasLimit="$(jobSpec.performUpkeepGasLimit)"
-                          txMeta="{\\"jobID\\":$(jobSpec.jobID),\\"upkeepID\\":$(jobSpec.prettyID)}"]
-encode_check_upkeep_tx -> check_upkeep_tx -> decode_check_upkeep_tx -> encode_perform_upkeep_tx -> simulate_perform_upkeep_tx -> decode_check_perform_tx -> check_success -> perform_upkeep_tx`
 }
 
 // marshallTemplate Helper to marshall templates


### PR DESCRIPTION
Because the observation source is the same for all Keeper jobs (as part of [this](https://github.com/smartcontractkit/chainlink/pull/6582) PR in the main repo), the users do not need to pass it anymore in a Toml string when creating the jobs.