### PR TITLE
Enable statio user indexes collector for postgres exporter

### DIFF
--- a/lib/charts/chainlink/Chart.yaml
+++ b/lib/charts/chainlink/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.13
+version: 0.2.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lib/charts/chainlink/templates/pg-deployment.yaml
+++ b/lib/charts/chainlink/templates/pg-deployment.yaml
@@ -135,6 +135,7 @@ spec:
         {{- if $.Values.db.enablePrometheusPostgresExporter }}
         - name: prometheus-postgres-exporter
           image: {{ $.Values.prometheusPostgresExporter.image.image }}
+          args: ["--collector.statio_user_indexes"]
           resources:
             requests:
               memory: {{ $.Values.prometheusPostgresExporter.resources.requests.memory }}


### PR DESCRIPTION
Enable statio user indexes collector for prometheus-postgres-exporter to improve visibility for indexes usage.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the Chainlink Helm chart for better customization and monitoring enhancements. Specifically, upgrading the chart version facilitates tracking of improvements or fixes. The addition of arguments for the Prometheus PostgreSQL exporter allows for more detailed database performance monitoring, crucial for maintaining the health and efficiency of the Chainlink node's database.

## What
- **charts/chainlink/Chart.yaml**
  - Incremented the chart version from `0.2.11` to `0.2.12`. This change marks an update or improvement in the Helm chart.
- **charts/chainlink/templates/pg-deployment.yaml**
  - Added an argument `--collector.statio_user_indexes` to the Prometheus PostgreSQL exporter container. This enables the collection of statistics about user-defined indexes, which can help in database performance tuning.
