### PR TITLE
[TT-537] Force localhost to be ipv4 127.0.0.1 where needed

### DIFF
--- a/client/postgres.go
+++ b/client/postgres.go
@@ -51,7 +51,7 @@ func ConnectDB(nodeNum int, e *environment.Environment) (*PostgresConnector, err
 	spl := strings.Split(e.URLs["chainlink_db"][nodeNum], ":")
 	port := spl[len(spl)-1]
 	db, err := NewPostgresConnector(&PostgresConfig{
-		Host:     "localhost",
+		Host:     "127.0.0.1",
 		Port:     port,
 		User:     "postgres",
 		Password: "postgres",

--- a/docker/test_env/kafka.go
+++ b/docker/test_env/kafka.go
@@ -106,7 +106,7 @@ func (k *Kafka) StartContainer() error {
 	}
 	k.InternalUrl = fmt.Sprintf("%s:%s", k.ContainerName, "9092")
 	// TODO: Fix mapped port
-	k.ExternalUrl = fmt.Sprintf("localhost:%s", "29092")
+	k.ExternalUrl = fmt.Sprintf("127.0.0.1:%s", "29092")
 	k.BootstrapServerUrl = k.InternalUrl
 	envVars := map[string]string{
 		"KAFKA_ADVERTISED_LISTENERS": fmt.Sprintf("PLAINTEXT://%s,PLAINTEXT_HOST://%s", k.InternalUrl, k.ExternalUrl),

--- a/docker/test_env/killgrave.go
+++ b/docker/test_env/killgrave.go
@@ -122,7 +122,7 @@ func (k *Killgrave) StartContainer() error {
 	if err != nil {
 		return errors.Wrapf(err, "cannot start Killgrave container")
 	}
-	endpoint, err := c.Endpoint(context.Background(), "http")
+	endpoint, err := GetEndpoint(context.Background(), c, "http")
 	if err != nil {
 		return err
 	}

--- a/docker/test_env/mockserver.go
+++ b/docker/test_env/mockserver.go
@@ -90,7 +90,7 @@ func (ms *MockServer) StartContainer() error {
 		return errors.Wrapf(err, "cannot start MockServer container")
 	}
 	ms.Container = c
-	endpoint, err := c.Endpoint(context.Background(), "http")
+	endpoint, err := GetEndpoint(context.Background(), c, "http")
 	if err != nil {
 		return err
 	}

--- a/docker/test_env/non_dev_geth.go
+++ b/docker/test_env/non_dev_geth.go
@@ -300,7 +300,7 @@ func (g *NonDevGethNode) ConnectToClient() error {
 	if ct == nil {
 		return fmt.Errorf("container not started")
 	}
-	host, err := ct.Host(context.Background())
+	host, err := GetHost(context.Background(), ct)
 	if err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func (g *NonDevGethNode) ConnectToClient() error {
 	if err != nil {
 		return err
 	}
-	wsPort, err := getUniqueWsPort(context.Background(), ct, TX_GETH_HTTP_PORT, TX_NON_DEV_GETH_WS_PORT, g.l)
+	wsPort, err := ct.MappedPort(context.Background(), NatPort(TX_NON_DEV_GETH_WS_PORT))
 	if err != nil {
 		return err
 	}
@@ -391,8 +391,7 @@ func (g *NonDevGethNode) getGethContainerRequest() tc.ContainerRequest {
 			"30303/tcp", "30303/udp"},
 		Networks: g.Networks,
 		WaitingFor: tcwait.ForAll(
-			tcwait.NewHTTPStrategy("/").
-				WithPort(NatPort(TX_GETH_HTTP_PORT)),
+			NewHTTPStrategy("/", NatPort(TX_GETH_HTTP_PORT)),
 			tcwait.ForLog("WebSocket enabled"),
 			NewWebSocketStrategy(NatPort(TX_NON_DEV_GETH_WS_PORT), g.l),
 		),

--- a/docker/test_env/postgres.go
+++ b/docker/test_env/postgres.go
@@ -117,7 +117,7 @@ func (pg *PostgresDb) StartContainer() error {
 		return errors.Wrapf(err, "error parsing mercury db internal url")
 	}
 	pg.InternalURL = internalUrl
-	externalUrl, err := url.Parse(fmt.Sprintf("postgres://%s:%s@localhost:%s/%s?sslmode=disable",
+	externalUrl, err := url.Parse(fmt.Sprintf("postgres://%s:%s@127.0.0.1:%s/%s?sslmode=disable",
 		pg.User, pg.Password, externalPort.Port(), pg.DbName))
 	if err != nil {
 		return errors.Wrapf(err, "error parsing mercury db external url")
@@ -136,7 +136,7 @@ func (pg *PostgresDb) StartContainer() error {
 }
 
 func (pg *PostgresDb) ExecPgDump(stdout io.Writer) error {
-	cmd := exec.Command("pg_dump", "-U", pg.User, "-h", "localhost", "-p", pg.ExternalPort, pg.DbName) //nolint:gosec
+	cmd := exec.Command("pg_dump", "-U", pg.User, "-h", "127.0.0.1", "-p", pg.ExternalPort, pg.DbName) //nolint:gosec
 	cmd.Env = []string{
 		fmt.Sprintf("PGPASSWORD=%s", pg.Password),
 	}
@@ -156,7 +156,7 @@ func (pg *PostgresDb) getContainerRequest() *tc.ContainerRequest {
 			"POSTGRES_PASSWORD": pg.Password,
 		},
 		Networks: pg.Networks,
-		WaitingFor: tcwait.ForExec([]string{"psql", "-h", "localhost",
+		WaitingFor: tcwait.ForExec([]string{"psql", "-h", "127.0.0.1",
 			"-U", pg.User, "-c", "select", "1", "-d", pg.DbName}).
 			WithStartupTimeout(10 * time.Second),
 	}

--- a/docker/test_env/schema_registry.go
+++ b/docker/test_env/schema_registry.go
@@ -88,7 +88,7 @@ func (r *SchemaRegistry) StartContainer() error {
 	if err != nil {
 		return errors.Wrapf(err, "cannot start Schema Registry container")
 	}
-	host, err := c.Host(context.Background())
+	host, err := GetHost(context.Background(), c)
 	if err != nil {
 		return err
 	}

--- a/docker/test_env/utils.go
+++ b/docker/test_env/utils.go
@@ -1,9 +1,12 @@
 package test_env
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/go-connections/nat"
+	tc "github.com/testcontainers/testcontainers-go"
 )
 
 func NatPortFormat(port string) string {
@@ -12,4 +15,28 @@ func NatPortFormat(port string) string {
 
 func NatPort(port string) nat.Port {
 	return nat.Port(NatPortFormat(port))
+}
+
+// GetHost returns the host of a container, if localhost then force ipv4 localhost
+// to avoid ipv6 docker bugs https://github.com/moby/moby/issues/42442 https://github.com/moby/moby/issues/42375
+func GetHost(ctx context.Context, container tc.Container) (string, error) {
+	host, err := container.Host(ctx)
+	if err != nil {
+		return "", err
+	}
+	// if localhost then force it to ipv4 localhost
+	if host == "localhost" {
+		host = "127.0.0.1"
+	}
+	return host, nil
+}
+
+// GetEndpoint returns the endpoint of a container, if localhost then force ipv4 localhost
+// to avoid ipv6 docker bugs https://github.com/moby/moby/issues/42442 https://github.com/moby/moby/issues/42375
+func GetEndpoint(ctx context.Context, container tc.Container, endpointType string) (string, error) {
+	endpoint, err := container.Endpoint(ctx, endpointType)
+	if err != nil {
+		return "", err
+	}
+	return strings.Replace(endpoint, "localhost", "127.0.0.1", 1), nil
 }


### PR DESCRIPTION
Fixes issues with port mappings out of sync between ipv4 and ipv6
Docker can provide ipv4 and ipv6 ports for the same container that are different. This in combination with using localhost which will convert to either 127.0.0.1 or ::1 depending on the current port priority. This means sometimes we get containers we don't expect when the ipv4 and ipv6 ports are not the same and localhost uses ipv6.