### PR TITLE
make number of accounts configurable in anvil

### DIFF
--- a/charts/foundry/Chart.yaml
+++ b/charts/foundry/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: foundry
 description: A Helm chart for foundry, mostly used to run Anvil node
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 'latest'

--- a/charts/foundry/templates/deployment.yaml
+++ b/charts/foundry/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             {{- if .Values.anvil.runAsOptimism }}
             - "--optimism"
             {{- end }}
+            {{- if .Values.anvil.noOfAccounts }}
+            - "--accounts"
+            - {{ .Values.anvil.noOfAccounts | quote }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/foundry/values.yaml
+++ b/charts/foundry/values.yaml
@@ -16,6 +16,7 @@ anvil:
   # forkTimeout: "45000"
   # forkComputeUnitsPerSecond: "330"
   # forkNoRateLimit: "true"
+  noOfAccounts: 20
 
 image:
   repository: ghcr.io/foundry-rs/foundry

--- a/config/network.go
+++ b/config/network.go
@@ -25,6 +25,7 @@ type AnvilConfig struct {
 	Timeout           *int64  `toml:"timeout,omitempty"`             //  Needed if fork URL is provided for forking. Timeout in ms for requests sent to remote JSON-RPC server in forking mode. Refer to https://book.getfoundry.sh/reference/anvil/#options
 	ComputePerSecond  *int64  `toml:"compute_per_second,omitempty"`  // Needed if fork URL is provided for forking. Sets the number of assumed available compute units per second for this provider. Refer to https://book.getfoundry.sh/reference/anvil/#options
 	RateLimitDisabled *bool   `toml:"rate_limit_disabled,omitempty"` // Needed if fork URL is provided for forking. Rate limiting for this node’s provider. If set to true the node will start with --no-rate-limit Refer to https://book.getfoundry.sh/reference/anvil/#options
+	NoOfAccounts      *int    `toml:"no_of_accounts,omitempty"`      // Number of accounts to generate. Refer to https://book.getfoundry.sh/reference/anvil/#options
 }
 
 // NetworkConfig is the configuration for the networks to be used


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce enhancements and new features across the Helm chart and configuration files, aiming to provide better flexibility and control for deploying an Anvil node. Specifically, the addition of an option to specify the number of accounts to generate allows users to customize their node setup based on their specific needs. Updating the chart version reflects these improvements and ensures users can track and utilize the latest features.

## What
- **charts/foundry/Chart.yaml**
  - Updated the chart version from `0.1.1` to `0.1.2`. This change indicates an incremental improvement or addition of features to the chart.
- **charts/foundry/templates/deployment.yaml**
  - Added support for specifying the number of accounts (`--accounts`) when deploying an Anvil node. This allows users to define how many accounts should be generated upon node startup.
- **charts/foundry/values.yaml**
  - Introduced a new configuration option `noOfAccounts` with a default value of `20`. This allows users to customize the number of accounts their Anvil node generates.
- **config/network.go**
  - Added a new field `NoOfAccounts` to the `AnvilConfig` struct, enabling the configuration of account generation through the application's configuration files.
- **k8s/pkg/helm/reorg/reorg.go**
  - Enhanced network export functionality to include HTTP URLs for Ethereum Get nodes, providing additional connectivity options for network interactions. This change is beneficial for scenarios where WebSockets might not be the preferred or available method for connecting to nodes.
