### PR TITLE
Load test schedule

### DIFF
--- a/loadgen/instance_sleep_mock.go
+++ b/loadgen/instance_sleep_mock.go
@@ -3,8 +3,6 @@ package loadgen
 import (
 	"math/rand"
 	"time"
-
-	"github.com/rs/zerolog/log"
 )
 
 // MockInstanceConfig configures a mock instanceTemplate
@@ -28,7 +26,15 @@ type MockInstance struct {
 func NewMockInstance(cfg MockInstanceConfig) MockInstance {
 	return MockInstance{
 		cfg:  cfg,
-		stop: make(chan struct{}, 1),
+		stop: make(chan struct{}, 100),
+		Data: make([]string, 0),
+	}
+}
+
+func (m MockInstance) Clone(l *Generator) Instance {
+	return MockInstance{
+		cfg:  m.cfg,
+		stop: make(chan struct{}, 100),
 		Data: make([]string, 0),
 	}
 }
@@ -39,8 +45,6 @@ func (m MockInstance) Run(l *Generator) {
 		defer l.ResponsesWaitGroup.Done()
 		for {
 			select {
-			// TODO: this is mandatory, we should stop the instanceTemplate when test is done
-			// TODO: wrap this in closure to simplify setup
 			case <-l.ResponsesCtx.Done():
 				return
 			case <-m.stop:
@@ -70,6 +74,5 @@ func (m MockInstance) Run(l *Generator) {
 }
 
 func (m MockInstance) Stop(l *Generator) {
-	log.Info().Msg("Stopping instance")
 	m.stop <- struct{}{}
 }

--- a/loadgen/instance_sleep_mock.go
+++ b/loadgen/instance_sleep_mock.go
@@ -26,7 +26,7 @@ type MockInstance struct {
 func NewMockInstance(cfg MockInstanceConfig) MockInstance {
 	return MockInstance{
 		cfg:  cfg,
-		stop: make(chan struct{}, 100),
+		stop: make(chan struct{}, 1),
 		Data: make([]string, 0),
 	}
 }
@@ -34,7 +34,7 @@ func NewMockInstance(cfg MockInstanceConfig) MockInstance {
 func (m MockInstance) Clone(l *Generator) Instance {
 	return MockInstance{
 		cfg:  m.cfg,
-		stop: make(chan struct{}, 100),
+		stop: make(chan struct{}, 1),
 		Data: make([]string, 0),
 	}
 }

--- a/loadgen/instance_ws_mock.go
+++ b/loadgen/instance_ws_mock.go
@@ -24,7 +24,7 @@ type WSMockInstance struct {
 func NewWSMockInstance(cfg WSMockConfig) WSMockInstance {
 	return WSMockInstance{
 		cfg:  cfg,
-		stop: make(chan struct{}),
+		stop: make(chan struct{}, 1),
 		Data: make([]string, 0),
 	}
 }
@@ -32,7 +32,7 @@ func NewWSMockInstance(cfg WSMockConfig) WSMockInstance {
 func (m WSMockInstance) Clone(l *Generator) Instance {
 	return WSMockInstance{
 		cfg:  m.cfg,
-		stop: make(chan struct{}),
+		stop: make(chan struct{}, 1),
 		Data: make([]string, 0),
 	}
 }

--- a/loadgen/instance_ws_mock.go
+++ b/loadgen/instance_ws_mock.go
@@ -15,44 +15,52 @@ type WSMockConfig struct {
 
 // WSMockInstance ws mock mock
 type WSMockInstance struct {
-	cfg  *WSMockConfig
+	cfg  WSMockConfig
+	stop chan struct{}
 	Data []string
 }
 
-// NewWSMockInstance create a ws mock instance
-func NewWSMockInstance(cfg *WSMockConfig) *WSMockInstance {
-	return &WSMockInstance{
+// NewWSMockInstance create a ws mock instanceTemplate
+func NewWSMockInstance(cfg WSMockConfig) WSMockInstance {
+	return WSMockInstance{
 		cfg:  cfg,
+		stop: make(chan struct{}, 1),
 		Data: make([]string, 0),
 	}
 }
 
-// Run create an instance firing read requests against mock ws server
-func (m *WSMockInstance) Run(l *Generator) {
+// Run create an instanceTemplate firing read requests against mock ws server
+func (m WSMockInstance) Run(l *Generator) {
 	l.ResponsesWaitGroup.Add(1)
 	c, _, err := websocket.Dial(context.Background(), m.cfg.TargetURl, &websocket.DialOptions{})
 	if err != nil {
-		l.Log.Error().Err(err).Msg("failed to connect from instance")
+		l.Log.Error().Err(err).Msg("failed to connect from instanceTemplate")
 		//nolint
 		c.Close(websocket.StatusInternalError, "")
 	}
 	go func() {
+		defer l.ResponsesWaitGroup.Done()
 		for {
 			select {
 			case <-l.ResponsesCtx.Done():
-				l.ResponsesWaitGroup.Done()
 				//nolint
 				c.Close(websocket.StatusNormalClosure, "")
+				return
+			case <-m.stop:
 				return
 			default:
 				startedAt := time.Now()
 				v := map[string]string{}
 				err = wsjson.Read(context.Background(), c, &v)
 				if err != nil {
-					l.Log.Error().Err(err).Msg("failed read ws msg from instance")
+					l.Log.Error().Err(err).Msg("failed read ws msg from instanceTemplate")
 				}
 				l.ResponsesChan <- CallResult{StartedAt: &startedAt, Data: v}
 			}
 		}
 	}()
+}
+
+func (m WSMockInstance) Stop(l *Generator) {
+	m.stop <- struct{}{}
 }

--- a/loadgen/instance_ws_mock.go
+++ b/loadgen/instance_ws_mock.go
@@ -24,7 +24,15 @@ type WSMockInstance struct {
 func NewWSMockInstance(cfg WSMockConfig) WSMockInstance {
 	return WSMockInstance{
 		cfg:  cfg,
-		stop: make(chan struct{}, 1),
+		stop: make(chan struct{}),
+		Data: make([]string, 0),
+	}
+}
+
+func (m WSMockInstance) Clone(l *Generator) Instance {
+	return WSMockInstance{
+		cfg:  m.cfg,
+		stop: make(chan struct{}),
 		Data: make([]string, 0),
 	}
 }

--- a/loadgen/loadgen.go
+++ b/loadgen/loadgen.go
@@ -24,14 +24,15 @@ const (
 )
 
 var (
-	ErrNoCfg        = errors.New("config is nil")
-	ErrNoImpl       = errors.New("either \"gun\" or \"instanceTemplate\" implementation must provided")
-	ErrNoSched      = errors.New("no schedule segments were provided")
-	ErrCallTimeout  = errors.New("generator request call timeout")
-	ErrStartFrom    = errors.New("from must be > 0")
-	ErrInvalidSteps = errors.New("both \"Steps\" and \"StepsDuration\" must be defined in a schedule segment")
-	ErrNoGun        = errors.New("rps load scheduleSegments selected but gun implementation is nil")
-	ErrNoInstance   = errors.New("instanceTemplate load scheduleSegments selected but instanceTemplate implementation is nil")
+	ErrNoCfg              = errors.New("config is nil")
+	ErrNoImpl             = errors.New("either \"gun\" or \"instanceTemplate\" implementation must provided")
+	ErrNoSched            = errors.New("no schedule segments were provided")
+	ErrCallTimeout        = errors.New("generator request call timeout")
+	ErrStartFrom          = errors.New("from must be > 0")
+	ErrWrongLineDirection = errors.New("direction can be \"up\" or \"down\"")
+	ErrInvalidSteps       = errors.New("both \"Steps\" and \"StepsDuration\" must be defined in a schedule segment")
+	ErrNoGun              = errors.New("rps load scheduleSegments selected but gun implementation is nil")
+	ErrNoInstance         = errors.New("instanceTemplate load scheduleSegments selected but instanceTemplate implementation is nil")
 )
 
 // Gun is basic interface to run limited load with a contract call and save all transactions
@@ -292,6 +293,7 @@ func (l *Generator) processSegment() bool {
 		l.stats.CurrentStep.Store(0)
 		if l.stats.CurrentSegment.Load() == l.stats.LastSegment.Load() {
 			l.Log.Info().Msg("Finished all schedule segments")
+			//l.Stop()
 			return true
 		}
 		l.currentSegment = l.scheduleSegments[l.stats.CurrentSegment.Load()]

--- a/loadgen/loadgen_test.go
+++ b/loadgen/loadgen_test.go
@@ -22,9 +22,12 @@ func TestConcurrentGenerators(t *testing.T) {
 		gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 			T:        t,
 			Duration: 1 * time.Second,
-			Schedule: &LoadSchedule{
-				Type: RPSScheduleType,
-				From: 1,
+			LoadType: RPSScheduleType,
+
+			Schedule: []*Segment{
+				{
+					From: 1,
+				},
 			},
 			Gun: NewMockGun(&MockGunConfig{
 				CallSleep: 50 * time.Millisecond,
@@ -60,10 +63,12 @@ func TestConcurrentGenerators(t *testing.T) {
 func TestPositiveOneRequest(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		Gun: NewMockGun(&MockGunConfig{
 			CallSleep: 50 * time.Millisecond,
@@ -75,6 +80,9 @@ func TestPositiveOneRequest(t *testing.T) {
 	_, failed := gen.Stop()
 	require.Equal(t, false, failed)
 	gs := &GeneratorStats{}
+	gs.LastSegment.Store(1)
+	gs.CurrentSegment.Store(1)
+	gs.CurrentStep.Store(0)
 	gs.CurrentInstances.Store(0)
 	gs.CurrentRPS.Store(1)
 	gs.Success.Add(2)
@@ -92,10 +100,12 @@ func TestPositiveOneRequest(t *testing.T) {
 func TestFailedOneRequest(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		Gun: NewMockGun(&MockGunConfig{
 			FailRatio: 100,
@@ -108,6 +118,9 @@ func TestFailedOneRequest(t *testing.T) {
 	_, failed := gen.Stop()
 	require.Equal(t, true, failed)
 	gs := &GeneratorStats{}
+	gs.LastSegment.Store(1)
+	gs.CurrentSegment.Store(1)
+	gs.CurrentStep.Store(0)
 	gs.RunFailed.Store(true)
 	gs.CurrentRPS.Store(1)
 	gs.CurrentInstances.Store(0)
@@ -128,10 +141,12 @@ func TestFailedOneRequest(t *testing.T) {
 func TestLoadGenCallTimeout(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		CallTimeout: 40 * time.Millisecond,
 		Gun: NewMockGun(&MockGunConfig{
@@ -144,6 +159,9 @@ func TestLoadGenCallTimeout(t *testing.T) {
 	_, failed := gen.Stop()
 	require.Equal(t, true, failed)
 	gs := &GeneratorStats{}
+	gs.LastSegment.Store(1)
+	gs.CurrentSegment.Store(1)
+	gs.CurrentStep.Store(0)
 	gs.CurrentRPS.Store(1)
 	gs.CurrentInstances.Store(0)
 	gs.RunFailed.Store(true)
@@ -160,10 +178,12 @@ func TestLoadGenCallTimeout(t *testing.T) {
 func TestLoadGenCallTimeoutWait(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		CallTimeout: 50 * time.Millisecond,
 		Duration:    1 * time.Second,
@@ -191,10 +211,12 @@ func TestLoadGenCallTimeoutWait(t *testing.T) {
 func TestCancelledByDeadlineWait(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		Duration: 40 * time.Millisecond,
 		Gun: NewMockGun(&MockGunConfig{
@@ -211,6 +233,9 @@ func TestCancelledByDeadlineWait(t *testing.T) {
 	require.Greater(t, elapsed, 1050*time.Millisecond)
 	require.Equal(t, false, failed)
 	gs := &GeneratorStats{}
+	gs.LastSegment.Store(1)
+	gs.CurrentSegment.Store(1)
+	gs.CurrentStep.Store(0)
 	gs.CurrentInstances.Store(0)
 	gs.CurrentRPS.Store(1)
 	gs.Success.Add(2)
@@ -227,10 +252,12 @@ func TestCancelledByDeadlineWait(t *testing.T) {
 func TestCancelledBeforeDeadline(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		Duration: 40 * time.Millisecond,
 		Gun: NewMockGun(&MockGunConfig{
@@ -248,6 +275,9 @@ func TestCancelledBeforeDeadline(t *testing.T) {
 	require.Greater(t, elapsed, 1050*time.Millisecond)
 	require.Equal(t, false, failed)
 	gs := &GeneratorStats{}
+	gs.LastSegment.Store(1)
+	gs.CurrentSegment.Store(1)
+	gs.CurrentStep.Store(0)
 	gs.CurrentInstances.Store(0)
 	gs.CurrentRPS.Store(1)
 	gs.Success.Add(2)
@@ -263,9 +293,11 @@ func TestStaticRPSSchedulePrecision(t *testing.T) {
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:        t,
 		Duration: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1000,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1000,
+			},
 		},
 		Gun: NewMockGun(&MockGunConfig{
 			CallSleep: 50 * time.Millisecond,
@@ -291,12 +323,10 @@ func TestStaticRPSScheduleIsNotBlocking(t *testing.T) {
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:        t,
 		Duration: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1000,
-		},
+		LoadType: RPSScheduleType,
+		Schedule: HorizontalLine(1000),
 		Gun: NewMockGun(&MockGunConfig{
-			// call time must not affect the load schedule
+			// call time must not affect the load scheduleSegments
 			CallSleep: 1 * time.Second,
 		}),
 	})
@@ -316,17 +346,51 @@ func TestStaticRPSScheduleIsNotBlocking(t *testing.T) {
 	require.Empty(t, gen.Errors())
 }
 
-func TestLoadScheduleRPSIncrease(t *testing.T) {
+func TestMultipleScheduleSegments(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:                 t,
 		StatsPollInterval: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         RPSScheduleType,
-			From:         1,
-			Increase:     1,
-			StepDuration: 1 * time.Second,
-			Limit:        5,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         1,
+				Increase:     1,
+				Steps:        5,
+				StepDuration: 1 * time.Second,
+			},
+			{
+				From:         5,
+				Increase:     -1,
+				Steps:        5,
+				StepDuration: 1 * time.Second,
+			},
+		},
+		Duration: 12 * time.Second,
+		Gun: NewMockGun(&MockGunConfig{
+			CallSleep: 10 * time.Millisecond,
+		}),
+	})
+	require.NoError(t, err)
+	gen.Run()
+	_, failed := gen.Wait()
+	require.Equal(t, false, failed)
+	require.GreaterOrEqual(t, gen.Stats().Success.Load(), int64(35))
+}
+
+func TestLoadScheduleSegmentRPSIncrease(t *testing.T) {
+	t.Parallel()
+	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
+		T:                 t,
+		StatsPollInterval: 1 * time.Second,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         1,
+				Increase:     1,
+				Steps:        5,
+				StepDuration: 1 * time.Second,
+			},
 		},
 		Duration: 7000 * time.Millisecond,
 		Gun: NewMockGun(&MockGunConfig{
@@ -340,19 +404,21 @@ func TestLoadScheduleRPSIncrease(t *testing.T) {
 	require.GreaterOrEqual(t, gen.Stats().Success.Load(), int64(28))
 }
 
-func TestLoadScheduleRPSDecrease(t *testing.T) {
+func TestLoadScheduleSegmentRPSDecrease(t *testing.T) {
 	t.Parallel()
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:                 t,
 		StatsPollInterval: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         RPSScheduleType,
-			From:         5,
-			Increase:     -1,
-			StepDuration: 1 * time.Second,
-			Limit:        0,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         5,
+				Increase:     -1,
+				Steps:        5,
+				StepDuration: 1 * time.Second,
+			},
 		},
-		Duration: 7000 * time.Millisecond,
+		Duration: 7 * time.Second,
 		Gun: NewMockGun(&MockGunConfig{
 			CallSleep: 10 * time.Millisecond,
 		}),
@@ -361,7 +427,7 @@ func TestLoadScheduleRPSDecrease(t *testing.T) {
 	gen.Run()
 	_, failed := gen.Wait()
 	require.Equal(t, false, failed)
-	require.GreaterOrEqual(t, gen.Stats().Success.Load(), int64(28))
+	require.GreaterOrEqual(t, gen.Stats().Success.Load(), int64(20))
 }
 
 func TestValidation(t *testing.T) {
@@ -369,25 +435,61 @@ func TestValidation(t *testing.T) {
 	_, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:                 t,
 		StatsPollInterval: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         RPSScheduleType,
-			From:         0,
-			Increase:     1,
-			StepDuration: 1 * time.Second,
-			Limit:        5,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         0,
+				Increase:     1,
+				Steps:        1,
+				StepDuration: 1 * time.Second,
+			},
 		},
 		Gun: NewMockGun(&MockGunConfig{
 			CallSleep: 10 * time.Millisecond,
 		}),
 	})
 	require.Equal(t, ErrStartFrom, err)
+	_, err = NewLoadGenerator(&LoadGeneratorConfig{
+		T:                 t,
+		StatsPollInterval: 1 * time.Second,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         1,
+				Increase:     1,
+				StepDuration: 1 * time.Second,
+			},
+		},
+		Gun: NewMockGun(&MockGunConfig{
+			CallSleep: 10 * time.Millisecond,
+		}),
+	})
+	require.Equal(t, ErrInvalidSteps, err)
+	_, err = NewLoadGenerator(&LoadGeneratorConfig{
+		T:                 t,
+		StatsPollInterval: 1 * time.Second,
+		LoadType:          RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:     1,
+				Increase: 1,
+				Steps:    1,
+			},
+		},
+		Gun: NewMockGun(&MockGunConfig{
+			CallSleep: 10 * time.Millisecond,
+		}),
+	})
+	require.Equal(t, ErrInvalidSteps, err)
 	_, err = NewLoadGenerator(nil)
 	require.Equal(t, ErrNoCfg, err)
 	_, err = NewLoadGenerator(&LoadGeneratorConfig{
-		T: t,
-		Schedule: &LoadSchedule{
-			Type: RPSScheduleType,
-			From: 1,
+		T:        t,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From: 1,
+			},
 		},
 		Gun: nil,
 	})
@@ -399,12 +501,14 @@ func TestInstancesIncrease(t *testing.T) {
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:        t,
 		Duration: 1 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         InstancesScheduleType,
-			From:         1,
-			Increase:     1,
-			StepDuration: 100 * time.Millisecond,
-			Limit:        10,
+		LoadType: InstancesScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         1,
+				Increase:     1,
+				Steps:        10,
+				StepDuration: 100 * time.Millisecond,
+			},
 		},
 		Instance: NewMockInstance(MockInstanceConfig{
 			CallSleep: 100 * time.Millisecond,
@@ -415,7 +519,7 @@ func TestInstancesIncrease(t *testing.T) {
 	_, failed := gen.Wait()
 	stats := gen.Stats()
 	require.Equal(t, false, failed)
-	require.Equal(t, int64(10), stats.CurrentInstances.Load())
+	require.Equal(t, int64(11), stats.CurrentInstances.Load())
 
 	okData, okResponses, failResponses := convertResponsesData(gen.GetData())
 	require.GreaterOrEqual(t, okResponses[0].Duration, 50*time.Millisecond)
@@ -432,12 +536,14 @@ func TestInstancesDecrease(t *testing.T) {
 	gen, err := NewLoadGenerator(&LoadGeneratorConfig{
 		T:        t,
 		Duration: 10 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         InstancesScheduleType,
-			From:         10,
-			Increase:     -1,
-			StepDuration: 1 * time.Second,
-			Limit:        0,
+		LoadType: InstancesScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         10,
+				Increase:     -1,
+				Steps:        10,
+				StepDuration: 1 * time.Second,
+			},
 		},
 		Instance: NewMockInstance(MockInstanceConfig{
 			CallSleep: 50 * time.Millisecond,
@@ -448,7 +554,7 @@ func TestInstancesDecrease(t *testing.T) {
 	_, failed := gen.Wait()
 	stats := gen.Stats()
 	require.Equal(t, false, failed)
-	require.Equal(t, int64(0), stats.CurrentInstances.Load())
+	require.Equal(t, int64(1), stats.CurrentInstances.Load())
 
 	okData, okResponses, failResponses := convertResponsesData(gen.GetData())
 	require.GreaterOrEqual(t, okResponses[0].Duration, 50*time.Millisecond)

--- a/loadgen/loki_test.go
+++ b/loadgen/loki_test.go
@@ -79,8 +79,8 @@ func TestLokiSamples(t *testing.T) {
 				Labels:     defaultLabels,
 				Duration:   55 * time.Millisecond,
 				Schedule: &LoadSchedule{
-					Type:      RPSScheduleType,
-					StartFrom: 1,
+					Type: RPSScheduleType,
+					From: 1,
 				},
 				Gun: NewMockGun(&MockGunConfig{
 					CallSleep: 50 * time.Millisecond,
@@ -98,7 +98,7 @@ func TestLokiSamples(t *testing.T) {
 				StatsSamples: []StatsSample{
 					{
 						CallTimeout:      0,
-						CurrentInstances: 1,
+						CurrentInstances: 0,
 						CurrentRPS:       1,
 						RunFailed:        false,
 						RunStopped:       false,
@@ -107,7 +107,7 @@ func TestLokiSamples(t *testing.T) {
 					},
 					{
 						CallTimeout:      0,
-						CurrentInstances: 1,
+						CurrentInstances: 0,
 						CurrentRPS:       1,
 						RunFailed:        false,
 						RunStopped:       false,

--- a/loadgen/loki_test.go
+++ b/loadgen/loki_test.go
@@ -63,25 +63,20 @@ func TestLokiSamples(t *testing.T) {
 
 	type test struct {
 		name       string
-		genCfg     *LoadGeneratorConfig
+		genCfg     *Config
 		assertions LokiSamplesAssertions
 	}
 
 	tests := []test{
 		{
 			name: "successful RPS run should contain at least 2 response samples without errors and 2 stats samples",
-			genCfg: &LoadGeneratorConfig{
+			genCfg: &Config{
 				T: t,
 				// empty URL is a special case for mocked client
 				LokiConfig: client.NewDefaultLokiConfig("", ""),
 				Labels:     defaultLabels,
-				Duration:   55 * time.Millisecond,
 				LoadType:   RPSScheduleType,
-				Schedule: []*Segment{
-					{
-						From: 1,
-					},
-				},
+				Schedule:   Plain(1, 55*time.Millisecond),
 				Gun: NewMockGun(&MockGunConfig{
 					CallSleep: 50 * time.Millisecond,
 				}),

--- a/loadgen/loki_test.go
+++ b/loadgen/loki_test.go
@@ -32,7 +32,6 @@ type LokiSamplesAssertions struct {
 func assertSamples(t *testing.T, samples []client.PromtailSendResult, a LokiSamplesAssertions) {
 	var cd CallResult
 	for i, s := range samples[0:2] {
-		t.Logf("Entry: %s", s.Entry)
 		err := json.Unmarshal([]byte(s.Entry), &cd)
 		require.NoError(t, err)
 		require.NotEmpty(t, cd.Duration)
@@ -41,7 +40,6 @@ func assertSamples(t *testing.T, samples []client.PromtailSendResult, a LokiSamp
 	// marshal to map because atomic can't be marshalled
 	var ls map[string]interface{}
 	for i, s := range samples[2:4] {
-		t.Logf("Stats: %s", s.Entry)
 		err := json.Unmarshal([]byte(s.Entry), &ls)
 		require.NoError(t, err)
 		require.Equal(t, ls["callTimeout"], a.StatsSamples[i].CallTimeout)
@@ -78,9 +76,11 @@ func TestLokiSamples(t *testing.T) {
 				LokiConfig: client.NewDefaultLokiConfig("", ""),
 				Labels:     defaultLabels,
 				Duration:   55 * time.Millisecond,
-				Schedule: &LoadSchedule{
-					Type: RPSScheduleType,
-					From: 1,
+				LoadType:   RPSScheduleType,
+				Schedule: []*Segment{
+					{
+						From: 1,
+					},
 				},
 				Gun: NewMockGun(&MockGunConfig{
 					CallSleep: 50 * time.Millisecond,

--- a/loadgen/perf_test.go
+++ b/loadgen/perf_test.go
@@ -73,8 +73,8 @@ func TestLocalTrace(t *testing.T) {
 				CallTimeout: 100 * time.Millisecond,
 				Duration:    10 * time.Second,
 				Schedule: &LoadSchedule{
-					Type:      RPSScheduleType,
-					StartFrom: 2000,
+					Type: RPSScheduleType,
+					From: 2000,
 				},
 				Gun: NewMockGun(&MockGunConfig{
 					TimeoutRatio: 1,
@@ -90,7 +90,7 @@ func TestLocalTrace(t *testing.T) {
 }
 
 func TestLokiRPSRun(t *testing.T) {
-	t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
+	//t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
 	t.Parallel()
 	t.Run("can_report_to_loki", func(t *testing.T) {
 		t.Parallel()
@@ -100,17 +100,17 @@ func TestLokiRPSRun(t *testing.T) {
 				os.Getenv("LOKI_URL"),
 				os.Getenv("LOKI_TOKEN")),
 			Labels: map[string]string{
-				"cluster":    "sdlc",
-				"namespace":  "load-dummy-test",
-				"app":        "dummy",
 				"test_group": "generator_healthcheck",
+				"cluster":    "sdlc",
+				"app":        "dummy",
+				"namespace":  "load-dummy-test",
 				"test_id":    "dummy-healthcheck-rps-1",
 			},
 			CallTimeout: 100 * time.Millisecond,
 			Duration:    10 * time.Second,
 			Schedule: &LoadSchedule{
-				Type:      RPSScheduleType,
-				StartFrom: 1000,
+				Type: RPSScheduleType,
+				From: 1000,
 			},
 			Gun: NewMockGun(&MockGunConfig{
 				TimeoutRatio: 1,
@@ -124,7 +124,7 @@ func TestLokiRPSRun(t *testing.T) {
 }
 
 func TestLokiInstancesRun(t *testing.T) {
-	t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
+	//t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
 	t.Parallel()
 	t.Run("can_report_to_loki", func(t *testing.T) {
 		t.Parallel()
@@ -134,22 +134,22 @@ func TestLokiInstancesRun(t *testing.T) {
 				os.Getenv("LOKI_URL"),
 				os.Getenv("LOKI_TOKEN")),
 			Labels: map[string]string{
-				"cluster":    "sdlc",
-				"namespace":  "load-dummy-test",
-				"app":        "dummy",
 				"test_group": "generator_healthcheck",
+				"cluster":    "sdlc",
+				"app":        "dummy",
+				"namespace":  "load-dummy-test",
 				"test_id":    "dummy-healthcheck-instances-1",
 			},
 			CallTimeout: 100 * time.Millisecond,
 			Duration:    30 * time.Second,
 			Schedule: &LoadSchedule{
-				Type:          InstancesScheduleType,
-				StartFrom:     1,
-				Increase:      3,
-				StageInterval: 10 * time.Second,
-				Limit:         30,
+				Type:         InstancesScheduleType,
+				From:         1,
+				Increase:     3,
+				StepDuration: 10 * time.Second,
+				Limit:        30,
 			},
-			Instance: NewMockInstance(&MockInstanceConfig{
+			Instance: NewMockInstance(MockInstanceConfig{
 				FailRatio: 5,
 				CallSleep: 100 * time.Millisecond,
 			}),
@@ -182,10 +182,9 @@ func TestLokiSpikeMaxLoadRun(t *testing.T) {
 			Schedule: &LoadSchedule{
 				Type: RPSScheduleType,
 				// TODO: tune Loki for 5k+ RPS responses
-				StartFrom: 5000,
+				From: 5000,
 			},
 			Gun: NewMockGun(&MockGunConfig{
-				//TimeoutRatio: 1,
 				CallSleep: 50 * time.Millisecond,
 			}),
 		})
@@ -217,13 +216,13 @@ func TestWS(t *testing.T) {
 		},
 		Duration: 100 * time.Second,
 		Schedule: &LoadSchedule{
-			Type:          InstancesScheduleType,
-			StartFrom:     10,
-			Increase:      20,
-			StageInterval: 10 * time.Second,
-			Limit:         300,
+			Type:         InstancesScheduleType,
+			From:         10,
+			Increase:     20,
+			StepDuration: 10 * time.Second,
+			Limit:        300,
 		},
-		Instance: NewWSMockInstance(&WSMockConfig{TargetURl: s.URL}),
+		Instance: NewWSMockInstance(WSMockConfig{TargetURl: s.URL}),
 	})
 	require.NoError(t, err)
 	gen.Run()
@@ -249,11 +248,11 @@ func TestHTTP(t *testing.T) {
 		},
 		Duration: 100 * time.Second,
 		Schedule: &LoadSchedule{
-			Type:          RPSScheduleType,
-			StartFrom:     5000,
-			Increase:      1000,
-			StageInterval: 10 * time.Second,
-			Limit:         20000,
+			Type:         RPSScheduleType,
+			From:         5000,
+			Increase:     1000,
+			StepDuration: 10 * time.Second,
+			Limit:        20000,
 		},
 		Gun: NewHTTPMockGun(&MockHTTPGunConfig{TargetURL: "http://localhost:8080"}),
 	})

--- a/loadgen/perf_test.go
+++ b/loadgen/perf_test.go
@@ -72,9 +72,11 @@ func TestLocalTrace(t *testing.T) {
 				},
 				CallTimeout: 100 * time.Millisecond,
 				Duration:    10 * time.Second,
-				Schedule: &LoadSchedule{
-					Type: RPSScheduleType,
-					From: 2000,
+				LoadType:    RPSScheduleType,
+				Schedule: []*Segment{
+					{
+						From: 2000,
+					},
 				},
 				Gun: NewMockGun(&MockGunConfig{
 					TimeoutRatio: 1,
@@ -106,12 +108,16 @@ func TestLokiRPSRun(t *testing.T) {
 				"namespace":  "load-dummy-test",
 				"test_id":    "dummy-healthcheck-rps-1",
 			},
+			Duration:    3 * time.Minute,
 			CallTimeout: 100 * time.Millisecond,
-			Duration:    10 * time.Second,
-			Schedule: &LoadSchedule{
-				Type: RPSScheduleType,
-				From: 1000,
-			},
+			LoadType:    RPSScheduleType,
+			Schedule: Saw(SawScheduleProfile{
+				From:         1,
+				Increase:     100,
+				Steps:        10,
+				StepDuration: 3 * time.Second,
+				Length:       4,
+			}),
 			Gun: NewMockGun(&MockGunConfig{
 				TimeoutRatio: 1,
 				CallSleep:    50 * time.Millisecond,
@@ -140,15 +146,16 @@ func TestLokiInstancesRun(t *testing.T) {
 				"namespace":  "load-dummy-test",
 				"test_id":    "dummy-healthcheck-instances-1",
 			},
+			Duration:    60 * time.Second,
 			CallTimeout: 100 * time.Millisecond,
-			Duration:    30 * time.Second,
-			Schedule: &LoadSchedule{
-				Type:         InstancesScheduleType,
+			LoadType:    InstancesScheduleType,
+			Schedule: Saw(SawScheduleProfile{
 				From:         1,
-				Increase:     3,
-				StepDuration: 10 * time.Second,
-				Limit:        30,
-			},
+				Increase:     2,
+				Steps:        10,
+				StepDuration: 1 * time.Second,
+				Length:       6,
+			}),
 			Instance: NewMockInstance(MockInstanceConfig{
 				FailRatio: 5,
 				CallSleep: 100 * time.Millisecond,
@@ -179,10 +186,11 @@ func TestLokiSpikeMaxLoadRun(t *testing.T) {
 			},
 			CallTimeout: 100 * time.Millisecond,
 			Duration:    20 * time.Second,
-			Schedule: &LoadSchedule{
-				Type: RPSScheduleType,
-				// TODO: tune Loki for 5k+ RPS responses
-				From: 5000,
+			LoadType:    RPSScheduleType,
+			Schedule: []*Segment{
+				{
+					From: 5000,
+				},
 			},
 			Gun: NewMockGun(&MockGunConfig{
 				CallSleep: 50 * time.Millisecond,
@@ -215,12 +223,14 @@ func TestWS(t *testing.T) {
 			"test_id":    "dummy-healthcheck-ws-instances-stages-25ms-answer",
 		},
 		Duration: 100 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         InstancesScheduleType,
-			From:         10,
-			Increase:     20,
-			StepDuration: 10 * time.Second,
-			Limit:        300,
+		LoadType: InstancesScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         10,
+				Increase:     20,
+				Steps:        10,
+				StepDuration: 10 * time.Second,
+			},
 		},
 		Instance: NewWSMockInstance(WSMockConfig{TargetURl: s.URL}),
 	})
@@ -247,12 +257,14 @@ func TestHTTP(t *testing.T) {
 			"test_id":    "dummy-healthcheck-http-rps-25ms-answer",
 		},
 		Duration: 100 * time.Second,
-		Schedule: &LoadSchedule{
-			Type:         RPSScheduleType,
-			From:         5000,
-			Increase:     1000,
-			StepDuration: 10 * time.Second,
-			Limit:        20000,
+		LoadType: RPSScheduleType,
+		Schedule: []*Segment{
+			{
+				From:         5000,
+				Increase:     1000,
+				Steps:        10,
+				StepDuration: 10 * time.Second,
+			},
 		},
 		Gun: NewHTTPMockGun(&MockHTTPGunConfig{TargetURL: "http://localhost:8080"}),
 	})

--- a/loadgen/perf_test.go
+++ b/loadgen/perf_test.go
@@ -92,7 +92,7 @@ func TestLocalTrace(t *testing.T) {
 }
 
 func TestLokiRPSRun(t *testing.T) {
-	//t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
+	t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
 	t.Parallel()
 	t.Run("can_report_to_loki", func(t *testing.T) {
 		t.Parallel()
@@ -108,7 +108,7 @@ func TestLokiRPSRun(t *testing.T) {
 				"namespace":  "load-dummy-test",
 				"test_id":    "dummy-healthcheck-rps-1",
 			},
-			Duration:    3 * time.Minute,
+			Duration:    2 * time.Minute,
 			CallTimeout: 100 * time.Millisecond,
 			LoadType:    RPSScheduleType,
 			Schedule: Saw(SawScheduleProfile{
@@ -130,7 +130,7 @@ func TestLokiRPSRun(t *testing.T) {
 }
 
 func TestLokiInstancesRun(t *testing.T) {
-	//t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
+	t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
 	t.Parallel()
 	t.Run("can_report_to_loki", func(t *testing.T) {
 		t.Parallel()
@@ -271,4 +271,36 @@ func TestHTTP(t *testing.T) {
 	require.NoError(t, err)
 	gen.Run()
 	_, _ = gen.Wait()
+}
+
+func TestIncreasingLine(t *testing.T) {
+	t.Skip("This test is for manual run and dashboard development, you need LOKI_URL and LOKI_TOKEN to run")
+	t.Parallel()
+	t.Run("can_report_to_loki", func(t *testing.T) {
+		t.Parallel()
+		gen, err := NewLoadGenerator(&LoadGeneratorConfig{
+			T: t,
+			LokiConfig: client.NewDefaultLokiConfig(
+				os.Getenv("LOKI_URL"),
+				os.Getenv("LOKI_TOKEN")),
+			Labels: map[string]string{
+				"test_group": "generator_healthcheck",
+				"cluster":    "sdlc",
+				"app":        "dummy",
+				"namespace":  "load-dummy-test",
+				"test_id":    "dummy-healthcheck-rps-1",
+			},
+			Duration:    80 * time.Second,
+			CallTimeout: 100 * time.Millisecond,
+			LoadType:    RPSScheduleType,
+			Schedule:    Line(10, 0, 60*time.Second),
+			Gun: NewMockGun(&MockGunConfig{
+				TimeoutRatio: 1,
+				CallSleep:    50 * time.Millisecond,
+			}),
+		})
+		require.NoError(t, err)
+		gen.Run()
+		_, _ = gen.Wait()
+	})
 }

--- a/loadgen/schedule.go
+++ b/loadgen/schedule.go
@@ -1,8 +1,16 @@
 package loadgen
 
-import "time"
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
 
 /* Different load profile schedules definitions */
+
+const (
+	DefaultStepChangePrecision = 10
+)
 
 type SawScheduleProfile struct {
 	From         int64
@@ -16,6 +24,23 @@ func HorizontalLine(from int64) []*Segment {
 	return []*Segment{
 		{
 			From: from,
+		},
+	}
+}
+
+func Line(from, to int64, duration time.Duration) []*Segment {
+	stepDur := duration / DefaultStepChangePrecision
+	inc := (to - from) / DefaultStepChangePrecision
+	log.Info().
+		Dur("StepDur", stepDur).
+		Int64("Increase", inc).
+		Msg("Stats generated")
+	return []*Segment{
+		{
+			From:         from,
+			Steps:        DefaultStepChangePrecision,
+			Increase:     inc,
+			StepDuration: stepDur,
 		},
 	}
 }

--- a/loadgen/schedule.go
+++ b/loadgen/schedule.go
@@ -1,0 +1,40 @@
+package loadgen
+
+import "time"
+
+/* Different load profile schedules definitions */
+
+type SawScheduleProfile struct {
+	From         int64
+	Increase     int64
+	Steps        int64
+	StepDuration time.Duration
+	Length       int
+}
+
+func HorizontalLine(from int64) []*Segment {
+	return []*Segment{
+		{
+			From: from,
+		},
+	}
+}
+
+func Saw(prof SawScheduleProfile) []*Segment {
+	segs := make([]*Segment, 0)
+	for i := 0; i < prof.Length; i++ {
+		s := &Segment{
+			From:         prof.From,
+			Steps:        prof.Steps,
+			StepDuration: prof.StepDuration,
+		}
+		if i%2 == 0 {
+			s.Increase = prof.Increase
+		} else {
+			s.From = prof.From + (prof.Increase * prof.Steps)
+			s.Increase = -prof.Increase
+		}
+		segs = append(segs, s)
+	}
+	return segs
+}

--- a/loadgen/schedule_test.go
+++ b/loadgen/schedule_test.go
@@ -1,0 +1,131 @@
+package loadgen
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedules(t *testing.T) {
+	type test struct {
+		name   string
+		input  []*Segment
+		output []*Segment
+	}
+
+	tests := []test{
+		{
+			name:  "increasing line",
+			input: Line(1, 100, 1*time.Second),
+			output: []*Segment{
+				{
+					From:         1,
+					Increase:     10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			name:  "decreasing line",
+			input: Line(10, 0, 1*time.Second),
+			output: []*Segment{
+				{
+					From:         10,
+					Increase:     -1,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			name: "combine lines",
+			input: Combine(
+				Line(1, 100, 1*time.Second),
+				Plain(200, 1*time.Second),
+				Line(100, 1, 1*time.Second),
+			),
+			output: []*Segment{
+				{
+					From:         1,
+					Increase:     10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         200,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         100,
+					Increase:     -10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			name: "combine disjointed lines",
+			input: Combine(
+				Line(1, 100, 1*time.Second),
+				Line(1, 300, 1*time.Second),
+			),
+			output: []*Segment{
+				{
+					From:         1,
+					Increase:     10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         1,
+					Increase:     30,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+			},
+		},
+		{
+			name: "combine and repeat",
+			input: CombineAndRepeat(
+				2,
+				Line(1, 100, 1*time.Second),
+				Line(100, 1, 1*time.Second),
+			),
+			output: []*Segment{
+				{
+					From:         1,
+					Increase:     10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         100,
+					Increase:     -10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         1,
+					Increase:     10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+				{
+					From:         100,
+					Increase:     -10,
+					Steps:        DefaultStepChangePrecision,
+					StepDuration: 100 * time.Millisecond,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.input, tc.output)
+		})
+	}
+}


### PR DESCRIPTION
This allows us to define a load schedule with syntax like:
```Go
			Schedule: CombineAndRepeat(
				2,
				Line(1, 20, 30*time.Second),
				Plain(30, 30*time.Second),
				Line(20, 1, 30*time.Second),
			),
```
You can combine `Plain` and `Line` to control the generator load profile, use `Combine` or `CombineAndRepeat` to create more complicated patterns