### PR TITLE
[TT-1078] allow to pass run id to remove function

### DIFF
--- a/utils/runid/run_id.go
+++ b/utils/runid/run_id.go
@@ -2,11 +2,15 @@ package runid
 
 import (
 	"bufio"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/google/uuid"
 )
 
+// GetOrGenerateRunId returns the runId if it is not nil, otherwise it reads the .run.id file and returns the value, or
+// creates it with a new UUID, saves to file and returns the value.
 func GetOrGenerateRunId(maybeRunId *string) (string, error) {
 	if maybeRunId != nil {
 		return *maybeRunId, nil
@@ -32,7 +36,7 @@ func GetOrGenerateRunId(maybeRunId *string) (string, error) {
 		return runId, nil
 	}
 
-	runId = uuid.NewString()
+	runId = fmt.Sprintf("local_%s", uuid.NewString())
 
 	if _, err := file.WriteString(runId); err != nil {
 		return "", err
@@ -41,9 +45,10 @@ func GetOrGenerateRunId(maybeRunId *string) (string, error) {
 	return runId, nil
 }
 
-func RemoveLocalRunId() error {
-	_, inOs := os.LookupEnv("RUN_ID")
-	if inOs {
+// RemoveLocalRunId removes the .run.id file if it exists and the runId contains 'local' substring indiciating local execution.
+// In GHA we get run_id from TOML config, so we don't need to remove the file.
+func RemoveLocalRunId(runId *string) error {
+	if runId != nil && !strings.Contains(*runId, "local") {
 		return nil
 	}
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the run ID generation and removal logic by making it more robust and context-aware. Specifically, enhancing the run ID to include a "local_" prefix for locally generated IDs and adjusting the removal logic to check if the run ID indicates local execution.

## What
- `utils/runid/run_id.go`
  - Added `fmt` and `strings` packages to support new logic.
  - Updated `GetOrGenerateRunId` function to prefix the generated UUID with "local_" indicating it was generated in a local context.
  - Changed `RemoveLocalRunId` function to accept a `runId` parameter and updated logic to only remove the `.run.id` file if the `runId` contains the substring "local", making the removal conditional on the run ID indicating it's from a local context. This change ensures that cleanup happens only when appropriate, avoiding unintended deletions in non-local environments.
