### PR TITLE
go-lint pre-commit fix the fix command and show issues

### DIFF
--- a/.githooks/go-lint
+++ b/.githooks/go-lint
@@ -6,13 +6,15 @@ find "./" -type f -name 'go.mod' -print0 | while IFS= read -r -d $'\0' file; do
     cd "$directory" || exit 1
 
     # Run linter and capture exit status
-    golangci-lint run > /dev/null
+    set +e
+    golangci-lint run
     linting_result=$?
+    set -e
 
     # Check linting result
     if [[ $linting_result -ne 0 ]]; then
         echo -e "Executing linters in $directory... \e[31mNOK!\e[0m\n"
-        echo -e "Run \`cd $directory && golangci-lint run -fix -v\` and fix the issues\n"
+        echo -e "Run \`cd $directory && golangci-lint run --fix -v\` and fix the issues\n"
         exit 1
     else
         echo -e "Executing linters in $directory... \e[32mOK!\e[0m\n"

--- a/.githooks/go-mod-tidy
+++ b/.githooks/go-mod-tidy
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-set -e
+set +e
 
 # Find all 'go.mod' files, get their directories, and run 'go mod tidy'
 find "./" -type f -name 'go.mod' -print0 | while IFS= read -r -d $'\0' file; do
     dir=$(dirname "$file")
     echo "Executing cd \"$dir\" && go mod tidy"
-    cd "$dir"
+    cd "$dir" || exit 1
     go mod tidy
-    cd -
+    cd - || exit 1
 done
 # pre-commit stashes changes before running the hooks so we can use git to check for changes here
 # Run git diff and capture output


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve error handling and output clarity in the git hooks for Go language projects, ensuring that linting and dependency management tasks are more robust and informative.

## What
- **.githooks/go-lint**
  - Added `set +e` and `set -e` to temporarily disable script exit on error around the `golangci-lint run` command. This change allows the script to handle errors more gracefully.
  - Updated the `golangci-lint run` command to output directly to the console instead of redirecting to `/dev/null`. This modification provides immediate feedback on linting issues.
  - Corrected the `golangci-lint run` help message by adding `--fix` to the suggested command, making it clearer how to automatically fix some issues.
- **.githooks/go-mod-tidy**
  - Changed from `set -e` to `set +e` at the start of the script, aligning error handling behavior with the go-lint hook for consistency.
  - Added error handling for `cd` commands using `|| exit 1`, which ensures the script exits if changing directories fails, preventing potential misexecution in the wrong directory.
