### PR TITLE
[TT-373] Restart Subscription

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -1,6 +1,6 @@
 package blockchain
 
-// Contans implementations for multi and single node ethereum clients
+// Contains implementations for multi and single node ethereum clients
 import (
 	"bytes"
 	"context"
@@ -83,7 +83,10 @@ func newEVMClient(networkSettings EVMNetwork) (EVMClient, error) {
 		return nil, err
 	}
 	ec.gasStats = NewGasStats(ec.ID)
-	go ec.newHeadersLoop()
+	err = ec.subscribeToNewHeaders()
+	if err != nil {
+		return nil, err
+	}
 
 	// Check if the chain supports EIP-1559
 	// https://eips.ethereum.org/EIPS/eip-1559
@@ -104,22 +107,6 @@ func (e *EthereumClient) SyncNonce(c EVMClient) {
 	defer n.NonceMu.Unlock()
 	e.NonceSettings.NonceMu = n.NonceMu
 	e.NonceSettings.Nonces = n.Nonces
-}
-
-// newHeadersLoop Logs when new headers come in
-func (e *EthereumClient) newHeadersLoop() {
-	for {
-		if err := e.subscribeToNewHeaders(); err != nil {
-			log.Error().
-				Err(err).
-				Str("NetworkName", e.NetworkConfig.Name).
-				Msg("Error while subscribing to headers")
-			time.Sleep(time.Second)
-			continue
-		}
-		break
-	}
-	log.Debug().Str("NetworkName", e.NetworkConfig.Name).Msg("Stopped subscribing to new headers")
 }
 
 // Get returns the underlying client type to be used generically across the framework for switching

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -339,7 +339,10 @@ func (e *EthereumClient) headerSubscriptionLoop(subscription ethereum.Subscripti
 					if err == nil { // No error on resubscription, RPC connection restored, back to regularly scheduled programming
 						ticker.Stop()
 						log.Info().Dur("Time waiting", time.Since(rpcDegradedTime)).Msg("RPC and subscription connection restored")
-						e.backfillMissedBlocks(lastHeaderNumber, headerChannel)
+						err = e.backfillMissedBlocks(lastHeaderNumber, headerChannel)
+						if err != nil {
+							log.Error().Err(err).Msg("Error backfilling missed blocks, subscriptions may be out of sync")
+						}
 						break reSubLoop
 					}
 					log.Trace().Err(err).Msg("Error trying to resubscribe to new headers, likely RPC down")

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -299,44 +299,51 @@ func (e *EthereumClient) GetHeaderSubscriptions() map[string]HeaderEventSubscrip
 	return newMap
 }
 
-// subscribeToNewHeaders
+// subscribeToNewHeaders is called at client creation, and subscribes to new headers, attempting to reconnect if encountering issues
 func (e *EthereumClient) subscribeToNewHeaders() error {
-	headerChannel, latestHeaderNumber := make(chan *SafeEVMHeader), big.NewInt(0)
+	headerChannel := make(chan *SafeEVMHeader)
 	subscription, err := e.SubscribeNewHeaders(context.Background(), headerChannel)
 	if err != nil {
 		return err
 	}
-	defer subscription.Unsubscribe()
 
 	log.Info().Str("Network", e.NetworkConfig.Name).Msg("Subscribed to new block headers")
 
-	for {
-		select {
-		case err := <-subscription.Err():
-			log.Error().Err(err).Msg("Error while subscribed to new headers, waiting to restart subscription")
-			subscription.Unsubscribe() // Probably unnecessary, but just in case
-
-			// If the sub is down, it's likely RPC node issues, keep trying to reconnect
-			resubStart, resubTicker := time.Now(), time.NewTicker(time.Second)
-			for range resubTicker.C {
-				subscription, err = e.SubscribeNewHeaders(context.Background(), headerChannel)
+	go func() {
+		defer subscription.Unsubscribe()
+		for {
+			select {
+			case err := <-subscription.Err():
 				if err == nil {
-					log.Info().Msg("Resubscribed to new headers, resuming test")
-					break
+					log.Debug().Msg("Subscription stopped")
+					return
 				}
-				log.Debug().Err(err).Dur("Time Retrying", time.Since(resubStart)).Msg("Attempting to resubscribe to new headers")
+				log.Error().Err(err).Msg("Error while subscribed to new headers, waiting to restart subscription")
+				subscription.Unsubscribe() // Probably unnecessary, but just in case
+
+				// If the sub is down, it's likely RPC node issues, keep trying to reconnect
+				resubStart, resubTicker := time.Now(), time.NewTicker(time.Second)
+				for range resubTicker.C {
+					subscription, err = e.SubscribeNewHeaders(context.Background(), headerChannel)
+					if err == nil {
+						log.Info().Msg("Resubscribed to new headers, resuming test")
+						break
+					}
+					log.Debug().Err(err).Dur("Time Retrying", time.Since(resubStart)).Msg("Attempting to resubscribe to new headers")
+				}
+				log.Info().Dur("Time Retrying", time.Since(resubStart)).Msg("Resubscribed to new headers")
+				resubTicker.Stop()
+			case header := <-headerChannel:
+				e.receiveHeader(header)
+			case <-e.doneChan:
+				log.Debug().Str("Network", e.NetworkConfig.Name).Msg("Subscription cancelled")
+				e.Client.Close()
+				return
 			}
-			log.Info().Dur("Time Retrying", time.Since(resubStart)).Msg("Resubscribed to new headers")
-			resubTicker.Stop()
-		case header := <-headerChannel:
-			latestHeaderNumber = header.Number
-			e.receiveHeader(header)
-		case <-e.doneChan:
-			log.Debug().Str("Network", e.NetworkConfig.Name).Msg("Subscription cancelled")
-			e.Client.Close()
-			return nil
 		}
-	}
+	}()
+
+	return nil
 }
 
 // receiveHeader takes in a new header from the chain, and sends the header to all active header subscriptions

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -314,6 +314,7 @@ func (e *EthereumClient) subscribeToNewHeaders() error {
 
 // headerSubscriptionLoop receives new headers, and handles subscription errors when they pop up
 func (e *EthereumClient) headerSubscriptionLoop(subscription ethereum.Subscription, headerChannel chan *SafeEVMHeader) {
+	lastHeaderNumber := uint64(0)
 	for {
 		select {
 		case err := <-subscription.Err(): // Most subscription errors are temporary RPC downtime, so let's poll to resubscribe
@@ -338,12 +339,14 @@ func (e *EthereumClient) headerSubscriptionLoop(subscription ethereum.Subscripti
 					if err == nil { // No error on resubscription, RPC connection restored, back to regularly scheduled programming
 						ticker.Stop()
 						log.Info().Dur("Time waiting", time.Since(rpcDegradedTime)).Msg("RPC and subscription connection restored")
+						e.backfillMissedBlocks(lastHeaderNumber, headerChannel)
 						break reSubLoop
 					}
 					log.Trace().Err(err).Msg("Error trying to resubscribe to new headers, likely RPC down")
 				}
 			}
 		case header := <-headerChannel:
+			lastHeaderNumber = header.Number.Uint64()
 			e.receiveHeader(header)
 		case <-e.doneChan:
 			log.Debug().Str("Network", e.NetworkConfig.Name).Msg("Subscription cancelled")
@@ -351,6 +354,26 @@ func (e *EthereumClient) headerSubscriptionLoop(subscription ethereum.Subscripti
 			return
 		}
 	}
+}
+
+// backfillMissedBlocks checks if there are any missed blocks since a bad connection was detected, and if so, backfills them
+// to our header channel
+func (e *EthereumClient) backfillMissedBlocks(lastBlockSeen uint64, headerChannel chan *SafeEVMHeader) error {
+	latestBlockNumber, err := e.LatestBlockNumber(context.Background())
+	if err != nil {
+		return err
+	}
+	if latestBlockNumber <= lastBlockSeen {
+		return nil
+	}
+	for i := lastBlockSeen + 1; i <= latestBlockNumber; i++ {
+		header, err := e.HeaderByNumber(context.Background(), big.NewInt(int64(i)))
+		if err != nil {
+			return err
+		}
+		headerChannel <- header
+	}
+	return nil
 }
 
 // receiveHeader takes in a new header from the chain, and sends the header to all active header subscriptions

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -299,51 +299,58 @@ func (e *EthereumClient) GetHeaderSubscriptions() map[string]HeaderEventSubscrip
 	return newMap
 }
 
-// subscribeToNewHeaders is called at client creation, and subscribes to new headers, attempting to reconnect if encountering issues
+// subscribeToNewHeaders kicks of the primary header subscription for the test loop
 func (e *EthereumClient) subscribeToNewHeaders() error {
 	headerChannel := make(chan *SafeEVMHeader)
 	subscription, err := e.SubscribeNewHeaders(context.Background(), headerChannel)
 	if err != nil {
 		return err
 	}
-
 	log.Info().Str("Network", e.NetworkConfig.Name).Msg("Subscribed to new block headers")
 
-	go func() {
-		defer subscription.Unsubscribe()
-		for {
-			select {
-			case err := <-subscription.Err():
-				if err == nil {
-					log.Debug().Msg("Subscription stopped")
-					return
-				}
-				log.Error().Err(err).Msg("Error while subscribed to new headers, waiting to restart subscription")
-				subscription.Unsubscribe() // Probably unnecessary, but just in case
-
-				// If the sub is down, it's likely RPC node issues, keep trying to reconnect
-				resubStart, resubTicker := time.Now(), time.NewTicker(time.Second)
-				for range resubTicker.C {
-					subscription, err = e.SubscribeNewHeaders(context.Background(), headerChannel)
-					if err == nil {
-						log.Info().Msg("Resubscribed to new headers, resuming test")
-						break
-					}
-					log.Debug().Err(err).Dur("Time Retrying", time.Since(resubStart)).Msg("Attempting to resubscribe to new headers")
-				}
-				log.Info().Dur("Time Retrying", time.Since(resubStart)).Msg("Resubscribed to new headers")
-				resubTicker.Stop()
-			case header := <-headerChannel:
-				e.receiveHeader(header)
-			case <-e.doneChan:
-				log.Debug().Str("Network", e.NetworkConfig.Name).Msg("Subscription cancelled")
-				e.Client.Close()
-				return
-			}
-		}
-	}()
-
+	go e.headerSubscriptionLoop(subscription, headerChannel)
 	return nil
+}
+
+// headerSubscriptionLoop receives new headers, and handles subscription errors when they pop up
+func (e *EthereumClient) headerSubscriptionLoop(subscription ethereum.Subscription, headerChannel chan *SafeEVMHeader) {
+	for {
+		select {
+		case err := <-subscription.Err(): // Most subscription errors are temporary RPC downtime, so let's poll to resubscribe
+			log.Error().Err(err).Msg("Error while subscribed to new headers, likely RPC errors")
+			subscription.Unsubscribe()
+
+			rpcDegradedTime, rpcDegradedNotifyTime := time.Now(), time.Now()
+			timeout, ticker := time.NewTimer(e.NetworkConfig.Timeout.Duration), time.NewTicker(time.Second)
+		reSubLoop:
+			for { // Loop to resubscribe to new headers,
+				select {
+				case <-timeout.C: // Timeout waiting for RPC to come back up
+					log.Error().Dur("Time waiting", time.Since(rpcDegradedTime)).Msg("RPC connection still down, timed out waiting for it to come back up")
+					e.Client.Close()
+					return
+				case <-ticker.C: // Poll the RPC connection to see if it's back up
+					if time.Since(rpcDegradedNotifyTime) >= time.Second*15 { // Periodically inform that we're still waiting for RPC to come back up
+						log.Warn().Dur("Time waiting", time.Since(rpcDegradedTime)).Msg("RPC connection still down, waiting for it to come back up")
+						rpcDegradedNotifyTime = time.Now()
+					}
+					subscription, err = e.SubscribeNewHeaders(context.Background(), headerChannel)
+					if err == nil { // No error on resubscription, RPC connection restored, back to regularly scheduled programming
+						ticker.Stop()
+						log.Info().Dur("Time waiting", time.Since(rpcDegradedTime)).Msg("RPC and subscription connection restored")
+						break reSubLoop
+					}
+					log.Trace().Err(err).Msg("Error trying to resubscribe to new headers, likely RPC down")
+				}
+			}
+		case header := <-headerChannel:
+			e.receiveHeader(header)
+		case <-e.doneChan:
+			log.Debug().Str("Network", e.NetworkConfig.Name).Msg("Subscription cancelled")
+			e.Client.Close()
+			return
+		}
+	}
 }
 
 // receiveHeader takes in a new header from the chain, and sends the header to all active header subscriptions


### PR DESCRIPTION
This is the first step in improving our tests' durability when faced with unreliable RPC nodes. This should cover the most basic case for now.

### RPC Issues We Gotta Handle

- [x] Handle RPC down for a short amount of time
- [x] Handle missed blocks during downtime
- [ ] Handle RPC down for a long amount of time
- [ ] Multiple RPC node failover
- [ ] Handle bad info from RPCs