### PR TITLE
Adding evmconfig and fork config into TOML networkConfig

### DIFF
--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -42,43 +42,43 @@ var (
 // EVMNetwork configures all the data the test needs to connect and operate on an EVM compatible network
 type EVMNetwork struct {
 	// Human-readable name of the network:
-	Name string `envconfig:"evm_name" default:"Unnamed EVM Network" toml:"evm_name" json:"evm_name"`
+	Name string `toml:"evm_name" json:"evm_name"`
 	// Chain ID for the blockchain
-	ChainID int64 `envconfig:"evm_chain_id" default:"1337" toml:"evm_chain_id" json:"evm_chain_id"`
+	ChainID int64 `toml:"evm_chain_id" json:"evm_chain_id"`
 	// List of websocket URLs you want to connect to
-	URLs []string `envconfig:"evm_urls" default:"ws://example.url" toml:"evm_urls" json:"evm_urls"`
+	URLs []string `toml:"evm_urls" json:"evm_urls"`
 	// List of websocket URLs you want to connect to
-	HTTPURLs []string `envconfig:"evm_http_urls" default:"http://example.url" toml:"evm_http_urls" json:"evm_http_urls"`
+	HTTPURLs []string `toml:"evm_http_urls" json:"evm_http_urls"`
 	// True if the network is simulated like a geth instance in dev mode. False if the network is a real test or mainnet
-	Simulated bool `envconfig:"evm_simulated" default:"false" toml:"evm_simulated" json:"evm_simulated"`
+	Simulated bool `toml:"evm_simulated" json:"evm_simulated"`
 	// Type of chain client node. Values: "none" | "geth" | "besu"
-	SimulationType string `envconfig:"evm_simulation_type" default:"geth" toml:"evm_simulation_type" json:"evm_simulation_type"`
+	SimulationType string `toml:"evm_simulation_type" json:"evm_simulation_type"`
 	// List of private keys to fund the tests
-	PrivateKeys []string `envconfig:"evm_keys" default:"examplePrivateKey" toml:"evm_keys" json:"evm_keys"`
+	PrivateKeys []string `toml:"evm_keys" json:"evm_keys"`
 	// Default gas limit to assume that Chainlink nodes will use. Used to try to estimate the funds that Chainlink
 	// nodes require to run the tests.
-	ChainlinkTransactionLimit uint64 `envconfig:"evm_chainlink_transaction_limit" default:"500000" toml:"evm_chainlink_transaction_limit" json:"evm_chainlink_transaction_limit"`
+	ChainlinkTransactionLimit uint64 `toml:"evm_chainlink_transaction_limit" json:"evm_chainlink_transaction_limit"`
 	// How long to wait for on-chain operations before timing out an on-chain operation
-	Timeout StrDuration `envconfig:"evm_transaction_timeout" default:"2m" toml:"evm_transaction_timeout" json:"evm_transaction_timeout"`
+	Timeout StrDuration `toml:"evm_transaction_timeout" json:"evm_transaction_timeout"`
 	// How many block confirmations to wait to confirm on-chain events
-	MinimumConfirmations int `envconfig:"evm_minimum_confirmations" default:"1" toml:"evm_minimum_confirmations" json:"evm_minimum_confirmations"`
+	MinimumConfirmations int `toml:"evm_minimum_confirmations" json:"evm_minimum_confirmations"`
 	// How much WEI to add to gas estimations for sending transactions
-	GasEstimationBuffer uint64 `envconfig:"evm_gas_estimation_buffer" default:"1000" toml:"evm_gas_estimation_buffer" json:"evm_gas_estimation_buffer"`
+	GasEstimationBuffer uint64 `toml:"evm_gas_estimation_buffer" json:"evm_gas_estimation_buffer"`
 	// ClientImplementation is the blockchain client to use when interacting with the test chain
-	ClientImplementation ClientImplementation `envconfig:"client_implementation" default:"Ethereum" toml:"client_implementation" json:"client_implementation"`
+	ClientImplementation ClientImplementation `toml:"client_implementation" json:"client_implementation"`
 	// SupportsEIP1559 indicates if the client should try to use EIP1559 style gas and transactions
-	SupportsEIP1559 bool `envconfig:"evm_supports_eip1559" default:"false" toml:"evm_supports_eip1559" json:"evm_supports_eip1559"`
+	SupportsEIP1559 bool `toml:"evm_supports_eip1559" json:"evm_supports_eip1559"`
 
 	// Default gaslimit to use when sending transactions. If set this will override the transactionOptions gaslimit in case the
 	// transactionOptions gaslimit is lesser than the defaultGasLimit.
-	DefaultGasLimit uint64 `envconfig:"evm_default_gas_limit" default:"500000" toml:"evm_default_gas_limit" json:"evm_default_gas_limit"`
+	DefaultGasLimit uint64 `toml:"evm_default_gas_limit" json:"evm_default_gas_limit"`
 	// Few chains use finality tags to mark blocks as finalized. This is used to determine if the chain uses finality tags.
-	FinalityTag bool `envconfig:"evm_finality_tag" default:"false" toml:"evm_finality_tag" json:"evm_finality_tag"`
+	FinalityTag bool `toml:"evm_finality_tag" json:"evm_finality_tag"`
 	// If the chain does not use finality tags, this is used to determine how many blocks to wait for before considering a block finalized.
-	FinalityDepth uint64 `envconfig:"evm_finality_depth" default:"50" toml:"evm_finality_depth" json:"evm_finality_depth"`
+	FinalityDepth uint64 `toml:"evm_finality_depth" json:"evm_finality_depth"`
 
 	// TimeToReachFinality is the time it takes for a block to be considered final. This is used to determine how long to wait for a block to be considered final.
-	TimeToReachFinality StrDuration `envconfig:"evm_time_to_reach_finality" default:"0s" toml:"evm_time_to_reach_finality" json:"evm_time_to_reach_finality"`
+	TimeToReachFinality StrDuration `toml:"evm_time_to_reach_finality" json:"evm_time_to_reach_finality"`
 
 	// Only used internally, do not set
 	URL string `ignored:"true"`

--- a/config/README.md
+++ b/config/README.md
@@ -87,11 +87,38 @@ evm_default_gas_limit = 6000000
 arbitrum_goerli = ["https://devnet-2.mt/ABC/rpc/"]
 new_network = ["http://localhost:8545"]
 
+[RpcWsUrls]
+arbitrum_goerli = ["wss://devnet-2.mt/ABC/ws/"]
+new_network = ["ws://localhost:8546"]
+
 [WalletKeys]
 arbitrum_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
 optimism_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
 new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
 ```
+
+Whenver you are adding a new EVMNetwork to the config, you can either 
+- provide the rpcs and wallet keys in Rpc<Http/Ws>Urls and WalletKeys. Like in the example above, you can see that `new_network` is added to the `selected_networks` and `EVMNetworks` and then the rpcs and wallet keys are provided in `RpcHttpUrls`, `RpcWsUrls` and `WalletKeys` respectively.
+- provide the rpcs and wallet keys in the `EVMNetworks` itself. Like in the example below, you can see that `new_network` is added to the `selected_networks` and `EVMNetworks` and then the rpcs and wallet keys are provided in `EVMNetworks` itself.
+```toml
+
+selected_networks = ["new_network"]
+
+[EVMNetworks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+```
+
 
 If your config struct looks like that:
 ```golang

--- a/config/README.md
+++ b/config/README.md
@@ -45,9 +45,17 @@ Some more explanation is needed for the `NetworkConfig`:
 type NetworkConfig struct {
 	// list of networks that should be used for testing
 	SelectedNetworks []string            `toml:"selected_networks"`
-	// map of network name to RPC endpoints where key is network name and value is a list of RPC HTTP endpoints
+	// map of network name to EVMNetworks where key is network name and value is a pointer to EVMNetwork
+	// if not set, it will try to find the network from defined networks in MappedNetworks under known_networks.go
 	// it doesn't matter if you use `arbitrum_sepolia` or `ARBITRUM_SEPOLIA` or even `arbitrum_SEPOLIA` as key
 	// as all keys will be uppercased when loading the Default config
+	EVMNetworks map[string]*blockchain.EVMNetwork `toml:"EVMNetworks,omitempty"`
+	// map of network name to ForkConfigs where key is network name and value is a pointer to ForkConfig
+	// only used if network fork is needed, if provided, the network will be forked with the given config
+	// networkname is fetched first from the EVMNetworks and 
+	// if not defined with EVMNetworks, it will try to find the network from defined networks in MappedNetworks under known_networks.go
+    ForkConfigs map[string]*ForkConfig `toml:"ForkConfigs,omitempty"`
+	// map of network name to RPC endpoints where key is network name and value is a list of RPC HTTP endpoints
 	RpcHttpUrls      map[string][]string `toml:"RpcHttpUrls"`
 	// map of network name to RPC endpoints where key is network name and value is a list of RPC WS endpoints
 	RpcWsUrls        map[string][]string `toml:"RpcWsUrls"`
@@ -62,14 +70,27 @@ func (n *NetworkConfig) Default() error {
 
 Sample TOML config:
 ```toml
-selected_networks = ["arbitrum_goerli", "optimism_goerli"]
+selected_networks = ["arbitrum_goerli", "optimism_goerli", "new_network"]
+
+[EVMNetworks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
 
 [RpcHttpUrls]
 arbitrum_goerli = ["https://devnet-2.mt/ABC/rpc/"]
+new_network = ["http://localhost:8545"]
 
 [WalletKeys]
 arbitrum_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
 optimism_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
+new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
 ```
 
 If your config struct looks like that:
@@ -83,16 +104,30 @@ type TestConfig struct {
 then your TOML file should look like that:
 ```toml
 [Network]
-selected_networks = ["arbitrum_goerli"]
+selected_networks = ["arbitrum_goerli","new_network"]
+
+[Network.EVMNetworks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
 
 [Network.RpcHttpUrls]
 arbitrum_goerli = ["https://devnet-2.mt/ABC/rpc/"]
+new_network = ["http://localhost:8545"]
 
 [Network.RpcWsUrls]
 arbitrum_goerli = ["ws://devnet-2.mt/ABC/rpc/"]
+new_network = ["ws://localhost:8546"]
 
 [Network.WalletKeys]
 arbitrum_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
+new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
 ```
 
 

--- a/config/README.md
+++ b/config/README.md
@@ -83,6 +83,10 @@ client_implementation = "Ethereum"
 evm_supports_eip1559 = true
 evm_default_gas_limit = 6000000
 
+[ForkConfigs.new_network]
+url = "ws://localhost:8546"
+block_number = 100
+
 [RpcHttpUrls]
 arbitrum_goerli = ["https://devnet-2.mt/ABC/rpc/"]
 new_network = ["http://localhost:8545"]

--- a/config/network.go
+++ b/config/network.go
@@ -17,13 +17,13 @@ const (
 )
 
 type ForkConfig struct {
-	URL              string `toml:"url"`          // URL is the URL of the node to fork from
-	BlockNumber      int64  `toml:"block_number"` // BlockNumber is the block number to fork from
-	BlockTime        int64  `toml:"block_time"`
-	Retries          int    `toml:"retries,omitempty"`
-	Timeout          int64  `toml:"timeout,omitempty"`
-	ComputePerSecond int64  `toml:"compute_per_second,omitempty"`
-	RateLimitEnabled bool   `toml:"rate_limit_enabled,omitempty"`
+	URL              string `toml:"url"`                          // URL is the URL of the node to fork from. Refer to https://book.getfoundry.sh/reference/anvil/#options
+	BlockNumber      int64  `toml:"block_number"`                 // BlockNumber is the block number to fork from. Refer to https://book.getfoundry.sh/reference/anvil/#options
+	BlockTime        int64  `toml:"block_time"`                   // how frequent blocks are mined. By default, it automatically generates a new block as soon as a transaction is submitted. Refer to https://book.getfoundry.sh/reference/anvil/#options
+	Retries          int    `toml:"retries,omitempty"`            //  Number of retry requests for spurious networks (timed out requests). Refer to https://book.getfoundry.sh/reference/anvil/#options
+	Timeout          int64  `toml:"timeout,omitempty"`            //  Timeout in ms for requests sent to remote JSON-RPC server in forking mode. Refer to https://book.getfoundry.sh/reference/anvil/#options
+	ComputePerSecond int64  `toml:"compute_per_second,omitempty"` // Sets the number of assumed available compute units per second for this provider. Refer to https://book.getfoundry.sh/reference/anvil/#options
+	RateLimitEnabled bool   `toml:"rate_limit_enabled,omitempty"` //  rate limiting for this node’s provider. Refer to https://book.getfoundry.sh/reference/anvil/#options
 }
 
 // NetworkConfig is the configuration for the networks to be used
@@ -77,15 +77,15 @@ func (n *NetworkConfig) applyDecoded(configDecoded string) error {
 	if err != nil {
 		return fmt.Errorf("error applying overrides from decoded network config file to config: %w", err)
 	}
-	n.ApplyURLsAndKeysFromEVMNetwork()
+	n.OverrideURLsAndKeysFromEVMNetwork()
 
 	return nil
 }
 
-// ApplyURLsAndKeysFromEVMNetwork applies the URLs and keys from the EVMNetworks to the NetworkConfig
+// OverrideURLsAndKeysFromEVMNetwork applies the URLs and keys from the EVMNetworks to the NetworkConfig
 // it overrides the URLs and Keys present in RpcHttpUrls, RpcWsUrls and WalletKeys in the NetworkConfig
 // with the URLs and Keys provided in the EVMNetworks
-func (n *NetworkConfig) ApplyURLsAndKeysFromEVMNetwork() {
+func (n *NetworkConfig) OverrideURLsAndKeysFromEVMNetwork() {
 	if n.EVMNetworks == nil {
 		return
 	}

--- a/config/network.go
+++ b/config/network.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/logging"
 )
 
 const (
@@ -91,18 +92,21 @@ func (n *NetworkConfig) OverrideURLsAndKeysFromEVMNetwork() {
 	}
 	for name, evmNetwork := range n.EVMNetworks {
 		if evmNetwork.URLs != nil && len(evmNetwork.URLs) > 0 {
+			logging.L.Warn().Str("network", name).Msg("found URLs in EVMNetwork. overriding RPC URLs in RpcWsUrls with EVMNetwork URLs")
 			if n.RpcWsUrls == nil {
 				n.RpcWsUrls = make(map[string][]string)
 			}
 			n.RpcWsUrls[name] = evmNetwork.URLs
 		}
 		if evmNetwork.HTTPURLs != nil && len(evmNetwork.HTTPURLs) > 0 {
+			logging.L.Warn().Str("network", name).Msg("found HTTPURLs in EVMNetwork. overriding RPC URLs in RpcHttpUrls with EVMNetwork HTTP URLs")
 			if n.RpcHttpUrls == nil {
 				n.RpcHttpUrls = make(map[string][]string)
 			}
 			n.RpcHttpUrls[name] = evmNetwork.HTTPURLs
 		}
 		if evmNetwork.PrivateKeys != nil && len(evmNetwork.PrivateKeys) > 0 {
+			logging.L.Warn().Str("network", name).Msg("found PrivateKeys in EVMNetwork. overriding wallet keys in WalletKeys with EVMNetwork private keys")
 			if n.WalletKeys == nil {
 				n.WalletKeys = make(map[string][]string)
 			}

--- a/config/network.go
+++ b/config/network.go
@@ -196,20 +196,22 @@ func (n *NetworkConfig) UpperCaseNetworkNames() {
 	upperCaseMapKeys(n.RpcWsUrls)
 	upperCaseMapKeys(n.WalletKeys)
 
+	for network := range n.EVMNetworks {
+		if network != strings.ToUpper(network) {
+			n.EVMNetworks[strings.ToUpper(network)] = n.EVMNetworks[network]
+			delete(n.EVMNetworks, network)
+		}
+	}
+
+	for network := range n.ForkConfigs {
+		if network != strings.ToUpper(network) {
+			n.ForkConfigs[strings.ToUpper(network)] = n.ForkConfigs[network]
+			delete(n.ForkConfigs, network)
+		}
+	}
+
 	for i, network := range n.SelectedNetworks {
 		n.SelectedNetworks[i] = strings.ToUpper(network)
-		if _, ok := n.EVMNetworks[network]; ok {
-			if network != strings.ToUpper(network) {
-				n.EVMNetworks[strings.ToUpper(network)] = n.EVMNetworks[network]
-				delete(n.EVMNetworks, network)
-			}
-		}
-		if _, ok := n.ForkConfigs[network]; ok {
-			if network != strings.ToUpper(network) {
-				n.ForkConfigs[strings.ToUpper(network)] = n.ForkConfigs[network]
-				delete(n.ForkConfigs, network)
-			}
-		}
 	}
 }
 

--- a/config/network.go
+++ b/config/network.go
@@ -31,10 +31,10 @@ type NetworkConfig struct {
 	SelectedNetworks []string `toml:"selected_networks"`
 	// EVMNetworks is the configuration for the EVM networks, key is the network name as declared in selected_networks slice.
 	// if not set, it will try to find the network from defined networks in MappedNetworks under known_networks.go
-	EVMNetworks map[string]*blockchain.EVMNetwork `toml:"evm_networks,omitempty"`
+	EVMNetworks map[string]*blockchain.EVMNetwork `toml:"EVMNetworks,omitempty"`
 	// ForkConfigs is the configuration for forking from a node,
 	// key is the network name as declared in selected_networks slice
-	ForkConfigs map[string]*ForkConfig `toml:"fork_config,omitempty"`
+	ForkConfigs map[string]*ForkConfig `toml:"ForkConfigs,omitempty"`
 	// RpcHttpUrls is the RPC HTTP endpoints for each network,
 	// key is the network name as declared in selected_networks slice
 	RpcHttpUrls map[string][]string `toml:"RpcHttpUrls"`

--- a/logging/default_logger.go
+++ b/logging/default_logger.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	LogLevelEnvVar = "TEST_LOG_LEVEL"
+)
+
+var (
+	L zerolog.Logger
+)
+
+func init() {
+	initDefaultLogging()
+}
+
+func initDefaultLogging() {
+	lvlStr := os.Getenv(LogLevelEnvVar)
+	if lvlStr == "" {
+		lvlStr = "info"
+	}
+	lvl, err := zerolog.ParseLevel(lvlStr)
+	if err != nil {
+		panic(err)
+	}
+	L = log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).Level(lvl)
+}

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -861,7 +861,7 @@ func MustSetNetworks(networkCfg config.NetworkConfig) []blockchain.EVMNetwork {
 				continue
 			}
 		}
-
+		// if there is no evm_network config, use the known networks to find the network config from the map
 		if knownNetwork, valid := MappedNetworks[networkName]; valid {
 			err := NewEVMNetwork(&knownNetwork, walletKeys, httpUrls, wsUrls)
 			if err != nil {
@@ -870,6 +870,7 @@ func MustSetNetworks(networkCfg config.NetworkConfig) []blockchain.EVMNetwork {
 			networks = append(networks, knownNetwork)
 			continue
 		}
+		// if network is not found in known networks or in toml's evm_network config, panic
 		panic(fmt.Errorf("no evm_network config found in network config. "+
 			"network '%s' is not a valid network. "+
 			"Use valid network(s) separated by comma from %v "+

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -810,7 +810,7 @@ var (
 		"NEXON_TEST":            NexonTest,
 		"NEXON_QA":              NexonQa,
 		"NEXON_STAGE":           NexonStage,
-    "GNOSIS_CHIADO":         GnosisChiado,
+		"GNOSIS_CHIADO":         GnosisChiado,
 		"GNOSIS_MAINNET":        GnosisMainnet,
 	}
 )
@@ -820,14 +820,14 @@ func MustGetSelectedNetworkConfig(networkCfg *config.NetworkConfig) []blockchain
 	if networkCfg == nil || len(networkCfg.SelectedNetworks) == 0 {
 		panic(fmt.Errorf("network config has no or empty selected networks. Use valid network(s) separated by comma from %v", getValidNetworkKeys()))
 	}
-	nets, err := MustSetNetworks(*networkCfg)
+	nets, err := SetNetworks(*networkCfg)
 	if err != nil {
 		panic(err)
 	}
 	return nets
 }
 
-func MustSetNetworks(networkCfg config.NetworkConfig) ([]blockchain.EVMNetwork, error) {
+func SetNetworks(networkCfg config.NetworkConfig) ([]blockchain.EVMNetwork, error) {
 	networks := make([]blockchain.EVMNetwork, 0)
 	selectedNetworks := networkCfg.SelectedNetworks
 	for i := range selectedNetworks {

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -884,8 +884,8 @@ func MustSetNetworks(networkCfg config.NetworkConfig) ([]blockchain.EVMNetwork, 
 	return networks, nil
 }
 
+// NewEVMNetwork sets the network's private key(s) and rpc urls
 func NewEVMNetwork(network *blockchain.EVMNetwork, walletKeys, httpUrls, wsUrls []string) error {
-	// Overwrite network default values
 	if len(httpUrls) > 0 {
 		network.HTTPURLs = httpUrls
 	}

--- a/networks/known_networks_test.go
+++ b/networks/known_networks_test.go
@@ -220,24 +220,19 @@ func TestNewEVMNetwork(t *testing.T) {
 	}()
 
 	t.Run("valid networkKey", func(t *testing.T) {
-		network, err := NewEVMNetwork("VALID_KEY", nil, nil, nil)
+		network := MappedNetworks["VALID_KEY"]
+		err := NewEVMNetwork(&network, nil, nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, MappedNetworks["VALID_KEY"].HTTPURLs, network.HTTPURLs)
 		require.Equal(t, MappedNetworks["VALID_KEY"].URLs, network.URLs)
-	})
-
-	t.Run("invalid networkKey", func(t *testing.T) {
-		_, err := NewEVMNetwork("INVALID_KEY", nil, nil, nil)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "network key: 'INVALID_KEY' is invalid")
 	})
 
 	t.Run("overwriting default values", func(t *testing.T) {
 		walletKeys := []string{"1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"}
 		httpUrls := []string{"http://newurl.com"}
 		wsUrls := []string{"ws://newwsurl.com"}
-
-		network, err := NewEVMNetwork("VALID_KEY", walletKeys, httpUrls, wsUrls)
+		network := MappedNetworks["VALID_KEY"]
+		err := NewEVMNetwork(&network, walletKeys, httpUrls, wsUrls)
 		require.NoError(t, err)
 		require.Equal(t, httpUrls, network.HTTPURLs)
 		require.Equal(t, wsUrls, network.URLs)

--- a/networks/known_networks_test.go
+++ b/networks/known_networks_test.go
@@ -293,7 +293,7 @@ func TestVariousNetworkConfig(t *testing.T) {
 			networkConfigTOML: `
 selected_networks = ["KROMA_SEPOLIA"]
 
-[fork_config.KROMA_SEPOLIA]
+[ForkConfigs.KROMA_SEPOLIA]
 url = "ws://localhost:8546"
 block_number = 100
 `,
@@ -305,7 +305,7 @@ block_number = 100
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_simulated = true
@@ -316,7 +316,7 @@ evm_gas_estimation_buffer = 10000
 evm_supports_eip1559 = true
 evm_default_gas_limit = 6000000
 
-[fork_config.new_network]
+[ForkConfigs.new_network]
 url = "ws://localhost:8546"
 block_number = 100
 `,
@@ -327,7 +327,7 @@ block_number = 100
 			networkConfigTOML: `
 selected_networks = ["new_network","arbitrum_goerli", "optimism_goerli"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_urls = ["ws://localhost:8546"]
@@ -362,7 +362,7 @@ optimism_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b6
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_urls = ["ws://localhost:8546"]
 evm_http_urls = ["http://localhost:8545"]
@@ -382,7 +382,7 @@ evm_default_gas_limit = 6000000
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_urls = ["ws://localhost:8546"]
@@ -402,7 +402,7 @@ evm_default_gas_limit = 6000000
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
@@ -421,7 +421,7 @@ evm_default_gas_limit = 6000000
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_urls = ["ws://localhost:8546"]
@@ -449,7 +449,7 @@ new_network = ["something random"]
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_urls = ["ws://localhost:8546"]
@@ -470,7 +470,7 @@ evm_default_gas_limit = 6000000
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_urls = ["ws://localhost:8546"]
@@ -493,7 +493,7 @@ new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 			networkConfigTOML: `
 selected_networks = ["new_network"]
 
-[evm_networks.new_network]
+[EVMNetworks.new_network]
 evm_name = "new_test_network"
 evm_chain_id = 100009
 evm_simulated = true

--- a/networks/known_networks_test.go
+++ b/networks/known_networks_test.go
@@ -239,3 +239,306 @@ func TestNewEVMNetwork(t *testing.T) {
 		require.Equal(t, walletKeys, network.PrivateKeys)
 	})
 }
+
+func TestVariousNetworkConfig(t *testing.T) {
+	newNetwork := blockchain.EVMNetwork{
+		Name:                      "new_test_network",
+		ChainID:                   100009,
+		Simulated:                 true,
+		ChainlinkTransactionLimit: 5000,
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		HTTPURLs: []string{
+			"http://localhost:8545",
+		},
+		URLs: []string{
+			"ws://localhost:8546",
+		},
+		SupportsEIP1559: true,
+		DefaultGasLimit: 6000000,
+		PrivateKeys: []string{
+			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+		},
+	}
+	forkedNetwork := newNetwork
+	forkedNetwork.HTTPURLs = nil
+	forkedNetwork.URLs = nil
+	forkedNetwork.PrivateKeys = nil
+
+	defer func() {
+		ArbitrumGoerli.URLs = []string{}
+		ArbitrumGoerli.HTTPURLs = []string{}
+		ArbitrumGoerli.PrivateKeys = []string{}
+		OptimismGoerli.URLs = []string{}
+		OptimismGoerli.HTTPURLs = []string{}
+		OptimismGoerli.PrivateKeys = []string{}
+	}()
+	ArbitrumGoerli.URLs = []string{"wss://devnet-1.mt/ABC/rpc/"}
+	ArbitrumGoerli.HTTPURLs = []string{"https://devnet-1.mt/ABC/rpc/"}
+	ArbitrumGoerli.PrivateKeys = []string{"1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"}
+	OptimismGoerli.URLs = []string{"wss://devnet-1.mt/ABC/rpc/"}
+	OptimismGoerli.HTTPURLs = []string{"https://devnet-1.mt/ABC/rpc/"}
+	OptimismGoerli.PrivateKeys = []string{"1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"}
+
+	testcases := []struct {
+		name                 string
+		networkConfigTOML    string
+		isNetworkConfigError bool
+		isEVMNetworkError    bool
+		expNetworks          []blockchain.EVMNetwork
+	}{
+		{
+			name: "forked network for existing network",
+			networkConfigTOML: `
+selected_networks = ["KROMA_SEPOLIA"]
+
+[fork_config.KROMA_SEPOLIA]
+url = "ws://localhost:8546"
+block_number = 100
+`,
+			expNetworks: []blockchain.EVMNetwork{KromaSepolia},
+		},
+
+		{
+			name: "forked network for new network",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_simulated = true
+client_implementation = "Ethereum"
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+
+[fork_config.new_network]
+url = "ws://localhost:8546"
+block_number = 100
+`,
+			expNetworks: []blockchain.EVMNetwork{forkedNetwork},
+		},
+		{
+			name: "existing network and new network together in one config",
+			networkConfigTOML: `
+selected_networks = ["new_network","arbitrum_goerli", "optimism_goerli"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+client_implementation = "Ethereum"
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+
+[RpcHttpUrls]
+arbitrum_goerli = ["https://devnet-1.mt/ABC/rpc/"]
+optimism_goerli = ["https://devnet-1.mt/ABC/rpc/"]
+
+[RpcWsUrls]
+arbitrum_goerli = ["wss://devnet-1.mt/ABC/rpc/"]
+optimism_goerli = ["wss://devnet-1.mt/ABC/rpc/"]
+
+[WalletKeys]
+arbitrum_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
+optimism_goerli = ["1810868fc221b9f50b5b3e0186d8a5f343f892e51ce12a9e818f936ec0b651ed"]
+		`,
+			expNetworks: []blockchain.EVMNetwork{
+				newNetwork, ArbitrumGoerli, OptimismGoerli,
+			},
+		},
+		{
+			name: "new network with empty chain id",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+client_implementation = "Ethereum"
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+		`,
+			isNetworkConfigError: true,
+		},
+		{
+			name: "new network with empty client implementation",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+		`,
+			isNetworkConfigError: true,
+		},
+		{
+			name: "new network without rpc urls",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+`,
+			isNetworkConfigError: true,
+		},
+		{
+			name: "new network with rpc urls and wallet keys both in EVMNetworks and Rpc<Http/Ws>Urls and WalletKeys",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+
+[RpcHttpUrls]
+new_network = ["http://localhost:iamnotvalid"]
+[RpcWsUrls]
+new_network = ["ws://localhost:iamnotvalid"]
+[WalletKeys]
+new_network = ["something random"]
+`,
+			expNetworks: []blockchain.EVMNetwork{newNetwork},
+		},
+		{
+			name: "new network with rpc urls and wallet keys in EVMNetworks",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_keys = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+`,
+			expNetworks: []blockchain.EVMNetwork{newNetwork},
+		},
+		{
+			name: "new network with rpc urls in EVMNetworks and wallet keys in WalletKeys NetworkConfig",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_urls = ["ws://localhost:8546"]
+evm_http_urls = ["http://localhost:8545"]
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+
+[WalletKeys]
+new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+`,
+			expNetworks: []blockchain.EVMNetwork{newNetwork},
+		},
+		{
+			name: "new network with rpc urls and wallet keys in NetworkConfig",
+			networkConfigTOML: `
+selected_networks = ["new_network"]
+
+[evm_networks.new_network]
+evm_name = "new_test_network"
+evm_chain_id = 100009
+evm_simulated = true
+evm_chainlink_transaction_limit = 5000
+evm_minimum_confirmations = 1
+evm_gas_estimation_buffer = 10000
+client_implementation = "Ethereum"
+evm_supports_eip1559 = true
+evm_default_gas_limit = 6000000
+
+[RpcHttpUrls]
+new_network = ["http://localhost:8545"]
+[RpcWsUrls]
+new_network = ["ws://localhost:8546"]
+[WalletKeys]
+new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"]
+`,
+			expNetworks: []blockchain.EVMNetwork{newNetwork},
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString([]byte(tc.networkConfigTOML))
+			err := os.Setenv("BASE64_NETWORK_CONFIG", encoded)
+			require.NoError(t, err, "error setting env var")
+
+			networkCfg := &config.NetworkConfig{}
+			networkCfg.UpperCaseNetworkNames()
+			err = networkCfg.Default()
+			require.NoError(t, err, "error setting default network config")
+			err = networkCfg.Validate()
+			if tc.isNetworkConfigError {
+				require.Error(t, err, "expected network config error")
+				return
+			}
+			require.NoError(t, err, "error validating network config")
+			actualNets, err := MustSetNetworks(*networkCfg)
+			if tc.isEVMNetworkError {
+				t.Log(err)
+				require.Error(t, err, "expected evmNetwork set up error")
+				return
+			}
+			require.NoError(t, err, "unexpected error")
+			require.Equal(t, tc.expNetworks, actualNets, "unexpected networks")
+		})
+	}
+}

--- a/networks/known_networks_test.go
+++ b/networks/known_networks_test.go
@@ -531,7 +531,7 @@ new_network = ["ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 				return
 			}
 			require.NoError(t, err, "error validating network config")
-			actualNets, err := MustSetNetworks(*networkCfg)
+			actualNets, err := SetNetworks(*networkCfg)
 			if tc.isEVMNetworkError {
 				t.Log(err)
 				require.Error(t, err, "expected evmNetwork set up error")


### PR DESCRIPTION
With this change we will be able to directly add EVMNetwork from test input toml. While config setting, from the `selected_networks` list, the network names will be first searched in `evm_networks` list passed in toml and if not found it will try to locate it in `MappedNetworks` under `known_networks.go`. If not found in both , it will throw error.
Also added fork config input in networkconfig. 
Added a test `TestVariousNetworkConfig` to demonstrate various toml inputs.