### PR TITLE
Faster Live Testnets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,14 +42,6 @@ jobs:
         with:
           files: ./unit-test-coverage.out
           name: codecov-umbrella
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: ./tests-unit-report.xml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          check_name: Unit Test Report
-          comment_mode: always
       - name: Publish Artifacts
         if: failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-go2-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go2-
-      - name: Download Go Vendor Packages and Ginkgo
+      - name: Download Go Vendor Packages
         if: steps.cache-packages.outputs.cache-hit != 'true'
         run: make install_ci
       - name: Run Tests

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.4
+golang 1.19.5
 nodejs 14.20.0
 k3d 5.4.6
 act 0.2.30

--- a/blockchain/arbitrum.go
+++ b/blockchain/arbitrum.go
@@ -64,7 +64,7 @@ func (a *ArbitrumClient) Fund(toAddress string, amount *big.Float) error {
 		Str("To", toAddress).
 		Str("Amount", amount.String()).
 		Msg("Funding Address")
-	if err := a.Client.SendTransaction(context.Background(), tx); err != nil {
+	if err := a.SendTransaction(context.Background(), tx); err != nil {
 		return err
 	}
 
@@ -116,7 +116,7 @@ func (a *ArbitrumClient) ReturnFunds(fromPrivateKey *ecdsa.PrivateKey) error {
 		Str("From", fromAddress.Hex()).
 		Str("Amount", balance.String()).
 		Msg("Returning Funds to Default Wallet")
-	if err := a.Client.SendTransaction(context.Background(), tx); err != nil {
+	if err := a.SendTransaction(context.Background(), tx); err != nil {
 		return err
 	}
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -40,6 +40,7 @@ type EVMClient interface {
 	HeaderHashByNumber(ctx context.Context, bn *big.Int) (string, error)
 	HeaderTimestampByNumber(ctx context.Context, bn *big.Int) (uint64, error)
 	LatestBlockNumber(ctx context.Context) (uint64, error)
+	SendTransaction(ctx context.Context, tx *types.Transaction) error
 	Fund(toAddress string, amount *big.Float) error
 	ReturnFunds(fromKey *ecdsa.PrivateKey) error
 	DeployContract(

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -28,22 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 )
 
-// Used for when running tests on a live test network, so tests can share nonces and run in parallel
-var globalNonceManager = newNonceSettings()
-
-// convenience function
-func newNonceSettings() *NonceSettings {
-	return &NonceSettings{
-		NonceMu: &sync.Mutex{},
-		Nonces:  make(map[string]uint64),
-	}
-}
-
-// NonceSettings is a convenient wrapper for holding nonce state
-type NonceSettings struct {
-	NonceMu *sync.Mutex
-	Nonces  map[string]uint64
-}
+var debugID int
 
 // EthereumClient wraps the client and the BlockChain network to interact with an EVM based Blockchain
 type EthereumClient struct {
@@ -58,6 +43,7 @@ type EthereumClient struct {
 	queueTransactions   bool
 	gasStats            *GasStats
 	doneChan            chan struct{}
+	debugID             int
 }
 
 // newEVMClient creates an EVM client for a single node/URL
@@ -72,8 +58,10 @@ func newEVMClient(networkSettings EVMNetwork) (EVMClient, error) {
 		return nil, err
 	}
 
+	debugID++
 	ec := &EthereumClient{
 		NetworkConfig:       networkSettings,
+		debugID:             debugID,
 		Client:              cl,
 		Wallets:             make([]*EthereumWallet, 0),
 		headerSubscriptions: map[string]HeaderEventSubscription{},
@@ -85,7 +73,7 @@ func newEVMClient(networkSettings EVMNetwork) (EVMClient, error) {
 	if ec.NetworkConfig.Simulated {
 		ec.NonceSettings = newNonceSettings()
 	} else { // un-simulated chain means potentially running tests in parallel, need to share nonces
-		ec.NonceSettings = globalNonceManager
+		ec.NonceSettings = useGlobalNonceManager()
 	}
 
 	if err := ec.LoadWallets(networkSettings); err != nil {
@@ -111,6 +99,7 @@ func (e *EthereumClient) newHeadersLoop() {
 		if err := e.subscribeToNewHeaders(); err != nil {
 			log.Error().
 				Err(err).
+				Int("Debug ID", e.debugID).
 				Str("NetworkName", e.NetworkConfig.Name).
 				Msg("Error while subscribing to headers")
 			time.Sleep(time.Second)
@@ -244,6 +233,18 @@ func (e *EthereumClient) LatestBlockNumber(ctx context.Context) (uint64, error) 
 	return bn, nil
 }
 
+func (e *EthereumClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	// for instant txs, wait for permission to go
+	if e.NetworkConfig.MinimumConfirmations <= 0 {
+		fromAddr, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
+		if err != nil {
+			return err
+		}
+		<-e.NonceSettings.registerInstantTransaction(fromAddr.Hex(), tx.Nonce())
+	}
+	return e.Client.SendTransaction(ctx, tx)
+}
+
 // Fund sends some ETH to an address using the default wallet
 func (e *EthereumClient) Fund(
 	toAddress string,
@@ -275,6 +276,11 @@ func (e *EthereumClient) Fund(
 	baseFeeMult := big.NewInt(1).Mul(latestHeader.BaseFee, big.NewInt(2))
 	gasFeeCap := baseFeeMult.Add(baseFeeMult, suggestedGasTipCap)
 
+	estimatedGas, err := e.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
+	if err != nil {
+		return err
+	}
+
 	tx, err := types.SignNewTx(privateKey, types.LatestSignerForChainID(e.GetChainID()), &types.DynamicFeeTx{
 		ChainID:   e.GetChainID(),
 		Nonce:     nonce,
@@ -282,7 +288,7 @@ func (e *EthereumClient) Fund(
 		Value:     utils.EtherToWei(amount),
 		GasTipCap: suggestedGasTipCap,
 		GasFeeCap: gasFeeCap,
-		Gas:       21000,
+		Gas:       estimatedGas,
 	})
 	if err != nil {
 		return err
@@ -294,7 +300,7 @@ func (e *EthereumClient) Fund(
 		Str("To", toAddress).
 		Str("Amount", amount.String()).
 		Msg("Funding Address")
-	if err := e.Client.SendTransaction(context.Background(), tx); err != nil {
+	if err := e.SendTransaction(context.Background(), tx); err != nil {
 		if strings.Contains(err.Error(), "nonce") {
 			err = errors.Wrap(err, fmt.Sprintf("using nonce %d", nonce))
 		}
@@ -305,32 +311,54 @@ func (e *EthereumClient) Fund(
 }
 
 func (e *EthereumClient) ReturnFunds(fromKey *ecdsa.PrivateKey) error {
+	var tx *types.Transaction
+	var err error
+	for attempt := 0; attempt < 5; attempt++ {
+		tx, err = attemptReturn(e, fromKey, attempt)
+		if err == nil {
+			return e.ProcessTransaction(tx)
+		}
+		log.Debug().Err(err).Int("Attempt", attempt+1).Msg("Error returning funds from Chainlink node, trying again")
+	}
+	return err
+}
+
+func attemptReturn(e *EthereumClient, fromKey *ecdsa.PrivateKey, attemptCount int) (*types.Transaction, error) {
 	to := common.HexToAddress(e.DefaultWallet.Address())
 
 	suggestedGasTipCap, err := e.Client.SuggestGasTipCap(context.Background())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	latestHeader, err := e.Client.HeaderByNumber(context.Background(), nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	baseFeeMult := big.NewInt(1).Mul(latestHeader.BaseFee, big.NewInt(2))
 	gasFeeCap := baseFeeMult.Add(baseFeeMult, suggestedGasTipCap)
+	gasFeeCap.Add(gasFeeCap, big.NewInt(int64(attemptCount*1000)))
 
 	fromAddress, err := utils.PrivateKeyToAddress(fromKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	balance, err := e.Client.BalanceAt(context.Background(), fromAddress, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	balance.Sub(balance, big.NewInt(1).Mul(gasFeeCap, big.NewInt(21000)))
+	estGas, err := e.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
+	if err != nil {
+		return nil, err
+	}
+	balance.Sub(balance, big.NewInt(1).Mul(gasFeeCap, big.NewInt(0).SetUint64(estGas)))
 
 	nonce, err := e.GetNonce(context.Background(), fromAddress)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	estimatedGas, err := e.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
+	if err != nil {
+		return nil, err
 	}
 
 	tx, err := types.SignNewTx(fromKey, types.LatestSignerForChainID(e.GetChainID()), &types.DynamicFeeTx{
@@ -340,22 +368,17 @@ func (e *EthereumClient) ReturnFunds(fromKey *ecdsa.PrivateKey) error {
 		Value:     balance,
 		GasTipCap: suggestedGasTipCap,
 		GasFeeCap: gasFeeCap,
-		Gas:       21000,
+		Gas:       estimatedGas,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-
 	log.Info().
 		Str("Token", "ETH").
 		Str("Amount", balance.String()).
 		Str("From", fromAddress.Hex()).
 		Msg("Returning Funds to Default Wallet")
-	if err := e.Client.SendTransaction(context.Background(), tx); err != nil {
-		return err
-	}
-
-	return e.ProcessTransaction(tx)
+	return tx, e.SendTransaction(context.Background(), tx)
 }
 
 // EstimateCostForChainlinkOperations calculates required amount of ETH for amountOfOperations Chainlink operations
@@ -394,16 +417,16 @@ func (e *EthereumClient) DeployContract(
 	contractName string,
 	deployer ContractDeployer,
 ) (*common.Address, *types.Transaction, interface{}, error) {
-	opts, err := e.TransactionOpts(e.DefaultWallet)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	suggestedTipCap, err := e.Client.SuggestGasTipCap(context.Background())
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	gasPriceBuffer := big.NewInt(0).SetUint64(e.NetworkConfig.GasEstimationBuffer)
+
+	opts, err := e.TransactionOpts(e.DefaultWallet)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	opts.GasTipCap = suggestedTipCap.Add(gasPriceBuffer, suggestedTipCap)
 
 	if e.NetworkConfig.GasEstimationBuffer > 0 {
@@ -470,6 +493,9 @@ func (e *EthereumClient) TransactionOpts(from *EthereumWallet) (*bind.TransactOp
 	}
 	opts.Nonce = big.NewInt(int64(nonce))
 
+	if e.NetworkConfig.MinimumConfirmations <= 0 { // Wait for your turn to send on an L2 chain
+		<-e.NonceSettings.registerInstantTransaction(from.Address(), nonce)
+	}
 	return opts, nil
 }
 
@@ -477,6 +503,11 @@ func (e *EthereumClient) TransactionOpts(from *EthereumWallet) (*bind.TransactOp
 func (e *EthereumClient) ProcessTransaction(tx *types.Transaction) error {
 	var txConfirmer HeaderEventSubscription
 	if e.GetNetworkConfig().MinimumConfirmations <= 0 {
+		fromAddr, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
+		if err != nil {
+			return err
+		}
+		e.NonceSettings.sentInstantTransaction(fromAddr.Hex()) // On an L2 chain, indicate the tx has been sent
 		txConfirmer = NewInstantConfirmer(e, tx.Hash(), nil, nil)
 	} else {
 		txConfirmer = NewTransactionConfirmer(e, tx, e.GetNetworkConfig().MinimumConfirmations)
@@ -598,22 +629,14 @@ func (e *EthereumClient) GetTxReceipt(txHash common.Hash) (*types.Receipt, error
 
 // ParallelTransactions when enabled, sends the transaction without waiting for transaction confirmations. The hashes
 // are then stored within the client and confirmations can be waited on by calling WaitForEvents.
-// When disabled, the minimum confirmations are waited on when the transaction is sent, so parallelisation is disabled.
 func (e *EthereumClient) ParallelTransactions(enabled bool) {
-	if e.NetworkConfig.MinimumConfirmations <= 0 {
-		log.Warn().
-			Str("Why", "Instant confirmation chains like Optimistic roll-ups don't play nice with parallel txs with out-of-order nonces").
-			Str("Network", e.NetworkConfig.Name).
-			Msg("Instant confirmations on for chain, setting parallel txs to false")
-		enabled = false
-	}
 	e.queueTransactions = enabled
 }
 
 // Close tears down the current open Ethereum client
 func (e *EthereumClient) Close() error {
-	e.doneChan <- struct{}{}
-	e.Client.Close()
+	// close(e.NonceSettings.doneChan)
+	close(e.doneChan)
 	return nil
 }
 
@@ -875,6 +898,11 @@ func (e *EthereumMultinodeClient) HeaderTimestampByNumber(ctx context.Context, b
 // LatestBlockNumber gets the latest block number from the default client
 func (e *EthereumMultinodeClient) LatestBlockNumber(ctx context.Context) (uint64, error) {
 	return e.DefaultClient.LatestBlockNumber(ctx)
+}
+
+// SendTransaction wraps ethereum's SendTransaction to make it safe with instant transaction types
+func (e *EthereumMultinodeClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return e.DefaultClient.SendTransaction(ctx, tx)
 }
 
 // Fund funds a specified address with ETH from the given wallet

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -28,8 +28,6 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 )
 
-var debugID int
-
 // EthereumClient wraps the client and the BlockChain network to interact with an EVM based Blockchain
 type EthereumClient struct {
 	ID                  int
@@ -43,7 +41,6 @@ type EthereumClient struct {
 	queueTransactions   bool
 	gasStats            *GasStats
 	doneChan            chan struct{}
-	debugID             int
 }
 
 // newEVMClient creates an EVM client for a single node/URL
@@ -58,10 +55,8 @@ func newEVMClient(networkSettings EVMNetwork) (EVMClient, error) {
 		return nil, err
 	}
 
-	debugID++
 	ec := &EthereumClient{
 		NetworkConfig:       networkSettings,
-		debugID:             debugID,
 		Client:              cl,
 		Wallets:             make([]*EthereumWallet, 0),
 		headerSubscriptions: map[string]HeaderEventSubscription{},
@@ -99,7 +94,6 @@ func (e *EthereumClient) newHeadersLoop() {
 		if err := e.subscribeToNewHeaders(); err != nil {
 			log.Error().
 				Err(err).
-				Int("Debug ID", e.debugID).
 				Str("NetworkName", e.NetworkConfig.Name).
 				Msg("Error while subscribing to headers")
 			time.Sleep(time.Second)

--- a/blockchain/nonce_settings.go
+++ b/blockchain/nonce_settings.go
@@ -1,0 +1,144 @@
+package blockchain
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Used for when running tests on a live test network, so tests can share nonces and run in parallel on the same network
+var (
+	globalNonceManager *NonceSettings
+	onlyOnce           sync.Once
+)
+
+// useGlobalNonceManager for when running tests on a non-simulated network
+func useGlobalNonceManager() *NonceSettings {
+	onlyOnce.Do(func() {
+		globalNonceManager = newNonceSettings()
+		go globalNonceManager.watchInstantTransactions()
+	})
+	return globalNonceManager
+}
+
+// convenience function
+func newNonceSettings() *NonceSettings {
+	return &NonceSettings{
+		NonceMu: &sync.Mutex{},
+		Nonces:  make(map[string]uint64),
+
+		doneChan:            make(chan struct{}),
+		instantTransactions: make(map[string]map[uint64]chan struct{}),
+		instantNonces:       make(map[string]uint64),
+		registerChan:        make(chan instantTxRegistration),
+		sentChan:            make(chan string),
+	}
+}
+
+// NonceSettings is a convenient wrapper for holding nonce state
+type NonceSettings struct {
+	NonceMu *sync.Mutex
+	Nonces  map[string]uint64
+
+	// used to properly meter out instant txs on L2s
+	doneChan            chan struct{}
+	instantTransactions map[string]map[uint64]chan struct{}
+	instantNonces       map[string]uint64
+	instantNoncesMu     sync.Mutex
+	registerChan        chan instantTxRegistration
+	sentChan            chan string
+}
+
+// GetNonce keep tracking of nonces per address, add last nonce for addr if the map is empty
+func (e *EthereumClient) GetNonce(ctx context.Context, addr common.Address) (uint64, error) {
+	e.NonceSettings.NonceMu.Lock()
+	defer e.NonceSettings.NonceMu.Unlock()
+	if _, ok := e.NonceSettings.Nonces[addr.Hex()]; !ok {
+		pendingNonce, err := e.Client.PendingNonceAt(ctx, addr)
+		if err != nil {
+			return 0, err
+		}
+		e.NonceSettings.Nonces[addr.Hex()] = pendingNonce
+
+		e.NonceSettings.instantNoncesMu.Lock()
+		e.NonceSettings.instantNonces[addr.Hex()] = pendingNonce
+		e.NonceSettings.instantNoncesMu.Unlock()
+
+		return pendingNonce, nil
+	}
+	e.NonceSettings.Nonces[addr.Hex()]++
+	return e.NonceSettings.Nonces[addr.Hex()], nil
+}
+
+// PeekPendingNonce returns the current pending nonce for the address. Does not change any nonce settings state
+func (e *EthereumClient) PeekPendingNonce(addr common.Address) (uint64, error) {
+	e.NonceSettings.NonceMu.Lock()
+	defer e.NonceSettings.NonceMu.Unlock()
+	if _, ok := e.NonceSettings.Nonces[addr.Hex()]; !ok {
+		pendingNonce, err := e.Client.PendingNonceAt(context.Background(), addr)
+		if err != nil {
+			return 0, err
+		}
+		e.NonceSettings.Nonces[addr.Hex()] = pendingNonce
+	}
+	return e.NonceSettings.Nonces[addr.Hex()], nil
+}
+
+// watchInstantTransactions should only be called when minConfirmations for the chain is 0, generally an L2 chain.
+// This helps meter out transactions to L2 chains, so that nonces only send in order. For most (if not all) L2 chains,
+// the mempool is small or non-existent, meaning we can't send nonces out of order, otherwise the tx is instantly
+// rejected.
+func (ns *NonceSettings) watchInstantTransactions() {
+	ns.instantTransactions = make(map[string]map[uint64]chan struct{})
+
+	for {
+		select {
+		case toRegister := <-ns.registerChan:
+			if _, ok := ns.instantTransactions[toRegister.fromAddr]; !ok {
+				ns.instantTransactions[toRegister.fromAddr] = make(map[uint64]chan struct{})
+			}
+			ns.instantTransactions[toRegister.fromAddr][toRegister.nonce] = toRegister.releaseChan
+		case sentAddr := <-ns.sentChan:
+			ns.instantNoncesMu.Lock()
+			ns.instantNonces[sentAddr]++
+			ns.instantNoncesMu.Unlock()
+		case <-ns.doneChan: // Rarely need to call this
+			return
+		default:
+			for addr, releaseChannels := range ns.instantTransactions {
+				ns.instantNoncesMu.Lock()
+				nonceToSend := ns.instantNonces[addr]
+				ns.instantNoncesMu.Unlock()
+				if txChannel, ok := releaseChannels[nonceToSend]; ok {
+					close(txChannel)
+					delete(releaseChannels, nonceToSend)
+				}
+			}
+		}
+	}
+}
+
+// registerInstantTransaction helps meter out txs for L2 chains. Register, then wait to receive from the returned channel
+// to know when your Tx can send. See watchInstantTransactions for a deeper explanation.
+func (ns *NonceSettings) registerInstantTransaction(fromAddr string, nonce uint64) chan struct{} {
+	releaseChan := make(chan struct{})
+	ns.registerChan <- instantTxRegistration{
+		fromAddr:    fromAddr,
+		nonce:       nonce,
+		releaseChan: releaseChan,
+	}
+	return releaseChan
+}
+
+// sentInstantTransaction shows that you have sent this instant transaction, unlocking the next L2 transaction to run.
+// See watchInstantTransactions for a deeper explanation.
+func (ns *NonceSettings) sentInstantTransaction(fromAddr string) {
+	ns.sentChan <- fromAddr
+}
+
+type instantTxRegistration struct {
+	fromAddr    string
+	nonce       uint64
+	releaseChan chan struct{}
+}

--- a/blockchain/nonce_settings.go
+++ b/blockchain/nonce_settings.go
@@ -103,8 +103,6 @@ func (ns *NonceSettings) watchInstantTransactions() {
 			ns.instantNoncesMu.Lock()
 			ns.instantNonces[sentAddr]++
 			ns.instantNoncesMu.Unlock()
-		case <-ns.doneChan: // Rarely need to call this
-			return
 		default:
 			for addr, releaseChannels := range ns.instantTransactions {
 				ns.instantNoncesMu.Lock()

--- a/blockchain/optimism.go
+++ b/blockchain/optimism.go
@@ -1,24 +1,5 @@
 package blockchain
 
-import (
-	"context"
-	"crypto/ecdsa"
-	"fmt"
-	"math/big"
-	"strings"
-
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-
-	contracts "github.com/smartcontractkit/chainlink-testing-framework/contracts/ethereum"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
-)
-
 // OptimismMultinodeClient represents a multi-node, EVM compatible client for the Optimism network
 type OptimismMultinodeClient struct {
 	*EthereumMultinodeClient
@@ -29,169 +10,169 @@ type OptimismClient struct {
 	*EthereumClient
 }
 
-// Fund sends some OP to an address using the default wallet
-func (o *OptimismClient) Fund(toAddress string, amount *big.Float) error {
-	privateKey, err := crypto.HexToECDSA(o.DefaultWallet.PrivateKey())
-	to := common.HexToAddress(toAddress)
-	if err != nil {
-		return fmt.Errorf("invalid private key: %v", err)
-	}
-	// Optimism uses legacy transactions and gas estimations
-	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return err
-	}
+// // Fund sends some OP to an address using the default wallet
+// func (o *OptimismClient) Fund(toAddress string, amount *big.Float) error {
+// 	privateKey, err := crypto.HexToECDSA(o.DefaultWallet.PrivateKey())
+// 	to := common.HexToAddress(toAddress)
+// 	if err != nil {
+// 		return fmt.Errorf("invalid private key: %v", err)
+// 	}
+// 	// Optimism uses legacy transactions and gas estimations
+// 	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
 
-	nonce, err := o.GetNonce(context.Background(), common.HexToAddress(o.DefaultWallet.Address()))
-	if err != nil {
-		return err
-	}
-	estimatedGas, err := o.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
-	if err != nil {
-		return err
-	}
+// 	nonce, err := o.GetNonce(context.Background(), common.HexToAddress(o.DefaultWallet.Address()))
+// 	if err != nil {
+// 		return err
+// 	}
+// 	estimatedGas, err := o.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
+// 	if err != nil {
+// 		return err
+// 	}
 
-	tx, err := types.SignNewTx(privateKey, types.LatestSignerForChainID(o.GetChainID()), &types.LegacyTx{
-		Nonce:    nonce,
-		To:       &to,
-		Value:    utils.EtherToWei(amount),
-		GasPrice: suggestedGasPrice,
-		Gas:      estimatedGas,
-	})
-	if err != nil {
-		return err
-	}
+// 	tx, err := types.SignNewTx(privateKey, types.LatestSignerForChainID(o.GetChainID()), &types.LegacyTx{
+// 		Nonce:    nonce,
+// 		To:       &to,
+// 		Value:    utils.EtherToWei(amount),
+// 		GasPrice: suggestedGasPrice,
+// 		Gas:      estimatedGas,
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
 
-	log.Info().
-		Str("Token", "OP").
-		Str("From", o.DefaultWallet.Address()).
-		Str("To", toAddress).
-		Str("Amount", amount.String()).
-		Uint64("Nonce", nonce).
-		Msg("Funding Address")
-	if err := o.SendTransaction(context.Background(), tx); err != nil {
-		if strings.Contains(err.Error(), "nonce") {
-			err = errors.Wrap(err, fmt.Sprintf("using nonce %d", nonce))
-		}
-		return err
-	}
+// 	log.Info().
+// 		Str("Token", "OP").
+// 		Str("From", o.DefaultWallet.Address()).
+// 		Str("To", toAddress).
+// 		Str("Amount", amount.String()).
+// 		Uint64("Nonce", nonce).
+// 		Msg("Funding Address")
+// 	if err := o.SendTransaction(context.Background(), tx); err != nil {
+// 		if strings.Contains(err.Error(), "nonce") {
+// 			err = errors.Wrap(err, fmt.Sprintf("using nonce %d", nonce))
+// 		}
+// 		return err
+// 	}
 
-	return o.ProcessTransaction(tx)
-}
+// 	return o.ProcessTransaction(tx)
+// }
 
-// DeployContract deploys smart contracts specifically on Optimism
-func (o *OptimismClient) DeployContract(
-	contractName string,
-	deployer ContractDeployer,
-) (*common.Address, *types.Transaction, interface{}, error) {
-	opts, err := o.TransactionOpts(o.DefaultWallet)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+// // DeployContract deploys smart contracts specifically on Optimism
+// func (o *OptimismClient) DeployContract(
+// 	contractName string,
+// 	deployer ContractDeployer,
+// ) (*common.Address, *types.Transaction, interface{}, error) {
+// 	opts, err := o.TransactionOpts(o.DefaultWallet)
+// 	if err != nil {
+// 		return nil, nil, nil, err
+// 	}
 
-	// Optimism uses legacy transactions and gas estimations, is behind London fork as of 04/27/2022
-	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return nil, nil, nil, err
-	}
+// 	// Optimism uses legacy transactions and gas estimations, is behind London fork as of 04/27/2022
+// 	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
+// 	if err != nil {
+// 		return nil, nil, nil, err
+// 	}
 
-	// Bump gas price
-	gasPriceBuffer := big.NewInt(0).SetUint64(o.NetworkConfig.GasEstimationBuffer)
-	suggestedGasPrice.Add(suggestedGasPrice, gasPriceBuffer)
+// 	// Bump gas price
+// 	gasPriceBuffer := big.NewInt(0).SetUint64(o.NetworkConfig.GasEstimationBuffer)
+// 	suggestedGasPrice.Add(suggestedGasPrice, gasPriceBuffer)
 
-	opts.GasPrice = suggestedGasPrice
+// 	opts.GasPrice = suggestedGasPrice
 
-	contractAddress, transaction, contractInstance, err := deployer(opts, o.Client)
-	if err != nil {
-		if strings.Contains(err.Error(), "nonce") {
-			err = errors.Wrap(err, fmt.Sprintf("using nonce %d", opts.Nonce.Uint64()))
-		}
-		return nil, nil, nil, err
-	}
+// 	contractAddress, transaction, contractInstance, err := deployer(opts, o.Client)
+// 	if err != nil {
+// 		if strings.Contains(err.Error(), "nonce") {
+// 			err = errors.Wrap(err, fmt.Sprintf("using nonce %d", opts.Nonce.Uint64()))
+// 		}
+// 		return nil, nil, nil, err
+// 	}
 
-	if err = o.ProcessTransaction(transaction); err != nil {
-		return nil, nil, nil, err
-	}
+// 	if err = o.ProcessTransaction(transaction); err != nil {
+// 		return nil, nil, nil, err
+// 	}
 
-	log.Info().
-		Str("Contract Address", contractAddress.Hex()).
-		Str("Contract Name", contractName).
-		Str("From", o.DefaultWallet.Address()).
-		Str("Total Gas Cost (OP)", utils.WeiToEther(transaction.Cost()).String()).
-		Str("Network Name", o.NetworkConfig.Name).
-		Msg("Deployed contract")
-	return &contractAddress, transaction, contractInstance, err
-}
+// 	log.Info().
+// 		Str("Contract Address", contractAddress.Hex()).
+// 		Str("Contract Name", contractName).
+// 		Str("From", o.DefaultWallet.Address()).
+// 		Str("Total Gas Cost (OP)", utils.WeiToEther(transaction.Cost()).String()).
+// 		Str("Network Name", o.NetworkConfig.Name).
+// 		Msg("Deployed contract")
+// 	return &contractAddress, transaction, contractInstance, err
+// }
 
-// Fund sends some ARB to an address using the default wallet
-func (o *OptimismClient) ReturnFunds(fromPrivateKey *ecdsa.PrivateKey) error {
-	to := common.HexToAddress(o.DefaultWallet.Address())
+// // Fund sends some ARB to an address using the default wallet
+// func (o *OptimismClient) ReturnFunds(fromPrivateKey *ecdsa.PrivateKey) error {
+// 	to := common.HexToAddress(o.DefaultWallet.Address())
 
-	// Arbitrum uses legacy transactions and gas estimations
-	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
-	if err != nil {
-		return err
-	}
-	fromAddress, err := utils.PrivateKeyToAddress(fromPrivateKey)
-	if err != nil {
-		return err
-	}
+// 	// Arbitrum uses legacy transactions and gas estimations
+// 	suggestedGasPrice, err := o.Client.SuggestGasPrice(context.Background())
+// 	if err != nil {
+// 		return err
+// 	}
+// 	fromAddress, err := utils.PrivateKeyToAddress(fromPrivateKey)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	balance, err := o.Client.BalanceAt(context.Background(), fromAddress, nil)
-	if err != nil {
-		return err
-	}
-	estimatedGas, err := o.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
-	if err != nil {
-		return err
-	}
-	estimatedGasCost := big.NewInt(1).Mul(suggestedGasPrice, big.NewInt(0).SetUint64(estimatedGas))
-	// Optimism needs to calculate both the L1 and L2 gas fees
-	// https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee
-	optimismL1GasContract := common.HexToAddress("0x420000000000000000000000000000000000000F")
-	optimismGasContract, err := contracts.NewOptimismGas(optimismL1GasContract, o.Client)
-	if err != nil {
-		return err
-	}
-	l1Fee, err := optimismGasContract.GetL1Fee(&bind.CallOpts{}, types.LegacyTx{}.Data)
-	if err != nil {
-		return err
-	}
-	// Optimism's L1 gas estimation has an error margin of 25%, we use 26 for rounding errors
-	// https://help.optimism.io/hc/en-us/articles/4416677738907
-	l1FeeFloat := big.NewFloat(1).SetUint64(l1Fee.Uint64())
-	l1FeeFloat.Mul(l1FeeFloat, big.NewFloat(1.26))
-	l1FeeFloatUint, _ := l1FeeFloat.Uint64()
-	l1Fee.SetUint64(l1FeeFloatUint)
+// 	balance, err := o.Client.BalanceAt(context.Background(), fromAddress, nil)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	estimatedGas, err := o.Client.EstimateGas(context.Background(), ethereum.CallMsg{})
+// 	if err != nil {
+// 		return err
+// 	}
+// 	estimatedGasCost := big.NewInt(1).Mul(suggestedGasPrice, big.NewInt(0).SetUint64(estimatedGas))
+// 	// Optimism needs to calculate both the L1 and L2 gas fees
+// 	// https://community.optimism.io/docs/developers/build/transaction-fees/#the-l1-data-fee
+// 	optimismL1GasContract := common.HexToAddress("0x420000000000000000000000000000000000000F")
+// 	optimismGasContract, err := contracts.NewOptimismGas(optimismL1GasContract, o.Client)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	l1Fee, err := optimismGasContract.GetL1Fee(&bind.CallOpts{}, types.LegacyTx{}.Data)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	// Optimism's L1 gas estimation has an error margin of 25%, we use 26 for rounding errors
+// 	// https://help.optimism.io/hc/en-us/articles/4416677738907
+// 	l1FeeFloat := big.NewFloat(1).SetUint64(l1Fee.Uint64())
+// 	l1FeeFloat.Mul(l1FeeFloat, big.NewFloat(1.26))
+// 	l1FeeFloatUint, _ := l1FeeFloat.Uint64()
+// 	l1Fee.SetUint64(l1FeeFloatUint)
 
-	estimatedGasCost.Add(estimatedGasCost, l1Fee)
-	balance.Sub(balance, estimatedGasCost)
+// 	estimatedGasCost.Add(estimatedGasCost, l1Fee)
+// 	balance.Sub(balance, estimatedGasCost)
 
-	nonce, err := o.GetNonce(context.Background(), fromAddress)
-	if err != nil {
-		return err
-	}
+// 	nonce, err := o.GetNonce(context.Background(), fromAddress)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	tx, err := types.SignNewTx(fromPrivateKey, types.LatestSignerForChainID(o.GetChainID()), &types.LegacyTx{
-		Nonce:    nonce,
-		To:       &to,
-		Value:    balance,
-		GasPrice: suggestedGasPrice,
-		Gas:      estimatedGas,
-	})
-	if err != nil {
-		return err
-	}
+// 	tx, err := types.SignNewTx(fromPrivateKey, types.LatestSignerForChainID(o.GetChainID()), &types.LegacyTx{
+// 		Nonce:    nonce,
+// 		To:       &to,
+// 		Value:    balance,
+// 		GasPrice: suggestedGasPrice,
+// 		Gas:      estimatedGas,
+// 	})
+// 	if err != nil {
+// 		return err
+// 	}
 
-	log.Info().
-		Str("Token", "OP").
-		Str("From", fromAddress.Hex()).
-		Uint64("Amount", balance.Uint64()).
-		Uint64("Estimated Gas Cost", estimatedGasCost.Uint64()).
-		Msg("Returning Funds to Default Wallet")
-	if err := o.SendTransaction(context.Background(), tx); err != nil {
-		return err
-	}
+// 	log.Info().
+// 		Str("Token", "OP").
+// 		Str("From", fromAddress.Hex()).
+// 		Uint64("Amount", balance.Uint64()).
+// 		Uint64("Estimated Gas Cost", estimatedGasCost.Uint64()).
+// 		Msg("Returning Funds to Default Wallet")
+// 	if err := o.SendTransaction(context.Background(), tx); err != nil {
+// 		return err
+// 	}
 
-	return o.ProcessTransaction(tx)
-}
+// 	return o.ProcessTransaction(tx)
+// }

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -85,6 +85,12 @@ func (t *TransactionConfirmer) Wait() error {
 		t.complete = true
 		t.completeMu.Unlock()
 	}()
+
+	if t.Complete() {
+		t.cancel()
+		return nil
+	}
+
 	for {
 		select {
 		case <-t.doneChan:
@@ -109,6 +115,7 @@ type InstantConfirmer struct {
 	txHash       common.Hash
 	complete     bool // tracks if the subscription is completed or not
 	completeChan chan struct{}
+	completeMu   sync.Mutex
 	context      context.Context
 	cancel       context.CancelFunc
 	// For events
@@ -151,7 +158,6 @@ func (l *InstantConfirmer) ReceiveHeader(x NodeHeader) error {
 		}
 		return err
 	}
-	l.complete = l.confirmed
 	log.Debug().Bool("Confirmed", l.confirmed).Str("Tx", l.txHash.Hex()).Msg("Instant Confirmation")
 	if l.confirmed {
 		l.completeChan <- struct{}{}
@@ -164,10 +170,11 @@ func (l *InstantConfirmer) ReceiveHeader(x NodeHeader) error {
 
 // Wait checks every header if the tx has been included on chain or not
 func (l *InstantConfirmer) Wait() error {
-	defer func() { l.complete = true }()
-	if l.complete {
-		return nil
-	}
+	defer func() {
+		l.completeMu.Lock()
+		l.complete = true
+		l.completeMu.Unlock()
+	}()
 
 	for {
 		select {
@@ -181,8 +188,10 @@ func (l *InstantConfirmer) Wait() error {
 	}
 }
 
-// Complete is a no-op
+// Complete returns if the transaction is complete or not
 func (l *InstantConfirmer) Complete() bool {
+	l.completeMu.Lock()
+	defer l.completeMu.Unlock()
 	return l.complete
 }
 
@@ -271,25 +280,25 @@ func (e *EventConfirmer) Wait() error {
 	}
 }
 
-// Complete returns if the event has officially been confirmed (true or false)
+// Complete returns if the confirmer is done, whether confirmation was successful or not
 func (e *EventConfirmer) Complete() bool {
 	return e.complete
 }
 
 // GetNonce keep tracking of nonces per address, add last nonce for addr if the map is empty
 func (e *EthereumClient) GetNonce(ctx context.Context, addr common.Address) (uint64, error) {
-	e.NonceMu.Lock()
-	defer e.NonceMu.Unlock()
-	if _, ok := e.Nonces[addr.Hex()]; !ok {
-		lastNonce, err := e.Client.PendingNonceAt(ctx, addr)
+	e.NonceSettings.NonceMu.Lock()
+	defer e.NonceSettings.NonceMu.Unlock()
+	if _, ok := e.NonceSettings.Nonces[addr.Hex()]; !ok {
+		pendingNonce, err := e.Client.PendingNonceAt(ctx, addr)
 		if err != nil {
 			return 0, err
 		}
-		e.Nonces[addr.Hex()] = lastNonce
-		return lastNonce, nil
+		e.NonceSettings.Nonces[addr.Hex()] = pendingNonce
+		return pendingNonce, nil
 	}
-	e.Nonces[addr.Hex()]++
-	return e.Nonces[addr.Hex()], nil
+	e.NonceSettings.Nonces[addr.Hex()]++
+	return e.NonceSettings.Nonces[addr.Hex()], nil
 }
 
 // GetHeaderSubscriptions returns a duplicate map of the queued transactions

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -342,13 +342,11 @@ func (e *EthereumClient) receiveHeader(header *types.Header) {
 		suggestedPrice = big.NewInt(0)
 		log.Err(err).
 			Str("Header Hash", headerValue.Hash().String()).
-			Int("Debug ID", e.debugID).
 			Msg("Error retrieving Suggested Gas Price for new block header")
 	}
 	log.Debug().
 		Str("NetworkName", e.NetworkConfig.Name).
 		Int("Node", e.ID).
-		Int("Debug ID", e.debugID).
 		Str("Hash", headerValue.Hash().String()).
 		Str("Number", headerValue.Number.String()).
 		Str("Gas Price", suggestedPrice.String()).

--- a/docs/quickstart/running-our-tests.md
+++ b/docs/quickstart/running-our-tests.md
@@ -9,6 +9,5 @@ parent: Quick Start
 
 We have some tests written that we keep up to date in the [main Chainlink repo](https://github.com/smartcontractkit/chainlink). In order to run them for yourself, follow the steps below.
 
-1. [Install Ginkgo](https://onsi.github.io/ginkgo/#installing-ginkgo): go install github.com/onsi/ginkgo/v2/ginkgo
-2. Clone the latest develop branch of the [Chainlink repo](https://github.com/smartcontractkit/chainlink)
-3. See the tests and running instructions in the [integration-tests folder](https://github.com/smartcontractkit/chainlink/tree/develop/integration-tests)
+1. Clone the latest develop branch of the [Chainlink repo](https://github.com/smartcontractkit/chainlink)
+2. See the tests and running instructions in the [integration-tests folder](https://github.com/smartcontractkit/chainlink/tree/develop/integration-tests)

--- a/docs/writing-a-test/index.md
+++ b/docs/writing-a-test/index.md
@@ -9,4 +9,3 @@ has_children: true
 
 Here we walk through writing a couple different types of tests. More examples can be found in our [test suite directory](https://github.com/smartcontractkit/integrations-framework/tree/main/suite).
 
-We’ve been using [Ginkgo](https://github.com/onsi/ginkgo), a BDD testing framework for Go that we’ve found handy for organizing and running tests. You should be able to use any other testing framework you like, including Go’s built-in `testing` package, but the examples you find here will be in Ginkgo and its accompanying assertions library, [Gomega](https://github.com/onsi/gomega). Both of which are easily human readable however (part of why we like it) and shouldn’t hurt your understanding of the framework at all.


### PR DESCRIPTION
## Overview

This PR enables us to run multiple tests in parallel on the same live test network. This is done by creating a global nonce-manager in `blockchain/nonce_settings.go` whenever we find that the test network is not simulated.

## Details

If the test is running on a simulated network, there are no changes.

If the test is running on a non-simulated network, a global nonce-tracker is started. From there, each client (usually 1 per test) requests nonces from this manager. This enables tracking nonces across multiple threads on the same instance.

## Caveats

Things get complicated when running on instant confirmation networks (L2s like Optimism). These networks have little to no mempools, and so we need to not only get nonces in a proper order, but also submit transactions in proper order. This requires a couple channels to inform when each transaction is good to be released.