### PR TITLE
TT-916 Add _secret suffix to secrets in toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ When using `in-memory` or `file` target no other configuration variables are req
 [Logging.Loki]
 tenant_id="promtail"
 url="https://change.me"
-basic_auth="my-secret-auth"
-bearer_token="bearer-token"
+basic_auth_secret="my-secret-auth"
+bearer_token_secret="bearer-token"
 ```
 
 Also, do remember that different URL should be used when running in CI and everywhere else. In CI it should be a public endpoint, while in local environment it should be a private one.

--- a/config/README.md
+++ b/config/README.md
@@ -23,6 +23,10 @@ It's up to the user to provide a way to read the config from file and unmarshal 
 
 Also you might find `BytesToAnyTomlStruct(logger zerolog.Logger, filename, configurationName string, target any, content []byte) error` utility method useful for unmarshalling TOMLs read from env var or files into a struct
 
+## Secrets in TOML config
+
+For all values regarded as secrets, their keys should end with the `_secret` suffix. For example, use `basic_auth_secret="basic-auth"` instead of `basic_auth="basic-auth"`.
+
 ## Working example
 
 For a full working example making use of all the building blocks see [testconfig.go](../config/examples/testconfig.go). It provides methods for reading TOML, applying overrides and validating non-empty config blocks. It supports 4 levels of overrides, in order of precedence:
@@ -150,7 +154,7 @@ version="$CHAINLINK_VERSION"
 enabled=$pyroscope_enabled
 server_url="$PYROSCOPE_SERVER"
 environment="$PYROSCOPE_ENVIRONMENT"
-key="$PYROSCOPE_KEY"
+key_secret="$PYROSCOPE_KEY"
 
 [Logging]
 test_log_collect=$test_log_collect
@@ -162,8 +166,8 @@ log_targets=$log_targets
 [Logging.Loki]
 tenant_id="$LOKI_TENANT_ID"
 url="$LOKI_URL"
-basic_auth="$LOKI_BASIC_AUTH"
-bearer_token="$LOKI_BEARER_TOKEN"
+basic_auth_secret="$LOKI_BASIC_AUTH"
+bearer_token_secret="$LOKI_BEARER_TOKEN"
 
 [Logging.Grafana]
 url="$GRAFANA_URL"

--- a/config/examples/example.toml
+++ b/config/examples/example.toml
@@ -17,9 +17,9 @@ tenant_id="tenant_id"
 # full URL of Loki ingest endpoint
 endpoint="https://loki.url/api/v3/push"
 # currently only needed when using public instance
-basic_auth="loki-basic-auth"
+basic_auth_secret="loki-basic-auth"
 # only needed for cloud grafana
-bearer_token="bearer_token"
+bearer_token_secret="bearer_token"
 
 # LogStream will try to shorten Grafana URLs by default (if all 3 variables are set)
 [Logging.Grafana]
@@ -27,7 +27,7 @@ bearer_token="bearer_token"
 base_url="http://grafana.url"
 # url of your grafana dashboard (prefix and suffix "/" are stirpped), example: /d/ad61652-2712-1722/my-dashboard
 dashboard_url="/d/your-dashboard"
-bearer_token="my-awesome-token"
+bearer_token_secret="my-awesome-token"
 
 # if you want to use polygon_mumbial
 [Network]

--- a/config/logging.go
+++ b/config/logging.go
@@ -68,8 +68,8 @@ func (l *LogStreamConfig) Validate() error {
 type LokiConfig struct {
 	TenantId    *string `toml:"tenant_id"`
 	Endpoint    *string `toml:"endpoint"`
-	BasicAuth   *string `toml:"basic_auth"`
-	BearerToken *string `toml:"bearer_token"`
+	BasicAuth   *string `toml:"basic_auth_secret"`
+	BearerToken *string `toml:"bearer_token_secret"`
 }
 
 // Validate checks that the loki config is valid, which means that
@@ -90,7 +90,7 @@ func (l *LokiConfig) Validate() error {
 type GrafanaConfig struct {
 	BaseUrl      *string `toml:"base_url"`
 	DashboardUrl *string `toml:"dashboard_url"`
-	BearerToken  *string `toml:"bearer_token"`
+	BearerToken  *string `toml:"bearer_token_secret"`
 }
 
 // Validate checks that the grafana config is valid, which means that

--- a/config/pyroscope.go
+++ b/config/pyroscope.go
@@ -10,7 +10,7 @@ import (
 type PyroscopeConfig struct {
 	Enabled     *bool   `toml:"enabled"`
 	ServerUrl   *string `toml:"server_url"`
-	Key         *string `toml:"key"`
+	Key         *string `toml:"key_secret"`
 	Environment *string `toml:"environment"`
 }
 


### PR DESCRIPTION
Mercury keeps secrets directly in TOML configs and uses a [masking script](https://github.com/smartcontractkit/mercury-pipeline/blob/main/.github/scripts/mask_toml_secrets.py#L0-L1) to hide them on Github CI.

In order to reuse TOML object from CTF like GrafanaConfig we need to add _secret suffix to all keys that should be masked on Github.

- [x] Create draft PRs for core, CCIP and Mercury to use new CTF lib and _secret keys. Only these repos are affected ([search query](https://github.com/search?q=org%3Asmartcontractkit++basic_auth%3D&type=code))
- [x] Check if Core works https://github.com/smartcontractkit/chainlink/pull/12043 confirmed with @Tofel 
- [x] Check if CCIP works https://github.com/smartcontractkit/ccip/pull/524 confirmed with @AnieeG 
- [x] Check if Mercury works https://github.com/smartcontractkit/mercury-pipeline/pull/732 @lukaszcl 