### PR TITLE
ignore geth and loki vulerabilities since we cannot easily fix them now

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -6,3 +6,6 @@ CVE-2022-37450 # Geth bug that only affects nodes used for mining
 CVE-2021-42219 # Uncontrolled Resource Consumption ('Resource Exhaustion')
 CVE-2020-28483 # Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
 CVE-2022-29153 # Server-Side Request Forgery (SSRF)
+CVE-2023-3518 # CWE-Other (when using JWT Auth for service mesh incorrectly allows/denies access regardless of service identities) -- coming from WASP
+CVE-2023-40591 # CWE-400 Uncontrolled Resource Consumption ('Resource Exhaustion') by geth (fixed in v1.12.2, which needs core to bump that dep first)
+CVE-2023-42319 # CWE-400 Uncontrolled Resource Consumption ('Resource Exhaustion') by geth (fixed in v1.12.2, which needs core to bump that dep first)


### PR DESCRIPTION
why ignore?

1) The library with vulnerablilty is used by our Loki dependency, which is in version v1.6.2, but latest release is v.2.9.2 so I didn't want to get into updating the major version (yet).

2) Since this field doesn't exist in `.../toml/config.go` of `go-ethereum` anymore
```
txpool.DefaultConfig
```

I'll add that geth vulnerability to ignored ones and create a ticket in JIRA to remove it once `chainlink-core`'s [PR](https://github.com/smartcontractkit/chainlink/pull/10264) is merged. 

I don't like having vulnerability check always red.