### PR TITLE
[TT-536] Geth WS Getting HTTP Handshake Flake

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -18,6 +18,7 @@ func CreateNetwork(l zerolog.Logger) (*tc.DockerNetwork, error) {
 		NetworkRequest: tc.NetworkRequest{
 			Name:           networkName,
 			CheckDuplicate: true,
+			EnableIPv6:     false,
 		},
 	})
 	if err != nil {

--- a/docker/test_env/geth.go
+++ b/docker/test_env/geth.go
@@ -100,7 +100,7 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, InternalDockerUrls, erro
 	if err != nil {
 		return blockchain.EVMNetwork{}, InternalDockerUrls{}, err
 	}
-	wsPort, err := ct.MappedPort(context.Background(), NatPort(TX_GETH_WS_PORT))
+	wsPort, err := getUniqueWsPort(ct, TX_GETH_HTTP_PORT, TX_GETH_WS_PORT, g.l)
 	if err != nil {
 		return blockchain.EVMNetwork{}, InternalDockerUrls{}, err
 	}
@@ -129,6 +129,25 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, InternalDockerUrls, erro
 		Msg("Started Geth container")
 
 	return networkConfig, internalDockerUrls, nil
+}
+
+func getUniqueWsPort(ct tc.Container, httpInternalPort, wsInternalPort string, l zerolog.Logger) (nat.Port, error) {
+	p, err := ct.Ports(context.Background())
+	if err != nil {
+		return "", err
+	}
+	l.Info().
+		Interface("ports", p).
+		Msg("Ports mapped")
+	httpPorts := p[NatPort(httpInternalPort)]
+	wsPorts := p[NatPort(wsInternalPort)]
+	wsPort := NatPort(wsPorts[0].HostPort)
+	if len(wsPorts) > 1 {
+		if httpPorts[0].HostPort == wsPorts[0].HostPort || httpPorts[1].HostPort == wsPorts[0].HostPort {
+			wsPort = NatPort(wsPorts[1].HostPort)
+		}
+	}
+	return wsPort, nil
 }
 
 func (g *Geth) getGethContainerRequest(networks []string) (*tc.ContainerRequest, *keystore.KeyStore, *accounts.Account, error) {
@@ -301,13 +320,12 @@ func (w *WebSocketStrategy) WaitUntilReady(ctx context.Context, target tcwait.St
 			w.l.Error().Msg("Failed to get the target host")
 			return err
 		}
-		mappedPort, err := target.MappedPort(ctx, w.Port)
+		wsPort, err := getUniqueWsPort(target.(tc.Container), TX_GETH_HTTP_PORT, w.Port.Port(), w.l)
 		if err != nil {
-			w.l.Error().Msg("Failed to get the mapped ws port")
 			return err
 		}
 
-		url := fmt.Sprintf("ws://%s:%s", host, mappedPort.Port())
+		url := fmt.Sprintf("ws://%s:%s", host, wsPort.Port())
 		w.l.Info().Msgf("Attempting to dial %s", url)
 		client, err = rpc.DialContext(ctx, url)
 		if err == nil {

--- a/docker/test_env/geth.go
+++ b/docker/test_env/geth.go
@@ -100,7 +100,7 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, InternalDockerUrls, erro
 	if err != nil {
 		return blockchain.EVMNetwork{}, InternalDockerUrls{}, err
 	}
-	wsPort, err := getUniqueWsPort(ct, TX_GETH_HTTP_PORT, TX_GETH_WS_PORT, g.l)
+	wsPort, err := getUniqueWsPort(context.Background(), ct, TX_GETH_HTTP_PORT, TX_GETH_WS_PORT, g.l)
 	if err != nil {
 		return blockchain.EVMNetwork{}, InternalDockerUrls{}, err
 	}
@@ -131,8 +131,8 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, InternalDockerUrls, erro
 	return networkConfig, internalDockerUrls, nil
 }
 
-func getUniqueWsPort(ct tc.Container, httpInternalPort, wsInternalPort string, l zerolog.Logger) (nat.Port, error) {
-	p, err := ct.Ports(context.Background())
+func getUniqueWsPort(ctx context.Context, ct tc.Container, httpInternalPort, wsInternalPort string, l zerolog.Logger) (nat.Port, error) {
+	p, err := ct.Ports(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -320,7 +320,7 @@ func (w *WebSocketStrategy) WaitUntilReady(ctx context.Context, target tcwait.St
 			w.l.Error().Msg("Failed to get the target host")
 			return err
 		}
-		wsPort, err := getUniqueWsPort(target.(tc.Container), TX_GETH_HTTP_PORT, w.Port.Port(), w.l)
+		wsPort, err := getUniqueWsPort(ctx, target.(tc.Container), TX_GETH_HTTP_PORT, w.Port.Port(), w.l)
 		if err != nil {
 			return err
 		}

--- a/docker/test_env/non_dev_geth.go
+++ b/docker/test_env/non_dev_geth.go
@@ -309,7 +309,7 @@ func (g *NonDevGethNode) ConnectToClient() error {
 	if err != nil {
 		return err
 	}
-	wsPort, err := getUniqueWsPort(ct, TX_GETH_HTTP_PORT, TX_NON_DEV_GETH_WS_PORT, g.l)
+	wsPort, err := getUniqueWsPort(context.Background(), ct, TX_GETH_HTTP_PORT, TX_NON_DEV_GETH_WS_PORT, g.l)
 	if err != nil {
 		return err
 	}

--- a/docker/test_env/non_dev_geth.go
+++ b/docker/test_env/non_dev_geth.go
@@ -309,11 +309,11 @@ func (g *NonDevGethNode) ConnectToClient() error {
 	if err != nil {
 		return err
 	}
-	port = NatPort(TX_NON_DEV_GETH_WS_PORT)
-	wsPort, err := ct.MappedPort(context.Background(), port)
+	wsPort, err := getUniqueWsPort(ct, TX_GETH_HTTP_PORT, TX_NON_DEV_GETH_WS_PORT, g.l)
 	if err != nil {
 		return err
 	}
+
 	g.ExternalHttpUrl = fmt.Sprintf("http://%s:%s", host, httpPort.Port())
 	g.InternalHttpUrl = fmt.Sprintf("http://%s:%s", g.ContainerName, TX_GETH_HTTP_PORT)
 	g.ExternalWsUrl = fmt.Sprintf("ws://%s:%s", host, wsPort.Port())


### PR DESCRIPTION
I setup a test to reliably reproduce the geth websocket endpoint returning a http status 200 instead of a websocket upgrade here: https://github.com/smartcontractkit/chainlink-testing-framework/pull/723/files
It spins up and shuts down the geth container 500 times while trying to connect to the websocket once per launch. I setup a matrix to run this test 10 times so we got 5000 chances to catch it. It catches the issue every time until I changed the ports to be ws:8545 and http:8546 and then it passed the entire matrix twice:
https://github.com/smartcontractkit/chainlink-testing-framework/actions/runs/6448289888
https://github.com/smartcontractkit/chainlink-testing-framework/actions/runs/6448530929

So port ordering matters, why? After adding some more logging I found that only in the cases where tests failed did docker setup the networking like this:
```json
{
  "8544/tcp": [
    { "HostIp": "0.0.0.0", "HostPort": "32875" },
    { "HostIp": "::", "HostPort": "32874" }
  ],
  "8545/tcp": [
    { "HostIp": "0.0.0.0", "HostPort": "32874" },
    { "HostIp": "::", "HostPort": "32873" }
  ]
}
```
When the tests pass it looks like this:
```json
{
  "8544/tcp": [
    { "HostIp": "0.0.0.0", "HostPort": "32875" },
  ],
  "8545/tcp": [
    { "HostIp": "0.0.0.0", "HostPort": "32874" },
  ]
}
```
So we are getting double booked for the HostPort. This means the ws traffic gets sent to the server listening for http traffic. testcontainers-go sadly doesn't give us a way to force the ports being bound to which would be a good solution for this so instead I just grab the secondary port bound to the ws so it gets sent correct server on the container.

This is a nasty hack for a nasty bug and I have no idea why only a small percentage of the time we get an extra ipv6 port mapped to each of the exposed ports.
