### PR TITLE
set EIP-1559 to not supported in network config for Geth v1.10.x and …

### DIFF
--- a/docker/test_env/geth_base.go
+++ b/docker/test_env/geth_base.go
@@ -115,6 +115,11 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, error) {
 		networkConfig.DefaultGasLimit = 9_000_000
 	}
 
+	if comparableVersion < 110 {
+		// eth_maxPriorityFeePerGas is not implemented in Geth v1.10.x or lower
+		networkConfig.SupportsEIP1559 = false
+	}
+
 	g.l.Info().Str("containerName", g.ContainerName).
 		Msg("Started Geth PoS container")
 


### PR DESCRIPTION
…lower
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure compatibility and accurate configuration for different versions of Geth within test environments, specifically addressing network configuration based on the Geth version being used.

## What
- **docker/test_env/geth_base.go**
  - Added condition to set `networkConfig.SupportsEIP1559 = false` if `comparableVersion < 110`. This adjustment ensures that the test environment correctly reflects the capabilities of Geth versions prior to 1.10.x, where `eth_maxPriorityFeePerGas` is not implemented.
