### PR TITLE
Remove hard coded soak test docker build paths

### DIFF
--- a/suite/soak/Dockerfile.compiler
+++ b/suite/soak/Dockerfile.compiler
@@ -4,12 +4,13 @@
 FROM --platform=linux/amd64 golang AS compiler
 ENV CGO_ENABLED=1 GOOS=linux GOARCH=amd64
 ARG testDirectory=./suite/soak/tests
+ARG projectRootPath=../..
 
 WORKDIR /app
-COPY ../../go.mod .
-COPY ../../go.sum .
-RUN go mod download
-COPY ../../. .
+COPY ${projectRootPath}/go.mod .
+COPY ${projectRootPath}/go.sum .
+RUN go version && go mod download
+COPY ${projectRootPath}/. .
 
 RUN go test -c -ldflags="-s -w -extldflags=-static" -o ./remote.test ${testDirectory}
 


### PR DESCRIPTION
Pathing is different when building the test from an outside repo vs inside of this one. Paths pointing to tests and files that need to be run need to be relative to the project building the test, while things like the path to the docker file need to be specific to the go package. Also, paths passed into docker as build args need to be relative to the current working directory of the running go test that runs the docker command.

Also added a note in the RunSoakTest function stating that it only works for tests running inside of this repo. Tests outside of this repo need their own run function.