### PR TITLE
Ignore failed json unmarshalling in log message checking

### DIFF
--- a/testreporters/reporter_model.go
+++ b/testreporters/reporter_model.go
@@ -146,7 +146,8 @@ func verifyLogFile(file *os.File, failingLogLevel zapcore.Level) error {
 		jsonMapping := map[string]any{}
 
 		if err = json.Unmarshal([]byte(jsonLogLine), &jsonMapping); err != nil {
-			return err
+			// This error can occur anytime someone uses %+v in a log message, ignoring
+			continue
 		}
 		logLevel, ok := jsonMapping["level"].(string)
 		if !ok {


### PR DESCRIPTION
Anytime someone uses %+v to format logs in the default go fmt way this would fail