### PR TITLE
Besu network support

### DIFF
--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -52,7 +52,7 @@ type EVMNetwork struct {
 	// True if the network is simulated like a geth instance in dev mode. False if the network is a real test or mainnet
 	Simulated bool `envconfig:"evm_simulated" default:"false" toml:"evm_simulated" json:"evm_simulated"`
 	// Type of chain client node. Values: "none" | "geth" | "besu"
-	SimulationType string `envconfig:"evm_simulation_type" default:"false" toml:"evm_simulation_type" json:"evm_simulation_type"`
+	SimulationType string `envconfig:"evm_simulation_type" default:"geth" toml:"evm_simulation_type" json:"evm_simulation_type"`
 	// List of private keys to fund the tests
 	PrivateKeys []string `envconfig:"evm_keys" default:"examplePrivateKey" toml:"evm_keys" json:"evm_keys"`
 	// Default gas limit to assume that Chainlink nodes will use. Used to try to estimate the funds that Chainlink

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -51,6 +51,8 @@ type EVMNetwork struct {
 	HTTPURLs []string `envconfig:"evm_http_urls" default:"http://example.url" toml:"evm_http_urls" json:"evm_http_urls"`
 	// True if the network is simulated like a geth instance in dev mode. False if the network is a real test or mainnet
 	Simulated bool `envconfig:"evm_simulated" default:"false" toml:"evm_simulated" json:"evm_simulated"`
+	// Type of chain client node. Values: "none" | "geth" | "besu"
+	SimulationType string `envconfig:"evm_simulation_type" default:"false" toml:"evm_simulation_type" json:"evm_simulation_type"`
 	// List of private keys to fund the tests
 	PrivateKeys []string `envconfig:"evm_keys" default:"examplePrivateKey" toml:"evm_keys" json:"evm_keys"`
 	// Default gas limit to assume that Chainlink nodes will use. Used to try to estimate the funds that Chainlink
@@ -102,6 +104,7 @@ func (e *EVMNetwork) ToMap() map[string]interface{} {
 		"evm_urls":                        strings.Join(e.URLs, ","),
 		"evm_http_urls":                   strings.Join(e.HTTPURLs, ","),
 		"evm_simulated":                   fmt.Sprint(e.Simulated),
+		"evm_simulation_type":             e.SimulationType,
 		"evm_keys":                        strings.Join(e.PrivateKeys, ","),
 		"evm_chainlink_transaction_limit": fmt.Sprint(e.ChainlinkTransactionLimit),
 		"evm_transaction_timeout":         fmt.Sprint(e.Timeout),

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -389,6 +389,13 @@ func (e *EthereumClient) DeployContract(
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	if !e.NetworkConfig.SupportsEIP1559 {
+		gasEstimations, err := e.EstimateGas(ethereum.CallMsg{})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		opts.GasPrice = gasEstimations.GasPrice
+	}
 
 	contractAddress, transaction, contractInstance, err := deployer(opts, e.Client)
 	if err != nil {
@@ -453,6 +460,13 @@ func (e *EthereumClient) TransactionOpts(from *EthereumWallet) (*bind.TransactOp
 	// if the gas limit is less than the default gas limit, use the default
 	if e.NetworkConfig.DefaultGasLimit > opts.GasLimit {
 		opts.GasLimit = e.NetworkConfig.DefaultGasLimit
+	}
+	if !e.NetworkConfig.SupportsEIP1559 {
+		gasEstimations, err := e.EstimateGas(ethereum.CallMsg{})
+		if err != nil {
+			return nil, err
+		}
+		opts.GasPrice = gasEstimations.GasPrice
 	}
 	return opts, nil
 }

--- a/docker/test_env/non_dev_besu.go
+++ b/docker/test_env/non_dev_besu.go
@@ -1,0 +1,316 @@
+package test_env
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/google/uuid"
+	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/utils/templates"
+	tc "github.com/testcontainers/testcontainers-go"
+	tcwait "github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	BESU_IMAGE = "hyperledger/besu:latest"
+)
+
+type PrivateBesuChain struct {
+	PrimaryNode    *NonDevBesuNode
+	Nodes          []*NonDevBesuNode
+	NetworkConfig  *blockchain.EVMNetwork
+	DockerNetworks []string
+}
+
+func NewPrivateBesuChain(networkCfg *blockchain.EVMNetwork, dockerNetworks []string) PrivateBesuChain {
+	evmChain := PrivateBesuChain{
+		NetworkConfig:  networkCfg,
+		DockerNetworks: dockerNetworks,
+	}
+	evmChain.PrimaryNode = NewNonDevBesuNode(dockerNetworks, networkCfg)
+	evmChain.Nodes = []*NonDevBesuNode{evmChain.PrimaryNode}
+	return evmChain
+}
+
+type NonDevBesuNode struct {
+	EnvComponent
+	Config          gethTxNodeConfig
+	ExternalHttpUrl string
+	InternalHttpUrl string
+	ExternalWsUrl   string
+	InternalWsUrl   string
+	EVMClient       blockchain.EVMClient
+	EthClient       *ethclient.Client
+}
+
+func NewNonDevBesuNode(networks []string, networkCfg *blockchain.EVMNetwork) *NonDevBesuNode {
+	return &NonDevBesuNode{
+		Config: gethTxNodeConfig{
+			chainId:    strconv.FormatInt(networkCfg.ChainID, 10),
+			networkCfg: networkCfg,
+		},
+		EnvComponent: EnvComponent{
+			ContainerName: fmt.Sprintf("%s-%s",
+				strings.ReplaceAll(networkCfg.Name, " ", "_"), uuid.NewString()[0:3]),
+			Networks: networks,
+		},
+	}
+}
+
+func (g *NonDevBesuNode) createMountDirs() error {
+	keystorePath, err := os.MkdirTemp("", "keystore")
+	if err != nil {
+		return err
+	}
+	g.Config.keystorePath = keystorePath
+
+	// Create keystore and ethereum account
+	ks := keystore.NewKeyStore(g.Config.keystorePath, keystore.StandardScryptN, keystore.StandardScryptP)
+	account, err := ks.NewAccount("")
+	if err != nil {
+		return err
+	}
+
+	g.Config.accountAddr = account.Address.Hex()
+	addr := strings.Replace(account.Address.Hex(), "0x", "", 1)
+	FundingAddresses[addr] = ""
+	signerBytes, err := hex.DecodeString(addr)
+	if err != nil {
+		fmt.Println("Error decoding signer address:", err)
+		return err
+	}
+
+	zeroBytes := make([]byte, 32)                      // Create 32 zero bytes
+	extradata := append(zeroBytes, signerBytes...)     // Concatenate zero bytes and signer address
+	extradata = append(extradata, make([]byte, 65)...) // Concatenate 65 more zero bytes
+
+	fmt.Printf("Encoded extradata: 0x%s\n", hex.EncodeToString(extradata))
+
+	i := 1
+	var accounts []string
+	for addr, v := range FundingAddresses {
+		if v == "" {
+			continue
+		}
+		f, err := os.Create(fmt.Sprintf("%s/%s", g.Config.keystorePath, fmt.Sprintf("key%d", i)))
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(v)
+		if err != nil {
+			return err
+		}
+		i++
+		accounts = append(accounts, addr)
+	}
+	err = os.WriteFile(g.Config.keystorePath+"/password.txt", []byte(""), 0600)
+	if err != nil {
+		return err
+	}
+
+	genesisJsonStr, err := templates.BuildBesuGenesisJsonForNonDevChain(g.Config.chainId,
+		accounts,
+		fmt.Sprintf("0x%s", hex.EncodeToString(extradata)))
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp("", "genesis_json")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(genesisJsonStr)
+	if err != nil {
+		return err
+	}
+
+	g.Config.genesisPath = f.Name()
+
+	configDir, err := os.MkdirTemp("", "config")
+	if err != nil {
+		return err
+	}
+	g.Config.rootPath = configDir
+
+	return nil
+}
+
+func (g *NonDevBesuNode) Start() error {
+	err := g.createMountDirs()
+	if err != nil {
+		return err
+	}
+
+	// Besu Bootnode setup: BEGIN
+	// Generate public key for besu bootnode
+	bootNode, err := tc.GenericContainer(context.Background(),
+		tc.GenericContainerRequest{
+			ContainerRequest: g.getBesuBootNodeContainerRequest(),
+			Started:          true,
+			Reuse:            true,
+		})
+	if err != nil {
+		return err
+	}
+
+	err = g.exportBesuBootNodeAddress(bootNode)
+	if err != nil {
+		return err
+	}
+	// Besu Bootnode setup: END
+
+	host, err := bootNode.Host(context.Background())
+	if err != nil {
+		return err
+	}
+	r, err := bootNode.CopyFileFromContainer(context.Background(), "/opt/besu/nodedata/bootnodes")
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	bootnodePubKey := strings.TrimPrefix(strings.TrimSpace(string(b)), "0x")
+	g.Config.bootNodeURL = fmt.Sprintf("enode://%s@%s:%s", bootnodePubKey, host, BOOTNODE_PORT)
+
+	fmt.Printf("Besu Bootnode URL: %s\n", g.Config.bootNodeURL)
+
+	var ct tc.Container
+	ct, err = tc.GenericContainer(context.Background(),
+		tc.GenericContainerRequest{
+			ContainerRequest: g.getBesuContainerRequest(),
+			Started:          true,
+			Reuse:            true,
+		})
+	if err != nil {
+		return err
+	}
+	g.Container = ct
+	return nil
+}
+
+func (g *NonDevBesuNode) getBesuBootNodeContainerRequest() tc.ContainerRequest {
+	return tc.ContainerRequest{
+		Name:         g.ContainerName + "-bootnode",
+		Image:        BESU_IMAGE,
+		Networks:     g.Networks,
+		ExposedPorts: []string{"30301/udp"},
+		WaitingFor: tcwait.ForLog("PeerDiscoveryAgent | P2P peer discovery agent started and listening on").
+			WithStartupTimeout(999 * time.Second).
+			WithPollInterval(1 * time.Second),
+		Cmd: []string{
+			"--genesis-file",
+			"/opt/besu/nodedata/genesis.json",
+			"--data-path",
+			"/opt/besu/nodedata",
+			"--logging=INFO",
+			"--p2p-port=30301",
+			"--bootnodes",
+		},
+		Files: []tc.ContainerFile{
+			{
+				HostFilePath:      g.Config.genesisPath,
+				ContainerFilePath: "/opt/besu/nodedata/genesis.json",
+				FileMode:          0644,
+			},
+		},
+		Mounts: tc.ContainerMounts{
+			tc.ContainerMount{
+				Source: tc.GenericBindMountSource{
+					HostPath: g.Config.rootPath,
+				},
+				Target: "/opt/besu/nodedata/",
+			},
+		},
+	}
+}
+
+func (g *NonDevBesuNode) exportBesuBootNodeAddress(bootNode tc.Container) (err error) {
+	resCode, _, err := bootNode.Exec(context.Background(), []string{
+		"besu",
+		"--genesis-file", "/opt/besu/nodedata/genesis.json",
+		"--data-path", "/opt/besu/nodedata",
+		"public-key", "export",
+		"--to=/opt/besu/nodedata/bootnodes",
+	})
+	fmt.Printf("Export besu bootnode address, process exitcode: %d\n", resCode)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *NonDevBesuNode) getBesuContainerRequest() tc.ContainerRequest {
+	return tc.ContainerRequest{
+		Name:  g.ContainerName,
+		Image: BESU_IMAGE,
+		ExposedPorts: []string{
+			natPortFormat(TX_GETH_HTTP_PORT),
+			natPortFormat(TX_NON_DEV_GETH_WS_PORT),
+			"30303/tcp", "30303/udp"},
+		Networks: g.Networks,
+		WaitingFor: tcwait.ForAll(
+			tcwait.ForLog("WebSocketService | Websocket service started"),
+			NewWebSocketStrategy(natPort(TX_NON_DEV_GETH_WS_PORT)),
+			tcwait.NewHTTPStrategy("/").
+				WithPort(natPort(TX_GETH_HTTP_PORT)).
+				WithStatusCodeMatcher(func(status int) bool {
+					return status == 201
+				}),
+		),
+		Entrypoint: []string{
+			"besu",
+			"--genesis-file", "/opt/besu/nodedata/genesis.json",
+			"--host-allowlist", "*",
+			// "--sync-mode", "X_SNAP", // Requires at least 5 peers in X_SNAP mode
+			fmt.Sprintf("--bootnodes=%s", g.Config.bootNodeURL),
+			"--rpc-http-enabled",
+			"--rpc-http-cors-origins", "*",
+			"--rpc-http-api", "ADMIN,DEBUG,WEB3,ETH,TXPOOL,CLIQUE,MINER,NET",
+			"--rpc-http-host", "0.0.0.0",
+			fmt.Sprintf("--rpc-http-port=%s", TX_GETH_HTTP_PORT),
+			"--rpc-ws-enabled",
+			"--rpc-ws-api", "ADMIN,DEBUG,WEB3,ETH,TXPOOL,CLIQUE,MINER,NET",
+			"--rpc-ws-host", "0.0.0.0",
+			fmt.Sprintf("--rpc-ws-port=%s", TX_NON_DEV_GETH_WS_PORT),
+			"--miner-enabled=true",
+			"--miner-coinbase", g.Config.accountAddr,
+			fmt.Sprintf("--network-id=%s", g.Config.chainId),
+			"--logging=DEBUG",
+		},
+		Files: []tc.ContainerFile{
+			{
+				HostFilePath:      g.Config.genesisPath,
+				ContainerFilePath: "/opt/besu/nodedata/genesis.json",
+				FileMode:          0644,
+			},
+		},
+		Mounts: tc.ContainerMounts{
+			tc.ContainerMount{
+				Source: tc.GenericBindMountSource{
+					HostPath: g.Config.keystorePath,
+				},
+				Target: "/opt/besu/nodedata/keystore/",
+			},
+			tc.ContainerMount{
+				Source: tc.GenericBindMountSource{
+					HostPath: g.Config.rootPath,
+				},
+				Target: "/opt/besu/nodedata/",
+			},
+		},
+	}
+}

--- a/docker/test_env/non_dev_besu.go
+++ b/docker/test_env/non_dev_besu.go
@@ -15,10 +15,11 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils/templates"
 	tc "github.com/testcontainers/testcontainers-go"
 	tcwait "github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/utils/templates"
 )
 
 const (

--- a/docker/test_env/non_dev_chain.go
+++ b/docker/test_env/non_dev_chain.go
@@ -1,0 +1,18 @@
+package test_env
+
+import "github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+
+type NonDevNode interface {
+	GetInternalHttpUrl() string
+	GetInternalWsUrl() string
+	GetEVMClient() blockchain.EVMClient
+	Start() error
+	ConnectToClient() error
+}
+
+type PrivateChain interface {
+	GetPrimaryNode() NonDevNode
+	GetNodes() []NonDevNode
+	GetNetworkConfig() *blockchain.EVMNetwork
+	GetDockerNetworks() []string
+}

--- a/docker/test_env/non_dev_geth.go
+++ b/docker/test_env/non_dev_geth.go
@@ -54,14 +54,34 @@ type PrivateGethChain struct {
 	DockerNetworks []string
 }
 
-func NewPrivateGethChain(networkCfg *blockchain.EVMNetwork, dockerNetworks []string) PrivateGethChain {
-	evmChain := PrivateGethChain{
+func NewPrivateGethChain(networkCfg *blockchain.EVMNetwork, dockerNetworks []string) PrivateChain {
+	evmChain := &PrivateGethChain{
 		NetworkConfig:  networkCfg,
 		DockerNetworks: dockerNetworks,
 	}
 	evmChain.PrimaryNode = NewNonDevGethNode(dockerNetworks, networkCfg)
 	evmChain.Nodes = []*NonDevGethNode{evmChain.PrimaryNode}
 	return evmChain
+}
+
+func (p *PrivateGethChain) GetPrimaryNode() NonDevNode {
+	return p.PrimaryNode
+}
+
+func (p *PrivateGethChain) GetNodes() []NonDevNode {
+	nodes := make([]NonDevNode, 0)
+	for _, node := range p.Nodes {
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+func (p *PrivateGethChain) GetNetworkConfig() *blockchain.EVMNetwork {
+	return p.NetworkConfig
+}
+
+func (p *PrivateGethChain) GetDockerNetworks() []string {
+	return p.DockerNetworks
 }
 
 type gethTxNodeConfig struct {
@@ -99,6 +119,18 @@ func NewNonDevGethNode(networks []string, networkCfg *blockchain.EVMNetwork) *No
 			Networks: networks,
 		},
 	}
+}
+
+func (g *NonDevGethNode) GetInternalHttpUrl() string {
+	return g.InternalHttpUrl
+}
+
+func (g *NonDevGethNode) GetInternalWsUrl() string {
+	return g.InternalWsUrl
+}
+
+func (g *NonDevGethNode) GetEVMClient() blockchain.EVMClient {
+	return g.EVMClient
 }
 
 func (g *NonDevGethNode) createMountDirs() error {

--- a/docker/test_env/non_dev_geth_test.go
+++ b/docker/test_env/non_dev_geth_test.go
@@ -13,8 +13,8 @@ func TestNonDevGeth(t *testing.T) {
 	network, err := docker.CreateNetwork()
 	require.NoError(t, err)
 	g := NewPrivateGethChain(&blockchain.SimulatedEVMNetwork, []string{network.Name})
-	err = g.PrimaryNode.Start()
+	err = g.GetPrimaryNode().Start()
 	require.NoError(t, err)
-	err = g.PrimaryNode.ConnectToClient()
+	err = g.GetPrimaryNode().ConnectToClient()
 	require.NoError(t, err)
 }

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -91,6 +91,7 @@ var (
 		Simulated:            true,
 		ClientImplementation: blockchain.EthereumClientImplementation,
 		SupportsEIP1559:      false,
+		SimulationType:       "besu",
 		ChainID:              1337,
 		PrivateKeys: []string{
 			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
@@ -111,9 +112,10 @@ var (
 		Simulated:            true,
 		ClientImplementation: blockchain.EthereumClientImplementation,
 		SupportsEIP1559:      false,
+		SimulationType:       "besu",
 		ChainID:              2337,
 		PrivateKeys: []string{
-			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+			"59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
 		},
 		URLs:                      []string{"ws://dest-chain-ethereum-besu:8546"},
 		HTTPURLs:                  []string{"http://dest-chain-ethereum-besu:8544"},

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -84,6 +84,46 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	// SimulatedBesuNonDev1 represents a simulated network which can be used to deploy a non-dev besu node
+	// in a CCIP source-chain -> dest-chain communication
+	SimulatedBesuNonDev1 = blockchain.EVMNetwork{
+		Name:                 "source-chain",
+		Simulated:            true,
+		ClientImplementation: blockchain.EthereumClientImplementation,
+		SupportsEIP1559:      false,
+		ChainID:              1337,
+		PrivateKeys: []string{
+			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		},
+		URLs:                      []string{"ws://source-chain-ethereum-besu:8546"},
+		HTTPURLs:                  []string{"http://source-chain-ethereum-besu:8544"},
+		ChainlinkTransactionLimit: 500000,
+		Timeout:                   blockchain.JSONStrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		DefaultGasLimit:           6000000,
+	}
+
+	// SimulatedBesuNonDev2 represents a simulated network which can be used to deploy a non-dev besu node
+	// in a CCIP source-chain -> dest-chain communication
+	SimulatedBesuNonDev2 = blockchain.EVMNetwork{
+		Name:                 "dest-chain",
+		Simulated:            true,
+		ClientImplementation: blockchain.EthereumClientImplementation,
+		SupportsEIP1559:      false,
+		ChainID:              2337,
+		PrivateKeys: []string{
+			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		},
+		URLs:                      []string{"ws://dest-chain-ethereum-besu:8546"},
+		HTTPURLs:                  []string{"http://dest-chain-ethereum-besu:8544"},
+		ChainlinkTransactionLimit: 500000,
+		Timeout:                   blockchain.JSONStrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		DefaultGasLimit:           6000000,
+	}
+
 	SimulatedEVMNonDev = blockchain.EVMNetwork{
 		Name:                 "geth",
 		Simulated:            true,
@@ -445,10 +485,12 @@ var (
 	}
 
 	MappedNetworks = map[string]blockchain.EVMNetwork{
-		"SIMULATED":        SimulatedEVM,
-		"SIMULATED_1":      SimulatedEVMNonDev1,
-		"SIMULATED_2":      SimulatedEVMNonDev2,
-		"SIMULATED_NONDEV": SimulatedEVMNonDev,
+		"SIMULATED":               SimulatedEVM,
+		"SIMULATED_1":             SimulatedEVMNonDev1,
+		"SIMULATED_2":             SimulatedEVMNonDev2,
+		"SIMULATED_BESU_NONDEV_1": SimulatedBesuNonDev1,
+		"SIMULATED_BESU_NONDEV_2": SimulatedBesuNonDev2,
+		"SIMULATED_NONDEV":        SimulatedEVMNonDev,
 		// "GENERAL":         generalEVM, // See above
 		"ETHEREUM_MAINNET":  EthereumMainnet,
 		"GOERLI":            GoerliTestnet,

--- a/utils/templates/besu.go
+++ b/utils/templates/besu.go
@@ -1,0 +1,72 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+var BesuGenesisJson = `
+{
+	"config": {
+	  "chainId": {{ .ChainId }},
+	  "homesteadBlock": 0,
+	  "eip150Block": 0,
+	  "eip155Block": 0,
+	  "eip158Block": 0,
+	  "eip160Block": 0,
+	  "byzantiumBlock": 0,
+	  "constantinopleBlock": 0,
+	  "petersburgBlock": 0,
+	  "istanbulBlock": 0,
+	  "muirGlacierBlock": 0,
+	  "berlinBlock": 0,
+	  "londonBlock": 0,
+	  "clique": {
+		"blockperiodseconds": 2,
+		"epochlength": 30000
+      },
+	  "ethash": {
+		"fixeddifficulty": 100
+	  }
+	},
+	"nonce": "0x42",
+	"mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"difficulty": "0x10000",
+	"coinbase": "0x0000000000000000000000000000000000000000",
+	"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+	"extraData": "{{ .ExtraData }}",
+	"gasLimit": "0x1fffffffffffff",
+	"alloc": {
+	{{- $lastIndex := decrement (len $.AccountAddr)}}
+	{{- range $i, $addr := .AccountAddr }}
+  "{{$addr}}": {
+    "balance": "20000000000000000000000"
+  }{{ if ne $i $lastIndex }},{{ end }}
+{{- end }}
+	}
+  }`
+
+func BuildBesuGenesisJsonForNonDevChain(chainId string, accountAddr []string, extraData string) (string, error) {
+	data := struct {
+		AccountAddr []string
+		ChainId     string
+		ExtraData   string
+	}{
+		AccountAddr: accountAddr,
+		ChainId:     chainId,
+		ExtraData:   extraData,
+	}
+
+	t, err := template.New("genesis-json").Funcs(funcMap).Parse(BesuGenesisJson)
+	if err != nil {
+		fmt.Println("Error parsing template:", err)
+		os.Exit(1)
+	}
+
+	var buf bytes.Buffer
+	err = t.Execute(&buf, data)
+
+	return buf.String(), err
+}


### PR DESCRIPTION
## Motivation

- Currently there is no support for running Private chains using Besu client node.

## Solution

- Explore how to add support for Besu client node and find the correct docker settings of a working solution
- Find the right settings for running Besu bootnode and RPC node