### PR TITLE
TT-1132 : add quotes to anvil values

### DIFF
--- a/charts/foundry/Chart.yaml
+++ b/charts/foundry/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: foundry
 description: A Helm chart for foundry, mostly used to run Anvil node
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 'latest'

--- a/charts/foundry/templates/deployment.yaml
+++ b/charts/foundry/templates/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             {{- end }}
             {{- if .Values.anvil.accountBalance }}
             - "--balance"
-            -  {{ .Values.anvil.accountBalance | quote }}
+            - {{ .Values.anvil.accountBalance | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/foundry/templates/deployment.yaml
+++ b/charts/foundry/templates/deployment.yaml
@@ -45,15 +45,15 @@ spec:
             - {{ .Values.anvil.blockTime | quote }}
             {{- if .Values.anvil.blockGasLimit }}
             - "--gas-limit"
-            - {{ .Values.anvil.blockGasLimit }}
+            - {{ .Values.anvil.blockGasLimit | quote }}
             {{- end }}
             {{- if .Values.anvil.codeSizeLimit }}
             - "--code-size-limit"
-            - {{ .Values.anvil.codeSizeLimit }}
+            - {{ .Values.anvil.codeSizeLimit | quote }}
             {{- end }}
             {{- if .Values.anvil.baseFee }}
             - "--base-fee"
-            - {{ .Values.anvil.baseFee }}
+            - {{ .Values.anvil.baseFee | quote }}
             {{- end }}
             - "--host"
             - {{ .Values.anvil.host }}

--- a/charts/foundry/values.yaml
+++ b/charts/foundry/values.yaml
@@ -17,10 +17,10 @@ anvil:
   # forkComputeUnitsPerSecond: "330"
   # forkNoRateLimit: "true"
   noOfAccounts: 20
-  accountBalance: 2000000000000000000
-  blockGasLimit: 400000000000000
-  codeSizeLimit: 30000
-  baseFee: 100000
+  accountBalance: "2000000000000000000"
+  blockGasLimit: "400000000000000"
+  codeSizeLimit: "30000"
+  baseFee: "100000"
 
 image:
   repository: ghcr.io/foundry-rs/foundry


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the Foundry Helm chart to improve its configuration flexibility and ensure versioning consistency. Adjustments in deployment and values configuration enhance the application's deployment capabilities, allowing for more precise control over environment variables and operational parameters.

## What
- **charts/foundry/Chart.yaml**
  - Updated `version` from `0.1.3` to `0.1.4`. This change increments the chart version to reflect updates in configurations and capabilities.
- **charts/foundry/templates/deployment.yaml**
  - Added double quotes around the values for `--accounts`, `--balance`, `--gas-limit`, `--code-size-limit`, and `--base-fee` flags in the command section. This standardizes the input format, ensuring consistency and predictability in handling these values.
- **charts/foundry/values.yaml**
  - Changed the format of `accountBalance`, `blockGasLimit`, `codeSizeLimit`, and `baseFee` from numerical to string values enclosed in quotes. This modification aligns with the changes in the deployment template, ensuring the values are treated consistently as strings throughout the chart.
