### PR TITLE
[TT-755] grafana url shortener

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -155,24 +155,42 @@ func (l *LokiConfig) ApplyOverrides(from *LokiConfig) error {
 }
 
 type GrafanaConfig struct {
-	Url *string `toml:"url"`
+	BaseUrl      *string `toml:"base_url"`
+	DashboardUrl *string `toml:"dashboard_url"`
+	BearerToken  *string `toml:"bearer_token"`
 }
 
 func (c *GrafanaConfig) ApplyOverrides(from *GrafanaConfig) error {
 	if from == nil {
 		return nil
 	}
-	if from.Url != nil {
-		c.Url = from.Url
+	if from.BaseUrl != nil {
+		c.BaseUrl = from.BaseUrl
+	}
+	if from.DashboardUrl != nil {
+		c.DashboardUrl = from.DashboardUrl
+	}
+	if from.BearerToken != nil {
+		c.BearerToken = from.BearerToken
 	}
 
 	return nil
 }
 
 func (c *GrafanaConfig) Validate() error {
-	if c.Url != nil {
-		if !net.IsValidURL(*c.Url) {
-			return errors.Errorf("invalid grafana url %s", *c.Url)
+	if c.BaseUrl != nil {
+		if !net.IsValidURL(*c.BaseUrl) {
+			return errors.Errorf("invalid grafana url %s", *c.BaseUrl)
+		}
+	}
+	if c.DashboardUrl != nil {
+		if *c.DashboardUrl == "" {
+			return errors.Errorf("if set, grafana dashboard url cannot be an empty string")
+		}
+	}
+	if c.BearerToken != nil {
+		if *c.BearerToken == "" {
+			return errors.Errorf("if set, grafana Bearer token cannot be an empty string")
 		}
 	}
 

--- a/config/tomls/example.toml
+++ b/config/tomls/example.toml
@@ -21,7 +21,7 @@ basic_auth="loki-basic-auth"
 [Logging.Grafana]
 # grafana url (trailing "/" will be stripped)
 base_url="http://grafana.url"
-# url of your grafana dashboard (prefix and suffix "/" are stirpped)
+# url of your grafana dashboard (prefix and suffix "/" are stirpped), example: /d/ad61652-2712-1722/my-dashboard
 dashboard_url="/d/your-dashboard"
 bearer_token="my-awesome-token"
 

--- a/config/tomls/example.toml
+++ b/config/tomls/example.toml
@@ -17,9 +17,13 @@ tenant_id="tenant_id"
 url="https://loki.url"
 basic_auth="loki-basic-auth"
 
+# LogStream will try to shorten Grafana URLs by default (if all 3 variables are set)
 [Logging.Grafana]
-# url of your grafana dashboard
-url="http://grafana.url/your-dashboard"
+# grafana url (trailing "/" will be stripped)
+base_url="http://grafana.url"
+# url of your grafana dashboard (prefix and suffix "/" are stirpped)
+dashboard_url="/d/your-dashboard"
+bearer_token="my-awesome-token"
 
 # if you want to use polygon_mumbial
 [Network]

--- a/logstream/grafana.go
+++ b/logstream/grafana.go
@@ -1,0 +1,43 @@
+package logstream
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	ShorteningFailedErr = "failed to shorten Grafana URL"
+)
+
+func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
+	jsonBody := []byte(`{"path":"` + urlToShorten + `"}`)
+	bodyReader := bytes.NewReader(jsonBody)
+
+	var responseObject struct {
+		Uid string `json:"uid"`
+		Url string `json:"url"`
+	}
+
+	req, err := http.NewRequest(http.MethodPost, grafanaUrl, bodyReader)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+bearerToken)
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
+	}
+
+	defer res.Body.Close()
+	err = json.NewDecoder(res.Body).Decode(&responseObject)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
+	}
+
+	return responseObject.Url, nil
+}

--- a/logstream/grafana.go
+++ b/logstream/grafana.go
@@ -20,7 +20,7 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 		Url string `json:"url"`
 	}
 
-	req, err := http.NewRequest(http.MethodPost, grafanaUrl, bodyReader)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%sapi/short-urls", grafanaUrl), bodyReader)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
 	}
