### PR TITLE
[TT-628] Logging after test completes panic fix

### DIFF
--- a/logging/log.go
+++ b/logging/log.go
@@ -31,7 +31,7 @@ func (ct *CustomT) Write(p []byte) (n int, err error) {
 	}
 	if ct.ended {
 		l := GetTestLogger(nil)
-		l.Info().Msgf("%s %s: %s", afterTestEndedMsg, ct.Name(), string(p))
+		l.Error().Msgf("%s %s: %s", afterTestEndedMsg, ct.Name(), string(p))
 		return len(p), nil
 	}
 	ct.T.Log(strings.TrimSuffix(str, "\n"))
@@ -44,7 +44,7 @@ func (ct CustomT) Printf(format string, v ...interface{}) {
 		s := "%s: "
 		formatted := fmt.Sprintf("%s %s%s", afterTestEndedMsg, s, format)
 		l := GetTestLogger(nil)
-		l.Info().Msgf(formatted, ct.Name(), v)
+		l.Error().Msgf(formatted, ct.Name(), v)
 	} else {
 		ct.L.Info().Msgf(format, v...)
 	}

--- a/logging/log_test.go
+++ b/logging/log_test.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLogAfterTestEnd(t *testing.T) {
+	l := GetTestLogger(t)
+	go func() {
+		for i := 0; i < 5000; i++ {
+			l.Info().Msg("test")
+		}
+	}()
+	time.Sleep(1 * time.Millisecond)
+}


### PR DESCRIPTION
Caused by go routines that log out transaction info after the test completes.
We see this most often when we have subscribed to an EVMClient and are reading transactions in a goroutine. We didn't run into this before because it wasn't using the *testing.T.Log and was instead just using the base zerologger. It panics when using the test logger and doesn't when using the zero logger. This doesn't fix the core issue but at least won't panic and fail otherwise passing tests