### PR TITLE
Use newer syntax to update apple sdk in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,8 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; overlays = [ ]; };
-        # The current default sdk for macOS fails to compile go projects, so we use a newer one for now.
-        # This has no effect on other platforms.
-        callPackage = pkgs.darwin.apple_sdk_11_0.callPackage or pkgs.callPackage;
       in rec {
-        devShell = callPackage ./shell.nix {
+        devShell = pkgs.callPackage ./shell.nix {
           inherit pkgs;
           scriptDir = toString ./.;  # This converts the flake's root directory to a string
         };

--- a/shell.nix
+++ b/shell.nix
@@ -5,8 +5,13 @@ let
   postgresql = postgresql_15;
   nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override { inherit nodejs; };
+
+  mkShell' = mkShell.override {
+    # The current nix default sdk for macOS fails to compile go projects, so we use a newer one for now.
+    stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
+  };
 in
-mkShell {
+mkShell' {
   nativeBuildInputs = [
     go
     goreleaser
@@ -47,7 +52,6 @@ mkShell {
 
   LD_LIBRARY_PATH = lib.makeLibraryPath [pkgs.zlib stdenv.cc.cc.lib]; # lib64
   GOROOT = "${go}/share/go";
-  CGO_ENABLED = 0;
   HELM_REPOSITORY_CONFIG = "${scriptDir}/.helm-repositories.yaml";
 
   shellHook = ''


### PR DESCRIPTION
The way we were using before is planned to be deprecated
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance compatibility and address macOS-specific build issues by adjusting the development environment setup for the Chainlink testing framework, particularly focusing on Go projects compilation on macOS.

## What
- **flake.nix**
  - Removed macOS-specific SDK override for compiling Go projects. This change simplifies the setup by removing a condition that was only relevant for macOS users.
  - Updated `devShell` to directly use `pkgs.callPackage` instead of a conditional macOS-specific callPackage. This streamlines the package calling process.
- **shell.nix**
  - Introduced `mkShell'` with a conditional override for the standard environment (`stdenv`) on macOS to use a specified SDK version, addressing the Go projects compilation issue directly within the shell environment configuration.
  - Removed `CGO_ENABLED = 0` from the environment variables. This change might be aimed at leveraging CGO for certain dependencies or features within the projects.
  - Added `mkShell'` usage instead of `mkShell`, applying the newly introduced macOS-specific stdenv override directly in the development shell setup.
