### PR TITLE
[TT-714] Customisable container start retrying

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -42,27 +43,117 @@ func CreateNetwork(l zerolog.Logger) (*tc.DockerNetwork, error) {
 	return dockerNetwork, nil
 }
 
-func StartContainerWithRetry(l zerolog.Logger, req tc.GenericContainerRequest) (tc.Container, error) {
+type StartContainerRetrier func(l zerolog.Logger, startErr error, req tc.GenericContainerRequest) (tc.Container, error)
+
+var NaiveRetrier = func(l zerolog.Logger, startErr error, req tc.GenericContainerRequest) (tc.Container, error) {
+	l.Debug().
+		Str("Start error", startErr.Error()).
+		Str("Retrier", "NaiveRetrier").
+		Msgf("Attempting to start %s container", req.Name)
+
+	ct, err := tc.GenericContainer(testcontext.Get(nil), req)
+	if err == nil {
+		l.Debug().
+			Str("Retrier", "NaiveRetrier").
+			Msgf("Successfully started %s container", req.Name)
+		return ct, nil
+	}
+	if ct != nil {
+		err := ct.Terminate(testcontext.Get(nil))
+		if err != nil {
+			l.Error().
+				Err(err).
+				Msgf("Cannot terminate %s container to initiate restart", req.Name)
+			return nil, err
+		}
+	}
+	req.Reuse = false
+
+	l.Debug().
+		Str("Original start error", startErr.Error()).
+		Str("Current start error", err.Error()).
+		Str("Retrier", "NaiveRetrier").
+		Msgf("Failed to start %s container,", req.Name)
+
+	return nil, startErr
+}
+
+var LinuxPlatoformImageRetrier = func(l zerolog.Logger, startErr error, req tc.GenericContainerRequest) (tc.Container, error) {
+	// if it's nil we don't know if we can handle it so we won't try
+	if startErr == nil {
+		return nil, startErr
+	}
+
+	// a bit lame, but that's the lame error we get in case there's no specific image for our platform :facepalm:
+	if !strings.Contains(startErr.Error(), "No such image") {
+		l.Debug().
+			Str("Start error", startErr.Error()).
+			Str("Retrier", "PlatoformImageRetrier").
+			Msgf("Won't try to start %s container again, unsupported error", req.Name)
+		return nil, startErr
+	}
+
+	l.Debug().
+		Str("Start error", startErr.Error()).
+		Str("Retrier", "PlatoformImageRetrier").
+		Msgf("Attempting to start %s container", req.Name)
+
+	originalPlatform := req.ImagePlatform
+	req.ImagePlatform = "linux/x86_64"
+
+	ct, err := tc.GenericContainer(testcontext.Get(nil), req)
+	if err == nil {
+		l.Debug().
+			Str("Retrier", "PlatoformImageRetrier").
+			Msgf("Successfully started %s container", req.Name)
+		return ct, nil
+	}
+
+	req.ImagePlatform = originalPlatform
+
+	if ct != nil {
+		err := ct.Terminate(testcontext.Get(nil))
+		if err != nil {
+			l.Error().Err(err).Msgf("Cannot terminate %s container to initiate restart", req.Name)
+			return nil, err
+		}
+	}
+
+	l.Debug().
+		Str("Original start error", startErr.Error()).
+		Str("Current start error", err.Error()).
+		Str("Retrier", "PlatoformImageRetrier").
+		Msgf("Failed to start %s container,", req.Name)
+
+	return nil, startErr
+}
+
+// StartContainerWithRetry attempts to start a container with 3 retry attempts.
+// It will try to start the container with the provided retriers, if none are provided it will use the default retriers.
+// Default being: 1. tries to download image for "linux/x86_64" platform 2. simply starts again without changing anything
+func StartContainerWithRetry(l zerolog.Logger, req tc.GenericContainerRequest, retriers ...StartContainerRetrier) (tc.Container, error) {
 	var ct tc.Container
 	var err error
+
+	ct, err = tc.GenericContainer(testcontext.Get(nil), req)
+	if err == nil {
+		return ct, nil
+	}
+
+	if len(retriers) == 0 {
+		retriers = append(retriers, LinuxPlatoformImageRetrier, NaiveRetrier)
+	}
+
 	for i := 0; i < RetryAttempts; i++ {
-		ct, err = tc.GenericContainer(testcontext.Get(nil), req)
-		if err == nil {
-			break
-		}
 		l.Info().Err(err).Msgf("Cannot start %s container, retrying %d/%d", req.Name, i+1, RetryAttempts)
-		if ct != nil {
-			err := ct.Terminate(testcontext.Get(nil))
-			if err != nil {
-				l.Error().Err(err).Msgf("Cannot terminate %s container to initiate restart", req.Name)
-				return nil, err
+
+		for _, retrier := range retriers {
+			ct, err = retrier(l, err, req)
+			if err == nil {
+				return ct, nil
 			}
 		}
-		// TODO we should dynamically check if container was removed, otherwise retry will fail anyway, just becasuse
-		// container with the same name already exists | that or regenerate container name
-		// But regenerating container name will not help to remove temporary data created on host machine and that can be
-		// a problem if data is stateful
-		req.Reuse = false
 	}
-	return ct, err
+
+	return nil, err
 }

--- a/utils/runid/run_id.go
+++ b/utils/runid/run_id.go
@@ -42,3 +42,29 @@ func GetOrGenerateRunId() (string, error) {
 
 	return runId, nil
 }
+
+func RemoveLocalRunId() error {
+	_, inOs := os.LookupEnv("RUN_ID")
+	if inOs {
+		return nil
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	possiblePath := workingDir + "/.run.id"
+	_, err = os.Stat(possiblePath)
+
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(possiblePath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
For some images we have a situation, when image download fails, because there's no image for our platform (that's the case of CLL image, when you're running on Apple Silicon).  Error message is confusing.

Originally I thought that I could just add `linux/x86_84` image platform to container request, but then I thought that might not be optimal to hard code it.

So instead I added some strategies to retry starting of container. I wanted to do it using chain of responsibility pattern, but that proved impossible without changing method's signature and without having an interface implemented by specific types representing different strategies. So I opted for a simple approach, where each retry strategy is just a function with the same signature. We can pass a vararg of these functions when starting a container and we will try to use all of them in given order until one of them succeeds or we use all retry attempts.