### PR TITLE
Docker Compile Soak Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,5 @@ docs/Gemfile.lock
 
 dist/
 
-remote_runner_config.yaml
+**/remote_runner_config.yaml
 logs/

--- a/suite/remote_runner_config.yaml
+++ b/suite/remote_runner_config.yaml
@@ -1,6 +1,6 @@
 # any ginkgo tag to run, you can find them in Describe string in tests
 # you can use that file to start the tests locally or override vars from env:
 # SLACK_API_KEY="" SLACK_CHANNEL="" SLACK_USER_ID="" REMOTE_RUNNER_CONFIG_FILE="../runner.yaml"
-slack_api_key: xoxb-slack-oauth-key
+slack_api_key: xoxb-placeholder-slack-oauth-key
 slack_channel: C1A2B3C4D5G
 slack_user_id: U1A2B3C4D5G

--- a/suite/soak/Dockerfile.compiler
+++ b/suite/soak/Dockerfile.compiler
@@ -1,0 +1,17 @@
+# This docker file is used when compiling soak tests, to ensure complete platform to platform compatibility.
+# It also enables running soak tests that utilize CGO
+
+FROM --platform=linux/amd64 golang AS compiler
+ENV CGO_ENABLED=1 GOOS=linux GOARCH=amd64
+ARG testDirectory=./suite/soak/tests
+
+WORKDIR /app
+COPY ../../go.mod .
+COPY ../../go.sum .
+RUN go mod download
+COPY ../../. .
+
+RUN go test -c -ldflags="-s -w -extldflags=-static" -o ./remote.test ${testDirectory}
+
+FROM scratch AS export
+COPY --from=compiler /app/remote.test .


### PR DESCRIPTION
Protofire team kept running into issues with cross-compilations, both with M1 macs and with CGO apps. This uses a docker build to compile the tests. It is a bit slower but cleans up a lot of headaches.