### PR TITLE
set env var for rpcs in remote runner

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -701,10 +701,7 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 		if !strings.Contains(networkKeys[i], "SIMULATED") {
 			// Get network RPC WS URL from env var
 			wsEnvVar := fmt.Sprintf("%s_URLS", networkKeys[i])
-			wsEnvVal, err := osutil.GetEnv(wsEnvVar)
-			if err != nil {
-				panic(fmt.Errorf("error getting %s var: %w", wsEnvVar, err))
-			}
+			wsEnvVal, _ := osutil.GetEnv(wsEnvVar)
 			if wsEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_URLS")
@@ -722,10 +719,7 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network RPC HTTP URL from env var
 			httpEnvVar := fmt.Sprintf("%s_HTTP_URLS", networkKeys[i])
-			httpEnvVal, err := osutil.GetEnv(httpEnvVar)
-			if err != nil {
-				panic(fmt.Errorf("error getting %s var: %w", httpEnvVar, err))
-			}
+			httpEnvVal, _ := osutil.GetEnv(httpEnvVar)
 			if httpEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_HTTP_URLS")
@@ -743,10 +737,7 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network wallet key from env var
 			walletKeysEnvVar := fmt.Sprintf("%s_KEYS", networkKeys[i])
-			walletKeysEnvVal, err := osutil.GetEnv(walletKeysEnvVar)
-			if err != nil {
-				panic(fmt.Errorf("error getting %s var: %w", walletKeysEnvVar, err))
-			}
+			walletKeysEnvVal, _ := osutil.GetEnv(walletKeysEnvVar)
 			if walletKeysEnvVal == "" {
 				// Get default value
 				defaultKeys, err := osutil.GetEnv("EVM_KEYS")

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -701,7 +701,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 		if !strings.Contains(networkKeys[i], "SIMULATED") {
 			// Get network RPC WS URL from env var
 			wsEnvVar := fmt.Sprintf("%s_URLS", networkKeys[i])
-			wsEnvVal, _ := osutil.GetEnv(wsEnvVar)
+			wsEnvVal, err := osutil.GetEnv(wsEnvVar)
+			if err != nil {
+				log.Warn().Msgf("error getting %s var: %v", wsEnvVar, err)
+			}
 			if wsEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_URLS")
@@ -719,7 +722,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network RPC HTTP URL from env var
 			httpEnvVar := fmt.Sprintf("%s_HTTP_URLS", networkKeys[i])
-			httpEnvVal, _ := osutil.GetEnv(httpEnvVar)
+			httpEnvVal, err := osutil.GetEnv(httpEnvVar)
+			if err != nil {
+				log.Warn().Msgf("error getting %s var: %v", httpEnvVal, err)
+			}
 			if httpEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_HTTP_URLS")
@@ -737,7 +743,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network wallet key from env var
 			walletKeysEnvVar := fmt.Sprintf("%s_KEYS", networkKeys[i])
-			walletKeysEnvVal, _ := osutil.GetEnv(walletKeysEnvVar)
+			walletKeysEnvVal, err := osutil.GetEnv(walletKeysEnvVar)
+			if err != nil {
+				log.Warn().Msgf("error getting %s var: %v", walletKeysEnvVal, err)
+			}
 			if walletKeysEnvVal == "" {
 				// Get default value
 				defaultKeys, err := osutil.GetEnv("EVM_KEYS")

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -701,7 +701,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 		if !strings.Contains(networkKeys[i], "SIMULATED") {
 			// Get network RPC WS URL from env var
 			wsEnvVar := fmt.Sprintf("%s_URLS", networkKeys[i])
-			wsEnvVal := os.Getenv(wsEnvVar)
+			wsEnvVal, err := osutil.GetEnv(wsEnvVar)
+			if err != nil {
+				panic(fmt.Errorf("error getting %s var: %w", wsEnvVar, err))
+			}
 			if wsEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_URLS")
@@ -719,7 +722,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network RPC HTTP URL from env var
 			httpEnvVar := fmt.Sprintf("%s_HTTP_URLS", networkKeys[i])
-			httpEnvVal := os.Getenv(httpEnvVar)
+			httpEnvVal, err := osutil.GetEnv(httpEnvVar)
+			if err != nil {
+				panic(fmt.Errorf("error getting %s var: %w", httpEnvVar, err))
+			}
 			if httpEnvVal == "" {
 				// Get default value
 				defaultUrls, err := osutil.GetEnv("EVM_HTTP_URLS")
@@ -737,7 +743,10 @@ func SetNetworks(networkKeys []string) []blockchain.EVMNetwork {
 
 			// Get network wallet key from env var
 			walletKeysEnvVar := fmt.Sprintf("%s_KEYS", networkKeys[i])
-			walletKeysEnvVal := os.Getenv(walletKeysEnvVar)
+			walletKeysEnvVal, err := osutil.GetEnv(walletKeysEnvVar)
+			if err != nil {
+				panic(fmt.Errorf("error getting %s var: %w", walletKeysEnvVar, err))
+			}
 			if walletKeysEnvVal == "" {
 				// Get default value
 				defaultKeys, err := osutil.GetEnv("EVM_KEYS")


### PR DESCRIPTION
It's painful to set same env vars twice. change all `os.Getenv` to `osutil.GetEnv`