### PR TITLE
[TT-414] Add killgrave container with functions to add mocks similar to mock-server

### DIFF
--- a/docker/test_env/killgrave.go
+++ b/docker/test_env/killgrave.go
@@ -1,0 +1,226 @@
+package test_env
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/logging"
+)
+
+type Killgrave struct {
+	EnvComponent
+	ExternalEndpoint  string
+	InternalPort      string
+	InternalEndpoint  string
+	InternalImposters []*url.URL
+	impostersPath     string
+	t                 *testing.T
+	l                 zerolog.Logger
+}
+
+// Imposter define an imposter structure
+type KillgraveImposter struct {
+	Request  KillgraveRequest  `json:"request"`
+	Response KillgraveResponse `json:"response"`
+}
+
+type KillgraveRequest struct {
+	Method     string             `json:"method"`
+	Endpoint   string             `json:"endpoint,omitempty"`
+	SchemaFile *string            `json:"schemaFile,omitempty"`
+	Params     *map[string]string `json:"params,omitempty"`
+	Headers    *map[string]string `json:"headers"`
+}
+
+// Response represent the structure of real response
+type KillgraveResponse struct {
+	Status   int                     `json:"status"`
+	Body     string                  `json:"body,omitempty"`
+	BodyFile *string                 `json:"bodyFile,omitempty"`
+	Headers  *map[string]string      `json:"headers,omitempty"`
+	Delay    *KillgraveResponseDelay `json:"delay,omitempty"`
+}
+
+// ResponseDelay represent time delay before server responds.
+type KillgraveResponseDelay struct {
+	Delay  int64 `json:"delay,omitempty"`
+	Offset int64 `json:"offset,omitempty"`
+}
+
+// AdapterResponse represents a response from an adapter
+type KillgraveAdapterResponse struct {
+	Id    string                 `json:"id"`
+	Data  KillgraveAdapterResult `json:"data"`
+	Error interface{}            `json:"error"`
+}
+
+// AdapterResult represents an int result for an adapter
+type KillgraveAdapterResult struct {
+	Result interface{} `json:"result"`
+}
+
+func NewKillgrave(networks []string, impostersDirectoryPath string, opts ...EnvComponentOption) *Killgrave {
+	k := &Killgrave{
+		EnvComponent: EnvComponent{
+			ContainerName: fmt.Sprintf("%s-%s", "killgrave", uuid.NewString()[0:3]),
+			Networks:      networks,
+		},
+		InternalPort:  "3000",
+		impostersPath: impostersDirectoryPath,
+		l:             log.Logger,
+	}
+	for _, opt := range opts {
+		opt(&k.EnvComponent)
+	}
+	return k
+}
+
+func (k *Killgrave) WithTestLogger(t *testing.T) *Killgrave {
+	k.l = logging.GetTestLogger(t)
+	k.t = t
+	return k
+}
+
+func (k *Killgrave) StartContainer() error {
+	l := tc.Logger
+	if k.t != nil {
+		l = logging.CustomT{
+			T: k.t,
+			L: k.l,
+		}
+	}
+	c, err := tc.GenericContainer(context.Background(), tc.GenericContainerRequest{
+		ContainerRequest: k.getContainerRequest(),
+		Started:          true,
+		Reuse:            true,
+		Logger:           l,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "cannot start Killgrave container")
+	}
+	endpoint, err := c.Endpoint(context.Background(), "http")
+	if err != nil {
+		return err
+	}
+	k.Container = c
+	k.ExternalEndpoint = endpoint
+	k.InternalEndpoint = fmt.Sprintf("http://%s:%s", k.ContainerName, k.InternalPort)
+
+	log.Info().Str("External Endpoint", k.ExternalEndpoint).
+		Str("Internal Endpoint", k.InternalEndpoint).
+		Str("Container Name", k.ContainerName).
+		Msgf("Started Killgrave Container")
+	return nil
+}
+
+func (k *Killgrave) getContainerRequest() tc.ContainerRequest {
+	if len(k.impostersPath) == 0 {
+		_, f, _, _ := runtime.Caller(0)
+		k.impostersPath = path.Join(path.Dir(f), "/killgrave_imposters")
+	}
+	return tc.ContainerRequest{
+		Name:         k.ContainerName,
+		Networks:     k.Networks,
+		Image:        "friendsofgo/killgrave",
+		ExposedPorts: []string{NatPortFormat(k.InternalPort)},
+		Cmd:          []string{"-host=0.0.0.0", "-imposters=/imposters", "-watcher"},
+		Mounts: tc.ContainerMounts{
+			tc.ContainerMount{
+				Source: tc.GenericBindMountSource{
+					HostPath: k.impostersPath,
+				},
+				Target: "/imposters",
+			},
+		},
+		WaitingFor: wait.ForLog("The fake server is on tap now"),
+	}
+}
+
+// AddImposter adds an imposter to the killgrave container
+func (k *Killgrave) AddImposter(imposter KillgraveImposter) error {
+	req := imposter.Request
+
+	imposters := []KillgraveImposter{imposter}
+	data, err := json.Marshal(imposters)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.CreateTemp("", "imposter.imp.json")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(string(data))
+	if err != nil {
+		return err
+	}
+
+	localFile := f.Name()
+	containerFile := fmt.Sprintf("/imposters%s.imp.json", req.Endpoint)
+
+	err = k.Container.CopyFileToContainer(context.Background(), localFile, containerFile, 0644)
+	if err != nil {
+		return err
+	}
+
+	// wait for the log saying the imposter was loaded
+	logWaitStrategy := wait.ForLog(fmt.Sprintf("imposter %s loaded", containerFile)).WithStartupTimeout(15 * time.Second)
+	err = logWaitStrategy.WaitUntilReady(context.Background(), k.Container)
+	return err
+}
+
+// SetStringValuePath sets a path to return a string value
+func (k *Killgrave) SetStringValuePath(path string, method string, headers map[string]string, v string) error {
+	imp := KillgraveImposter{
+		Request: KillgraveRequest{
+			Method:   method,
+			Endpoint: path,
+		},
+		Response: KillgraveResponse{
+			Status:  200,
+			Body:    v,
+			Headers: &headers,
+		},
+	}
+
+	return k.AddImposter(imp)
+}
+
+// SetAdapterBasedAnyValuePath sets a path to return a value as though it was from an adapter
+func (k *Killgrave) SetAdapterBasedAnyValuePath(path string, method string, v interface{}) error {
+	ar := KillgraveAdapterResponse{
+		Id: "",
+		Data: KillgraveAdapterResult{
+			Result: v,
+		},
+		Error: nil,
+	}
+	data, err := json.Marshal(ar)
+	if err != nil {
+		return err
+	}
+
+	return k.SetStringValuePath(path, method, map[string]string{
+		"Content-Type": "application/json",
+	}, string(data))
+}
+
+// SetAdapterBasedAnyValuePathObject sets a path to return a value as though it was from an adapter
+func (k *Killgrave) SetAdapterBasedIntValuePath(path string, method string, v int) error {
+	return k.SetAdapterBasedAnyValuePath(path, method, v)
+}

