### PR TITLE
remove affinity labels

### DIFF
--- a/charts/besu-prysm/Chart.lock
+++ b/charts/besu-prysm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: eth2-common
-  repository: https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
-  version: 0.5.0
-digest: sha256:0abfcaf54d2e80132e61214c1aa08dc78a9a68aaa4c7f6950c6ba47ae823f094
-generated: "2024-03-01T17:04:26.234465-07:00"
+  repository: file://../eth2-common
+  version: 0.5.1
+digest: sha256:67d83fc46f476f62a840293c434f2eaf37feba09a342753895fd30e35c1d412b
+generated: "2024-03-04T18:12:36.014686+01:00"

--- a/charts/besu-prysm/Chart.yaml
+++ b/charts/besu-prysm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Eth2 private network with Besu and Prysm
 name: besu-prysm
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: eth2-common
-    version: 0.5.0
+    version: 0.5.2
     repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/charts/besu-prysm/README.md
+++ b/charts/besu-prysm/README.md
@@ -84,10 +84,8 @@ storage:
 # Usage
 1. Connect with kubectl to the cluster you want to deploy to
 2. Set the context/namespace you want to use (if the namespace doesn't exist you might need to create it manually)
-3. Make sure that there's 1 node with with label `eth2=true` (this is used to schedule beacon chain and validator pods affinity to make sure they are deployed on the same node and have access to the same persistent volume). You can check it by running `kubectl get nodes --selector=eth2=true`. If there's no such node (which will especially be true on your local cluster, when running for the first time), run `kubectl get nodes --show-labels` to see all nodes and then pick one and run `kubectl label nodes <node-name> eth2=true` to add the label to it (for Docker Desktop use: `kubectl label nodes docker-desktop eth2=true`). It's best if you *don't do that* on remote clusters without previous consultation with the cluster owners.
-Once you have one labeled node you can proceed with chart installation.
 3. Run `./install.sh`
-This command uses `values.yaml` file while generating one value on the flight: `currentUnixTimestamp`.
+This command uses `values.yaml` file while generating one value on the fly: `currentUnixTimestamp`. This is super important as all the components need to have the same genesis time.
 
 That script will run lints, prepare a package and then install it.
 

--- a/charts/besu-prysm/templates/besu.statefulset.yaml
+++ b/charts/besu-prysm/templates/besu.statefulset.yaml
@@ -24,8 +24,6 @@ spec:
                 values:
                 - {{ .Release.Name }}
             topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        eth2: "true"
       volumes:
       - name: {{ .Release.Name }}-genesis-config
         configMap:
@@ -94,6 +92,13 @@ spec:
             periodSeconds: 5
             failureThreshold: 2
             timeoutSeconds: 120
+          resources:
+            requests:
+              cpu: 300m
+              memory: 600Mi
+            limits:
+              cpu: 2
+              memory: 4Gi
 
 {{- $customData := dict "pvcName" (printf "%s-%s-besu" .Release.Name .Values.storage.claim) }}
 {{- $newContext := merge $customData . }}

--- a/charts/besu-prysm/values.yaml
+++ b/charts/besu-prysm/values.yaml
@@ -1,12 +1,12 @@
 imagePullPolicy: Always
 eth2-common:
   general:
-    networkId: 1337
+    networkId: 2337
   genesis:
     values:
       currentUnixTimestamp: 1600000000
 general:
-  networkId: 1337
+  networkId: 2337
 shared:
   mnemonic: giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete
   configDataDir: /data/custom_config_data

--- a/charts/eth2-common/Chart.yaml
+++ b/charts/eth2-common/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Elements shared by different eth2 clients
 name: eth2-common
-version: 0.5.1
+version: 0.5.2

--- a/charts/eth2-common/templates/chain-ready.deployment.yaml
+++ b/charts/eth2-common/templates/chain-ready.deployment.yaml
@@ -26,8 +26,6 @@ spec:
                 values:
                 - {{ .Release.Name }}
             topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        eth2: "true"
       containers:
         - name: {{ .Values.ready.name }}
           image: {{ .Values.ready.image.repository }}:{{ .Values.ready.image.tag }}

--- a/charts/eth2-common/templates/prysm-beacon.statefulset.yaml
+++ b/charts/eth2-common/templates/prysm-beacon.statefulset.yaml
@@ -26,8 +26,6 @@ spec:
                 values:
                 - {{ .Release.Name }}
             topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        eth2: "true"
       volumes:
       - name: {{ .Release.Name }}-genesis-config
         configMap:

--- a/charts/eth2-common/templates/prysm-validator.statefulset.yaml
+++ b/charts/eth2-common/templates/prysm-validator.statefulset.yaml
@@ -26,8 +26,6 @@ spec:
                 values:
                 - {{ .Release.Name }}
             topologyKey: kubernetes.io/hostname
-      nodeSelector:
-        eth2: "true"
       volumes:
       - name: {{ .Release.Name }}-genesis-config
         configMap:

--- a/charts/geth-prysm/Chart.yaml
+++ b/charts/geth-prysm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Eth2 private network with Geth and Prysm
 name: geth-prysm
-version: 0.2.1
+version: 0.2.2
 dependencies:
   - name: eth2-common
-    version: 0.5.0
+    version: 0.5.2
     repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/charts/geth-prysm/README.md
+++ b/charts/geth-prysm/README.md
@@ -77,10 +77,8 @@ storage:
 # Usage
 1. Connect with kubectl to the cluster you want to deploy to
 2. Set the context/namespace you want to use (if the namespace doesn't exist you might need to create it manually)
-3. Make sure that there's 1 node with with label `eth2=true` (this is used to schedule beacon chain and validator pods affinity to make sure they are deployed on the same node and have access to the same persistent volume). You can check it by running `kubectl get nodes --selector=eth2=true`. If there's no such node (which will especially be true on your local cluster, when running for the first time), run `kubectl get nodes --show-labels` to see all nodes and then pick one and run `kubectl label nodes <node-name> eth2=true` to add the label to it (for Docker Desktop use: `kubectl label nodes docker-desktop eth2=true`). It's best if you *don't do that* on remote clusters without previous consultation with the cluster owners.
-Once you have one labeled node you can proceed with chart installation.
 3. Run `./install.sh`
-This command uses `values.yaml` file while generating one value on the flight: `currentUnixTimestamp`.
+This command uses `values.yaml` file while generating one value on the fly: `currentUnixTimestamp`. This is super important as all the components need to have the same genesis time.
 
 That script will run lints, prepare a package and then install it.
 


### PR DESCRIPTION
why? we no longer need them now that we are using PVC templates and thus we don't have to manually tell k8s to deploy pods to the same node as where the PVC is