### PR TITLE
[TT-979] Geth pass helm chart version when simulated

### DIFF
--- a/k8s/pkg/helm/ethereum/geth.go
+++ b/k8s/pkg/helm/ethereum/geth.go
@@ -150,9 +150,10 @@ func NewVersioned(helmVersion string, props *Props) environment.ConnectedChart {
 		}
 		return Chart{
 			HelmProps: &HelmProps{
-				Name:   "geth",
-				Path:   chartPath,
-				Values: &targetProps.Values,
+				Name:    "geth",
+				Path:    chartPath,
+				Values:  &targetProps.Values,
+				Version: helmVersion,
 			},
 			Props: targetProps,
 		}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enable the specification of a Helm chart version for the Geth deployment in a Kubernetes environment, making it possible to choose a specific version of Geth for deployment purposes.

## What
- **k8s/pkg/helm/ethereum/geth.go**  
  - In the `NewVersioned` function, added a `Version: helmVersion` line within the `HelmProps` struct initialization for the `Chart` object when `targetProps.Simulated` is true. This change ensures that when deploying a simulated Geth network, the specified Helm chart version is used.