--- a/docker/test_env/killgrave_imposters/five.imp.json
+++ b/docker/test_env/killgrave_imposters/five.imp.json
@@ -1,0 +1,28 @@
+[
+  {
+    "request": {
+      "method": "GET",
+      "endpoint": "/five"
+    },
+    "response": {
+      "status": 200,
+      "body": "{ \"id\": \"\", \"error\": null, \"data\": { \"result\": 5 } }",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  },
+  {
+    "request": {
+      "method": "POST",
+      "endpoint": "/five"
+    },
+    "response": {
+      "status": 200,
+      "body": "{ \"id\": \"\", \"error\": null, \"data\": { \"result\": 5 } }",
+      "headers": {
+        "Content-Type": "application/json"
+      }
+    }
+  }
+]

--- a/docker/test_env/killgrave_test.go
+++ b/docker/test_env/killgrave_test.go
@@ -1,0 +1,126 @@
+package test_env
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/docker"
+	"github.com/smartcontractkit/chainlink-testing-framework/logging"
+)
+
+type kgTest struct {
+	Name          string
+	AdapterResult interface{}
+	Expected      string
+	Path          string
+	Headers       map[string]string
+}
+
+func TestKillgraveMocks(t *testing.T) {
+	n := t.Name()
+	l := logging.GetTestLogger(t)
+	network, err := docker.CreateNetwork(l)
+	require.NoError(t, err)
+
+	k := NewKillgrave([]string{network.Name}, "").
+		WithTestLogger(t)
+	err = k.StartContainer()
+	require.NoError(t, err)
+
+	expectations := []kgTest{
+		{
+			Name:     "DefaultFive",
+			Expected: "{ \"id\": \"\", \"error\": null, \"data\": { \"result\": 5 } }",
+			Path:     "/five",
+			Headers:  map[string]string{"Content-Type": "text/plain"},
+		},
+		{
+			Name:     "SetStringValuePath",
+			Expected: "bar",
+			Path:     "/stringany",
+			Headers:  map[string]string{"Content-Type": "text/plain"},
+		},
+		{
+			Name:          "SetAdapterBasedAnyValuePath",
+			AdapterResult: "bar",
+			Expected:      "{\"id\":\"\",\"data\":{\"result\":\"bar\"},\"error\":null}",
+			Path:          "/adapterany",
+			Headers:       map[string]string{"Content-Type": "application/json"},
+		},
+		{
+			Name:          "SetAdapterBasedAnyValuePathObject",
+			AdapterResult: map[string]string{"foo": "bar"},
+			Expected:      "{\"id\":\"\",\"data\":{\"result\":{\"foo\":\"bar\"}},\"error\":null}",
+			Path:          "/adapteranyobject",
+			Headers:       map[string]string{"Content-Type": "application/json"},
+		},
+		{
+			Name:          "SetAdapterBasedIntValuePath",
+			AdapterResult: 5,
+			Expected:      "{\"id\":\"\",\"data\":{\"result\":5},\"error\":null}",
+			Path:          "/adapterint",
+			Headers:       map[string]string{"Content-Type": "application/json"},
+		},
+	}
+
+	// cleanup the files created during the test
+	t.Cleanup(func() {
+		for _, e := range expectations {
+			if e.Path == "/five" {
+				continue
+			}
+			err := os.Remove(fmt.Sprintf("./killgrave_imposters%s.imp.json", e.Path))
+			if err != nil {
+				t.Logf("Failed to delete the file: %v", err)
+			}
+		}
+	})
+
+	// Check the different kinds of responses
+	for _, e := range expectations {
+		t.Run(e.Name, func(t *testing.T) {
+			test := e
+			switch t.Name() {
+			case fmt.Sprintf("%s/DefaultFive", n):
+				// do nothing, it is provided by default
+			case fmt.Sprintf("%s/SetStringValuePath", n):
+				err = k.SetStringValuePath(test.Path, http.MethodGet, test.Headers, test.Expected)
+			case fmt.Sprintf("%s/SetAdapterBasedAnyValuePath", n):
+				err = k.SetAdapterBasedAnyValuePath(test.Path, http.MethodGet, test.AdapterResult)
+			case fmt.Sprintf("%s/SetAdapterBasedAnyValuePathObject", n):
+				err = k.SetAdapterBasedAnyValuePath(test.Path, http.MethodGet, test.AdapterResult)
+			case fmt.Sprintf("%s/SetAdapterBasedIntValuePath", n):
+				err = k.SetAdapterBasedIntValuePath(test.Path, http.MethodGet, test.AdapterResult.(int))
+			default:
+				require.Fail(t, fmt.Sprintf("unknown test name %s", t.Name()))
+			}
+			require.NoError(t, err)
+
+			url := fmt.Sprintf("%s%s", k.ExternalEndpoint, test.Path)
+			client := &http.Client{
+				Timeout: 10 * time.Second,
+			}
+
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode, fmt.Sprintf("url: %s", url))
+
+			buf := new(bytes.Buffer)
+			_, err = buf.ReadFrom(resp.Body)
+			require.NoError(t, err)
+
+			responseString := buf.String()
+			require.Equal(t, test.Expected, responseString)
+		})
+	}
+}


### PR DESCRIPTION
- Can add imposters by pointing to an imposters directory on Start 
- Can add imposters dynamically with the helper methods provided