### PR TITLE
connect chainlink nodes by chart names for soak tests

### DIFF
--- a/client/chainlink.go
+++ b/client/chainlink.go
@@ -763,22 +763,29 @@ func ConnectChainlinkNodesByCharts(e *environment.Environment, charts []string) 
 
 // ConnectChainlinkNodesSoak assumes that the tests are being run from an internal soak test runner
 func ConnectChainlinkNodesSoak(e *environment.Environment) ([]Chainlink, error) {
+	return ConnectChainlinkNodesSoakByCharts(e, []string{"chainlink"})
+}
+
+// ConnectChainlinkNodesSoakByCharts assumes that the tests are being run from an internal soak test runner
+func ConnectChainlinkNodesSoakByCharts(e *environment.Environment, charts []string) ([]Chainlink, error) {
 	var clients []Chainlink
 
-	remoteURLs, err := e.Charts.Connections("chainlink").RemoteURLsByPort("access", environment.HTTP)
-	if err != nil {
-		return nil, err
-	}
-	for urlIndex, localURL := range remoteURLs {
-		c, err := NewChainlink(&ChainlinkConfig{
-			URL:      localURL.String(),
-			Email:    "notreal@fakeemail.ch",
-			Password: "twochains",
-			RemoteIP: remoteURLs[urlIndex].Hostname(),
-		}, http.DefaultClient)
-		clients = append(clients, c)
+	for _, chart := range charts {
+		remoteURLs, err := e.Charts.Connections(chart).RemoteURLsByPort("access", environment.HTTP)
 		if err != nil {
 			return nil, err
+		}
+		for _, remoteURL := range remoteURLs {
+			c, err := NewChainlink(&ChainlinkConfig{
+				URL:      remoteURL.String(),
+				Email:    "notreal@fakeemail.ch",
+				Password: "twochains",
+				RemoteIP: remoteURL.Hostname(),
+			}, http.DefaultClient)
+			clients = append(clients, c)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return clients, nil

--- a/testsetups/vrfv2.go
+++ b/testsetups/vrfv2.go
@@ -64,7 +64,7 @@ func NewVRFV2SoakTest(inputs *VRFV2SoakTestInputs) *VRFV2SoakTest {
 }
 
 // Setup sets up the test environment
-func (t *VRFV2SoakTest) Setup(env *environment.Environment, isLocal bool) {
+func (t *VRFV2SoakTest) Setup(env *environment.Environment, charts []string, isLocal bool) {
 	t.ensureInputValues()
 	t.env = env
 	var err error
@@ -75,13 +75,13 @@ func (t *VRFV2SoakTest) Setup(env *environment.Environment, isLocal bool) {
 		err = env.ConnectAll()
 		Expect(err).ShouldNot(HaveOccurred())
 		networkRegistry = blockchain.NewDefaultNetworkRegistry()
-		t.ChainlinkNodes, err = client.ConnectChainlinkNodes(env)
+		t.ChainlinkNodes, err = client.ConnectChainlinkNodesByCharts(env, charts)
 		Expect(err).ShouldNot(HaveOccurred(), "Connecting to chainlink nodes shouldn't fail")
 		t.mockServer, err = client.ConnectMockServer(env)
 		Expect(err).ShouldNot(HaveOccurred(), "Creating mockserver clients shouldn't fail")
 	} else {
 		networkRegistry = blockchain.NewSoakNetworkRegistry()
-		t.ChainlinkNodes, err = client.ConnectChainlinkNodesSoak(env)
+		t.ChainlinkNodes, err = client.ConnectChainlinkNodesSoakByCharts(env, charts)
 		Expect(err).ShouldNot(HaveOccurred(), "Connecting to chainlink nodes shouldn't fail")
 		t.mockServer, err = client.ConnectMockServerSoak(env)
 		Expect(err).ShouldNot(HaveOccurred(), "Creating mockserver clients shouldn't fail")


### PR DESCRIPTION
our monitoring tests have a non standard naming scheme so passing the array of names is needed for soak