### PR TITLE
[SHIP-1501] Enable X Layer

### DIFF
--- a/blockchain/known_networks.go
+++ b/blockchain/known_networks.go
@@ -26,6 +26,7 @@ const (
 	WeMixClientImplementation        ClientImplementation = "WeMix"
 	KromaClientImplementation        ClientImplementation = "Kroma"
 	GnosisClientImplementation       ClientImplementation = "Gnosis"
+	XLayerClientImplementation       ClientImplementation = "XLayer"
 )
 
 // wrapSingleClient Wraps a single EVM client in its appropriate implementation, based on the chain ID
@@ -66,6 +67,8 @@ func wrapSingleClient(networkSettings EVMNetwork, client *EthereumClient) EVMCli
 		wrappedEc = &KromaClient{client}
 	case GnosisClientImplementation:
 		wrappedEc = &GnosisClient{client}
+	case XLayerClientImplementation:
+		wrappedEc = &XLayerClient{client}
 	default:
 		wrappedEc = client
 	}
@@ -128,6 +131,9 @@ func wrapMultiClient(networkSettings EVMNetwork, client *EthereumMultinodeClient
 	case GnosisClientImplementation:
 		logMsg.Msg("Using Gnosis Client")
 		wrappedEc = &GnosisMultinodeClient{client}
+	case XLayerClientImplementation:
+		logMsg.Msg("Using XLayer Client")
+		wrappedEc = &XLayerMultinodeClient{client}
 	default:
 		log.Warn().Str("Network", networkSettings.Name).Msg("Unknown client implementation, defaulting to standard Ethereum client")
 		wrappedEc = client

--- a/blockchain/xlayer.go
+++ b/blockchain/xlayer.go
@@ -1,0 +1,11 @@
+package blockchain
+
+// XLayerMultinodeClient represents a multi-node, EVM compatible client for the XLayer network
+type XLayerMultinodeClient struct {
+	*EthereumMultinodeClient
+}
+
+// XLayerClient represents a single node, EVM compatible client for the XLayer network
+type XLayerClient struct {
+	*EthereumClient
+}

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -787,6 +787,34 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	XLayerSepolia = blockchain.EVMNetwork{
+		Name:                      "X Layer Sepolia",
+		SupportsEIP1559:           false,
+		ClientImplementation:      blockchain.XLayerClientImplementation,
+		ChainID:                   195,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: time.Minute * 5},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
+	XLayerMainnet = blockchain.EVMNetwork{
+		Name:                      "X Layer Mainnet",
+		SupportsEIP1559:           false,
+		ClientImplementation:      blockchain.XLayerClientImplementation,
+		ChainID:                   196,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: time.Minute * 5},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
 		"SIMULATED_1":             SimulatedEVMNonDev1,
@@ -842,6 +870,8 @@ var (
 		"NEXON_STAGE":           NexonStage,
 		"GNOSIS_CHIADO":         GnosisChiado,
 		"GNOSIS_MAINNET":        GnosisMainnet,
+		"XLAYER_SEPOLIA":        XLayerSepolia,
+		"XLAYER_MAINNET":        XLayerMainnet,
 	}
 )
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes integrate support for a new blockchain client, XLayer, into the system. This includes its incorporation into known networks and the creation of corresponding client classes for single and multi-node setups.

## What
- **blockchain/known_networks.go**
  - Added `XLayerClientImplementation` to the list of client implementations.
  - Implemented the wrapping of single and multi-node clients for XLayer in `wrapSingleClient` and `wrapMultiClient` functions respectively.
- **blockchain/xlayer.go**
  - Introduced new file defining `XLayerClient` and `XLayerMultinodeClient` structs, extending single and multi-node Ethereum client capabilities to the XLayer network.
- **networks/known_networks.go**
  - Added configuration for `XLayerSepolia` and `XLayerMainnet` within the `MappedNetworks` map and as standalone `EVMNetwork` instances, setting up network parameters for the XLayer blockchain on Sepolia testnet and mainnet.
