### PR TITLE
Use killgrave 0.4.1

### DIFF
--- a/docker/test_env/killgrave.go
+++ b/docker/test_env/killgrave.go
@@ -136,7 +136,7 @@ func (k *Killgrave) StartContainer() error {
 }
 
 func (k *Killgrave) getContainerRequest() (tc.ContainerRequest, error) {
-	killgraveImage, err := mirror.GetImage("friendsofgo/killgrave")
+	killgraveImage, err := mirror.GetImage("friendsofgo/killgrave:0.4.1")
 	if err != nil {
 		return tc.ContainerRequest{}, err
 	}


### PR DESCRIPTION
New version of killgrave was recently released. But, we are not compatible with it ([errors](https://github.com/smartcontractkit/chainlink/actions/runs/6948551353/job/18912175297?pr=11355)). This PR hardcodes the old version that we used in the past.
