### PR TITLE
Add helper functions for keepers

### DIFF
--- a/actions/keeper_helpers.go
+++ b/actions/keeper_helpers.go
@@ -249,7 +249,7 @@ func RegisterUpkeepContracts(
 	for _, txHash := range registrationTxHashes {
 		receipt, err := networks.Default.GetTxReceipt(txHash)
 		Expect(err).ShouldNot(HaveOccurred(), "Registration tx should be completed")
-		var upkeepId *big.Int = nil
+		var upkeepId *big.Int
 		for _, rawLog := range receipt.Logs {
 			parsedUpkeepId, err := registry.ParseUpkeepIdFromRegisteredLog(rawLog)
 			if err == nil {

--- a/actions/keeper_helpers.go
+++ b/actions/keeper_helpers.go
@@ -249,11 +249,10 @@ func RegisterUpkeepContracts(
 	for _, txHash := range registrationTxHashes {
 		receipt, err := networks.Default.GetTxReceipt(txHash)
 		Expect(err).ShouldNot(HaveOccurred(), "Registration tx should be completed")
-		var upkeepId *big.Int
-		upkeepId = nil
+		var upkeepId *big.Int = nil
 		for _, rawLog := range receipt.Logs {
 			parsedUpkeepId, err := registry.ParseUpkeepIdFromRegisteredLog(rawLog)
-			if err != nil {
+			if err == nil {
 				upkeepId = parsedUpkeepId
 				break
 			}

--- a/actions/keeper_helpers.go
+++ b/actions/keeper_helpers.go
@@ -53,7 +53,7 @@ func DeployKeeperContracts(
 	linkToken contracts.LinkToken,
 	contractDeployer contracts.ContractDeployer,
 	networks *blockchain.Networks,
-) (contracts.KeeperRegistry, []contracts.KeeperConsumer) {
+) (contracts.KeeperRegistry, []contracts.KeeperConsumer, []*big.Int) {
 	ef, err := contractDeployer.DeployMockETHLINKFeed(big.NewInt(2e18))
 	Expect(err).ShouldNot(HaveOccurred(), "Deploying mock ETH-Link feed shouldn't fail")
 	gf, err := contractDeployer.DeployMockGasFeed(big.NewInt(2e11))
@@ -91,9 +91,9 @@ func DeployKeeperContracts(
 	for _, upkeep := range upkeeps {
 		upkeepsAddresses = append(upkeepsAddresses, upkeep.Address())
 	}
-	RegisterUpkeepContracts(linkToken, big.NewInt(9e18), networks, uint32(2500000), registrar, numberOfUpkeeps, upkeepsAddresses)
+	upkeepIds := RegisterUpkeepContracts(linkToken, big.NewInt(9e18), networks, uint32(2500000), registry, registrar, numberOfUpkeeps, upkeepsAddresses)
 
-	return registry, upkeeps
+	return registry, upkeeps, upkeepIds
 }
 
 // DeployPerformanceKeeperContracts deploys a set amount of keeper performance contracts registered to a single registry
@@ -149,7 +149,7 @@ func DeployPerformanceKeeperContracts(
 	}
 	linkFunds := big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(blockRange/blockInterval))
 
-	RegisterUpkeepContracts(linkToken, linkFunds, networks, uint32(2500000), registrar, numberOfContracts, upkeepsAddresses)
+	RegisterUpkeepContracts(linkToken, linkFunds, networks, uint32(2500000), registry, registrar, numberOfContracts, upkeepsAddresses)
 
 	return registry, upkeeps
 }
@@ -209,10 +209,13 @@ func RegisterUpkeepContracts(
 	linkFunds *big.Int,
 	networks *blockchain.Networks,
 	checkGasLimit uint32,
+	registry contracts.KeeperRegistry,
 	registrar contracts.UpkeepRegistrar,
 	numberOfContracts int,
 	upkeepAdresses []string,
-) {
+) []*big.Int {
+	registrationTxHashes := make([]common.Hash, 0)
+	upkeepIds := make([]*big.Int, 0)
 	for contractCount, upkeepAddress := range upkeepAdresses {
 		req, err := registrar.EncodeRegisterRequest(
 			fmt.Sprintf("upkeep_%d", contractCount+1),
@@ -225,13 +228,15 @@ func RegisterUpkeepContracts(
 			0,
 		)
 		Expect(err).ShouldNot(HaveOccurred(), "Encoding the register request shouldn't fail")
-		err = linkToken.TransferAndCall(registrar.Address(), linkFunds, req)
+		tx, err := linkToken.TransferAndCall(registrar.Address(), linkFunds, req)
 		Expect(err).ShouldNot(HaveOccurred(), "Error registering the upkeep consumer to the registrar")
 		log.Debug().
 			Str("Contract Address", upkeepAddress).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
+			Str("TxHash", tx.Hash().String()).
 			Msg("Registered Keeper Consumer Contract")
+		registrationTxHashes = append(registrationTxHashes, tx.Hash())
 		if (contractCount+1)%ContractDeploymentInterval == 0 { // For large amounts of contract deployments, space things out some
 			err = networks.Default.WaitForEvents()
 			Expect(err).ShouldNot(HaveOccurred(), "Failed to wait after registering upkeep consumers")
@@ -239,7 +244,25 @@ func RegisterUpkeepContracts(
 	}
 	err := networks.Default.WaitForEvents()
 	Expect(err).ShouldNot(HaveOccurred(), "Failed while waiting for all consumer contracts to be registered to registrar")
+
+	// Fetch the upkeep IDs
+	for _, txHash := range registrationTxHashes {
+		receipt, err := networks.Default.GetTxReceipt(txHash)
+		Expect(err).ShouldNot(HaveOccurred(), "Registration tx should be completed")
+		var upkeepId *big.Int
+		upkeepId = nil
+		for _, rawLog := range receipt.Logs {
+			parsedUpkeepId, err := registry.ParseUpkeepIdFromRegisteredLog(rawLog)
+			if err != nil {
+				upkeepId = parsedUpkeepId
+				break
+			}
+		}
+		Expect(upkeepId).ShouldNot(BeNil(), "Upkeep ID should be found after registration")
+		upkeepIds = append(upkeepIds, upkeepId)
+	}
 	log.Info().Msg("Successfully registered all Keeper Consumer Contracts")
+	return upkeepIds
 }
 
 func DeployKeeperConsumers(

--- a/actions/keeper_helpers.go
+++ b/actions/keeper_helpers.go
@@ -259,6 +259,10 @@ func RegisterUpkeepContracts(
 			}
 		}
 		Expect(upkeepId).ShouldNot(BeNil(), "Upkeep ID should be found after registration")
+		log.Debug().
+			Str("TxHash", txHash.String()).
+			Str("Upkeep ID", upkeepId.String()).
+			Msg("Found upkeepId in tx hash")
 		upkeepIds = append(upkeepIds, upkeepId)
 	}
 	log.Info().Msg("Successfully registered all Keeper Consumer Contracts")

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -70,6 +70,7 @@ type EVMClient interface {
 	TransactionOpts(from *EthereumWallet) (*bind.TransactOpts, error)
 	ProcessTransaction(tx *types.Transaction) error
 	IsTxConfirmed(txHash common.Hash) (bool, error)
+	GetTxReceipt(txHash common.Hash) (*types.Receipt, error)
 	ParallelTransactions(enabled bool)
 	Close() error
 

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -377,6 +377,15 @@ func (e *EthereumClient) IsTxConfirmed(txHash common.Hash) (bool, error) {
 	return !isPending, err
 }
 
+// GetTxReceipt returns the receipt of the transaction if available, error otherwise
+func (e *EthereumClient) GetTxReceipt(txHash common.Hash) (*types.Receipt, error) {
+	receipt, err := e.Client.TransactionReceipt(context.Background(), txHash)
+	if err != nil {
+		return nil, err
+	}
+	return receipt, nil
+}
+
 // ParallelTransactions when enabled, sends the transaction without waiting for transaction confirmations. The hashes
 // are then stored within the client and confirmations can be waited on by calling WaitForEvents.
 // When disabled, the minimum confirmations are waited on when the transaction is sent, so parallelisation is disabled.
@@ -630,6 +639,11 @@ func (e *EthereumMultinodeClient) ProcessTransaction(tx *types.Transaction) erro
 // IsTxConfirmed returns the default client's transaction confirmations
 func (e *EthereumMultinodeClient) IsTxConfirmed(txHash common.Hash) (bool, error) {
 	return e.DefaultClient.IsTxConfirmed(txHash)
+}
+
+// GetTxReceipt returns the receipt of the transaction if available, error otherwise
+func (e *EthereumMultinodeClient) GetTxReceipt(txHash common.Hash) (*types.Receipt, error) {
+	return e.DefaultClient.GetTxReceipt(txHash)
 }
 
 // ParallelTransactions when enabled, sends the transaction without waiting for transaction confirmations. The hashes

--- a/contracts/contract_models.go
+++ b/contracts/contract_models.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/contracts/ethereum"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	ocrConfigHelper "github.com/smartcontractkit/libocr/offchainreporting/confighelper"
 	ocrConfigHelper2 "github.com/smartcontractkit/libocr/offchainreporting2/confighelper"
 )
@@ -71,7 +72,7 @@ type LinkToken interface {
 	Approve(to string, amount *big.Int) error
 	Transfer(to string, amount *big.Int) error
 	BalanceOf(ctx context.Context, addr string) (*big.Int, error)
-	TransferAndCall(to string, amount *big.Int, data []byte) error
+	TransferAndCall(to string, amount *big.Int, data []byte) (*types.Transaction, error)
 	Name(context.Context) (string, error)
 }
 

--- a/contracts/ethereum_contracts.go
+++ b/contracts/ethereum_contracts.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/client"
@@ -550,22 +551,23 @@ func (l *EthereumLinkToken) Transfer(to string, amount *big.Int) error {
 	return l.client.ProcessTransaction(tx)
 }
 
-func (l *EthereumLinkToken) TransferAndCall(to string, amount *big.Int, data []byte) error {
+func (l *EthereumLinkToken) TransferAndCall(to string, amount *big.Int, data []byte) (*types.Transaction, error) {
 	opts, err := l.client.TransactionOpts(l.client.GetDefaultWallet())
 	if err != nil {
-		return err
+		return nil, err
+	}
+	tx, err := l.instance.TransferAndCall(opts, common.HexToAddress(to), amount, data)
+	if err != nil {
+		return nil, err
 	}
 	log.Info().
 		Str("From", l.client.GetDefaultWallet().Address()).
 		Str("To", to).
 		Str("Amount", amount.String()).
 		Uint64("Nonce", opts.Nonce.Uint64()).
+		Str("TxHash", tx.Hash().String()).
 		Msg("Transferring and Calling LINK")
-	tx, err := l.instance.TransferAndCall(opts, common.HexToAddress(to), amount, data)
-	if err != nil {
-		return err
-	}
-	return l.client.ProcessTransaction(tx)
+	return tx, l.client.ProcessTransaction(tx)
 }
 
 // EthereumOffchainAggregator represents the offchain aggregation contract

--- a/suite/smoke/keeper_test.go
+++ b/suite/smoke/keeper_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Keeper suite @keeper", func() {
 			linkToken, err = contractDeployer.DeployLinkTokenContract()
 			Expect(err).ShouldNot(HaveOccurred(), "Deploying Link Token Contract shouldn't fail")
 
-			r, consumers := actions.DeployKeeperContracts(
+			r, consumers, _ := actions.DeployKeeperContracts(
 				ethereum.RegistryVersion_1_1,
 				contracts.KeeperRegistrySettings{
 					PaymentPremiumPPB:    uint32(200000000),


### PR DESCRIPTION
- Return upkeep IDs after registration. These are fetched from logs resulting from link.transferAndCall tx
- Add function to set config on registry

Corresponding CL repo PR here:  https://github.com/smartcontractkit/chainlink/pull/6673