### PR TITLE
fix edge case in evmclient

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -715,8 +715,12 @@ func (e *EthereumClient) IsTxConfirmed(txHash common.Hash) (bool, error) {
 		if receipt.Status == 0 { // 0 indicates failure, 1 indicates success
 			reason, err := e.errorReason(e.Client, tx, receipt)
 			if err != nil {
+				to := "(none)"
+				if tx.To() != nil {
+					to = tx.To().Hex()
+				}
 				e.l.Warn().Str("TX Hash", txHash.Hex()).
-					Str("To", tx.To().Hex()).
+					Str("To", to).
 					Uint64("Nonce", tx.Nonce()).
 					Str("Error extracting reason", err.Error()).
 					Msg("Transaction failed and was reverted! Unable to retrieve reason!")

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -551,7 +552,7 @@ func (e *EthereumClient) errorReason(
 	}
 	_, txError := b.CallContract(context.Background(), callMsg, receipt.BlockNumber)
 	if txError == nil {
-		return "", fmt.Errorf("no error in CallContract: %w", err)
+		return "", errors.New("couldn't find revert reason. CallContract did not fail")
 	}
 	return RPCErrorFromError(txError)
 }


### PR DESCRIPTION
where a nil pointer could be thrown when reverted transaction was a contract deployment