@@ -31,6 +31,10 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("%s: status code: %s", ShorteningFailedErr, res.Status)
 	}
 
 	defer res.Body.Close()

--- a/logstream/logstream.go
+++ b/logstream/logstream.go
@@ -386,8 +386,12 @@ func (m *LogStream) SaveLogTargetsLocations(writer LogWriter) {
 		name := string(handler.GetTarget())
 		location, err := handler.GetLogLocation(m.consumers)
 		if err != nil {
-			m.log.Error().Str("Handler", name).Err(err).Msg("Failed to get log location")
-			continue
+			if strings.Contains(err.Error(), ShorteningFailedErr) {
+				m.log.Warn().Str("Handler", name).Err(err).Msg("Failed to shorten Grafana URL, will use original one")
+			} else {
+				m.log.Error().Str("Handler", name).Err(err).Msg("Failed to get log location")
+				continue
+			}
 		}
 
 		if err := writer(m.testName, name, location); err != nil {

--- a/logstream/logstream_handlers.go
+++ b/logstream/logstream_handlers.go
@@ -165,17 +165,17 @@ func (h *LokiLogHandler) GetLogLocation(consumers map[string]*ContainerLogConsum
 
 	// if no Grafana URL has been set let's at least print query parameters that can be manually added to the dashboard url
 	baseUrl := ""
-	if h.loggingConfig.Grafana.BaseUrl != nil {
+	if h.loggingConfig.Grafana != nil && h.loggingConfig.Grafana.BaseUrl != nil {
 		baseUrl = *h.loggingConfig.Grafana.BaseUrl
 		baseUrl = strings.TrimSuffix(baseUrl, "/")
+		baseUrl = baseUrl + "/"
 	}
 
 	dabshoardUrl := ""
-	if h.loggingConfig.Grafana.DashboardUrl != nil {
+	if h.loggingConfig.Grafana != nil && h.loggingConfig.Grafana.DashboardUrl != nil {
 		dabshoardUrl = *h.loggingConfig.Grafana.DashboardUrl
 		dabshoardUrl = strings.TrimSuffix(dabshoardUrl, "/")
 		dabshoardUrl = strings.TrimPrefix(dabshoardUrl, "/")
-		dabshoardUrl = "/" + dabshoardUrl
 	}
 
 	rangeFrom := time.Now()
@@ -205,16 +205,16 @@ func (h *LokiLogHandler) GetLogLocation(consumers map[string]*ContainerLogConsum
 		sb.WriteString(fmt.Sprintf("&var-test=%s", testName))
 	}
 
+	relativeUrl := sb.String()
+	sb.WriteString(baseUrl)
+	h.grafanaUrl = sb.String()
+
 	// try to shorten the URL only if we have all the required configuration parameters
 	if baseUrl != "" && dabshoardUrl != "" && h.loggingConfig.Grafana.BearerToken != nil {
-		var err error
-		h.grafanaUrl, err = ShortenUrl(baseUrl, sb.String(), *h.loggingConfig.Grafana.BearerToken)
-		// if shortening fails return original URL
-		if err != nil {
-			return sb.String(), err
+		shortened, err := ShortenUrl(baseUrl, relativeUrl, *h.loggingConfig.Grafana.BearerToken)
+		if err == nil {
+			h.grafanaUrl = shortened
 		}
-	} else {
-		h.grafanaUrl = sb.String()
 	}
 
 	return h.grafanaUrl, nil

--- a/logstream/logstream_handlers.go
+++ b/logstream/logstream_handlers.go
@@ -183,6 +183,7 @@ func (h *LokiLogHandler) GetLogLocation(consumers map[string]*ContainerLogConsum
 
 	var sb strings.Builder
 	sb.WriteString(dabshoardUrl)
+	sb.WriteString("?orgId=1&")
 	sb.WriteString(fmt.Sprintf("&var-run_id=%s", *h.loggingConfig.RunId))
 
 	var testName string


### PR DESCRIPTION
LogStream will try to shorten grafana urls, when:
* grafana url is set **AND**
* dashboard url is set **AND**
* bearer token is set

Otherwise it will return partial url (e.g. if base url is not set), full url (if token is not set) or just query parameters (if neither base url nor dashboard url is set).

If shoretning fails original url will be returned.