### PR TITLE
Change New Header Log to Trace

### DIFF
--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -471,12 +471,12 @@ func (e *EthereumClient) backfillMissedBlocks(lastBlockSeen uint64, headerChanne
 // receiveHeader takes in a new header from the chain, and sends the header to all active header subscriptions
 func (e *EthereumClient) receiveHeader(header *SafeEVMHeader) error {
 	if header == nil {
-		e.l.Debug().Msg("Received Nil Header")
+		e.l.Trace().Msg("Received Nil Header")
 		return nil
 	}
 	headerValue := *header
 
-	e.l.Debug().
+	e.l.Trace().
 		Str("NetworkName", e.NetworkConfig.Name).
 		Int("Node", e.ID).
 		Str("Hash", headerValue.Hash.String()).


### PR DESCRIPTION
This log becomes incessantly noisy on fast chains, or in CCIP with multiple chains.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve logging verbosity for debugging purposes by changing some log messages from `Debug` to `Trace` level. This adjustment provides more granular log information without overwhelming the log with too much detail at the Debug level, making it easier to diagnose issues.

## What
- **blockchain/transaction_confirmers.go**
  - Changed logging level from `Debug` to `Trace` for the message "Received Nil Header" to reduce log verbosity.
  - Adjusted logging level from `Debug` to `Trace` for logging received header information including `NetworkName`, `Node`, `Hash`, and `Number` for the same reason.
  - Modified logging level to `Trace` for "Active Header Subscriptions" message to align with the overall logging level changes for detailed logging purposes.
