### PR TITLE
Add Celo FinalityDepth

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -478,7 +478,7 @@ var (
 
 	CeloAlfajores = blockchain.EVMNetwork{
 		Name:                      "Celo Alfajores",
-		SupportsEIP1559:           false,
+		SupportsEIP1559:           true,
 		ClientImplementation:      blockchain.CeloClientImplementation,
 		ChainID:                   44787,
 		Simulated:                 false,

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -486,6 +486,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       1000,
+		FinalityDepth:             10,
 	}
 
 	ScrollSepolia = blockchain.EVMNetwork{


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce updates to the blockchain network configurations, specifically adding a finality depth to the Celo Alfajores network and adjustments to various network properties across the board. These changes ensure that the network configurations are current and support the latest blockchain network standards and features.

## What
- **networks/known_networks.go**
  - Added `FinalityDepth: 10,` to `CeloAlfajores` network configuration. This change specifies the finality depth for the Celo Alfajores network, enhancing the reliability of transaction confirmations on this test network.
