### PR TITLE
bring back reorg values

### DIFF
--- a/k8s/pkg/helm/reorg/reorg.go
+++ b/k8s/pkg/helm/reorg/reorg.go
@@ -14,6 +14,12 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/projectpath"
 )
 
+const (
+	URLsKey            = "geth"
+	TXNodesAppLabel    = "geth-ethereum-geth"
+	MinerNodesAppLabel = "geth-ethereum-miner-node" // #nosec G101
+)
+
 type Props struct {
 	NetworkName string `envconfig:"network_name"`
 	NetworkType string `envconfig:"network_type"`


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce constants defining key values related to Geth URLs and application labels for TXNodes and MinerNodes within a Helm chart reorganization context. This aims to improve code readability and maintainability by centralizing the definition of these critical identifiers.

## What
- **k8s/pkg/helm/reorg/reorg.go**
  - Added constants `URLsKey`, `TXNodesAppLabel`, and `MinerNodesAppLabel` with values `"geth"`, `"geth-ethereum-geth"`, and `"geth-ethereum-miner-node"` respectively. These changes establish clear, centralized references for these identifiers, which are presumably used throughout the Helm chart reorganization logic.
