### PR TITLE
Send List of Env Vars to remote runner

### DIFF
--- a/utils/os_env.go
+++ b/utils/os_env.go
@@ -20,3 +20,14 @@ func GetEnv(key string) (string, error) {
 	}
 	return val, nil
 }
+
+// SetupEnvVarsForRemoteRunner sets up the environment variables in the list to propagate to the remote runner
+func SetupEnvVarsForRemoteRunner(envVars []string) error {
+	for _, envVar := range envVars {
+		_, err := GetEnv(envVar)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This adds a helper method to take a list of env variable names and propagate the whole list to the remote runner.