### PR TITLE
[TT-1136, CCIP-2255] make eth node log level configurable via TOML

### DIFF
--- a/config/tomls/default_ethereum_env.toml
+++ b/config/tomls/default_ethereum_env.toml
@@ -3,6 +3,7 @@ ethereum_version="eth2"
 consensus_layer="prysm"
 execution_layer="geth"
 wait_for_finalization=false
+node_log_level="info"
 
 [PrivateEthereumNetwork.EthereumChainConfig]
 seconds_per_slot=12

--- a/docker/test_env/besu_eth1.go
+++ b/docker/test_env/besu_eth1.go
@@ -81,7 +81,7 @@ func (g *Besu) getEth1ContainerRequest() (*tc.ContainerRequest, error) {
 			"--miner-enabled=true",
 			"--miner-coinbase", RootFundingAddr,
 			fmt.Sprintf("--network-id=%d", g.chainConfig.ChainID),
-			"--logging=DEBUG",
+			fmt.Sprintf("--logging=%s", strings.ToUpper(g.LogLevel)),
 		},
 		Files: []tc.ContainerFile{
 			{

--- a/docker/test_env/besu_eth2.go
+++ b/docker/test_env/besu_eth2.go
@@ -80,7 +80,7 @@ func (g *Besu) getEth2ContainerRequest() (*tc.ContainerRequest, error) {
 			fmt.Sprintf("--engine-rpc-port=%s", ETH2_EXECUTION_PORT),
 			"--sync-mode=FULL",
 			"--data-storage-format=BONSAI",
-			// "--logging=DEBUG",
+			fmt.Sprintf("--logging=%s", strings.ToUpper(g.LogLevel)),
 			"--rpc-tx-feecap=0",
 		},
 		Env: map[string]string{

--- a/docker/test_env/env_component.go
+++ b/docker/test_env/env_component.go
@@ -30,6 +30,7 @@ type EnvComponent struct {
 	PostStartsHooks    []tc.ContainerHook   `json:"-"`
 	PostStopsHooks     []tc.ContainerHook   `json:"-"`
 	PreTerminatesHooks []tc.ContainerHook   `json:"-"`
+	LogLevel           string               `json:"-"`
 }
 
 type EnvComponentOption = func(c *EnvComponent)
@@ -48,6 +49,14 @@ func WithContainerImageWithVersion(imageWithVersion string) EnvComponentOption {
 		if len(split) == 2 {
 			c.ContainerImage = split[0]
 			c.ContainerVersion = split[1]
+		}
+	}
+}
+
+func WithLogLevel(logLevel string) EnvComponentOption {
+	return func(c *EnvComponent) {
+		if logLevel != "" {
+			c.LogLevel = logLevel
 		}
 	}
 }

--- a/docker/test_env/erigon_eth1.go
+++ b/docker/test_env/erigon_eth1.go
@@ -166,16 +166,18 @@ func (g *Erigon) buildPowInitScript(minerAddr string) (string, error) {
 
 	echo "Starting Erigon..."
 	erigon --http --http.api=eth,erigon,engine,web3,net,debug,trace,txpool,admin --http.addr=0.0.0.0 --http.corsdomain=* --http.vhosts=* --http.port={{.HttpPort}} --ws \
-	--allow-insecure-unlock  --nodiscover --networkid={{.ChainID}} --mine --miner.etherbase={{.MinerAddr}} --fakepow`
+	--allow-insecure-unlock  --nodiscover --networkid={{.ChainID}} --mine --miner.etherbase={{.MinerAddr}} --fakepow --verbosity={{.LogLevel}}`
 
 	data := struct {
 		HttpPort  string
 		ChainID   int
 		MinerAddr string
+		LogLevel  string
 	}{
 		HttpPort:  DEFAULT_EVM_NODE_HTTP_PORT,
 		ChainID:   g.chainConfig.ChainID,
 		MinerAddr: minerAddr,
+		LogLevel:  g.LogLevel,
 	}
 
 	t, err := template.New("init").Parse(initTemplate)

--- a/docker/test_env/erigon_eth1.go
+++ b/docker/test_env/erigon_eth1.go
@@ -166,7 +166,7 @@ func (g *Erigon) buildPowInitScript(minerAddr string) (string, error) {
 
 	echo "Starting Erigon..."
 	erigon --http --http.api=eth,erigon,engine,web3,net,debug,trace,txpool,admin --http.addr=0.0.0.0 --http.corsdomain=* --http.vhosts=* --http.port={{.HttpPort}} --ws \
-	--allow-insecure-unlock  --nodiscover --networkid={{.ChainID}} --mine --miner.etherbase={{.MinerAddr}} --fakepow --verbosity={{.LogLevel}}`
+	--allow-insecure-unlock  --nodiscover --networkid={{.ChainID}} --mine --miner.etherbase={{.MinerAddr}} --fakepow --log.console.verbosity={{.LogLevel}}`
 
 	data := struct {
 		HttpPort  string

--- a/docker/test_env/ethereum_env.go
+++ b/docker/test_env/ethereum_env.go
@@ -188,7 +188,9 @@ func (b *EthereumNetworkBuilder) Build() (EthereumNetwork, error) {
 		return EthereumNetwork{}, err
 	}
 
-	return b.buildNetworkConfig(), nil
+	network := b.buildNetworkConfig()
+
+	return network, network.Validate()
 }
 
 func (b *EthereumNetworkBuilder) importExistingConfig() bool {

--- a/docker/test_env/ethereum_env.go
+++ b/docker/test_env/ethereum_env.go
@@ -44,6 +44,7 @@ type EthereumNetworkBuilder struct {
 	addressesToFund     []string
 	waitForFinalization bool
 	existingFromEnvVar  bool
+	nodeLogLevel        string
 }
 
 func NewEthereumNetworkBuilder() EthereumNetworkBuilder {
@@ -91,6 +92,11 @@ func (b *EthereumNetworkBuilder) WithEthereumChainConfig(config config.EthereumC
 
 func (b *EthereumNetworkBuilder) WithDockerNetworks(networks []string) *EthereumNetworkBuilder {
 	b.dockerNetworks = networks
+	return b
+}
+
+func (b *EthereumNetworkBuilder) WithNodeLogLevel(nodeLogLevel string) *EthereumNetworkBuilder {
+	b.nodeLogLevel = nodeLogLevel
 	return b
 }
 
@@ -144,6 +150,7 @@ func (b *EthereumNetworkBuilder) buildNetworkConfig() EthereumNetwork {
 	n.WaitForFinalization = &b.waitForFinalization
 	n.EthereumNetworkConfig.EthereumChainConfig = b.ethereumChainConfig
 	n.EthereumNetworkConfig.CustomDockerImages = b.customDockerImages
+	n.NodeLogLevel = &b.nodeLogLevel
 	n.t = b.t
 	n.ls = b.ls
 
@@ -215,6 +222,12 @@ func (b *EthereumNetworkBuilder) importExistingConfig() bool {
 	}
 	b.ethereumChainConfig = b.existingConfig.EthereumChainConfig
 	b.customDockerImages = b.existingConfig.CustomDockerImages
+
+	if b.existingConfig.NodeLogLevel != nil {
+		b.nodeLogLevel = *b.existingConfig.NodeLogLevel
+	} else {
+		b.nodeLogLevel = config.DefaultNodeLogLevel
+	}
 
 	return true
 }
@@ -417,7 +430,7 @@ func (en *EthereumNetwork) startEth2() (blockchain.EVMNetwork, RpcProvider, erro
 	case config.ExecutionLayer_Geth:
 		client, clientErr = NewGethEth2(dockerNetworks, en.EthereumChainConfig, generatedDataHostDir, config.ConsensusLayer_Prysm, opts...)
 	case config.ExecutionLayer_Nethermind:
-		client, clientErr = NewNethermindEth2(dockerNetworks, generatedDataHostDir, config.ConsensusLayer_Prysm, opts...)
+		client, clientErr = NewNethermindEth2(dockerNetworks, en.EthereumChainConfig, generatedDataHostDir, config.ConsensusLayer_Prysm, opts...)
 	case config.ExecutionLayer_Erigon:
 		client, clientErr = NewErigonEth2(dockerNetworks, en.EthereumChainConfig, generatedDataHostDir, config.ConsensusLayer_Prysm, opts...)
 	case config.ExecutionLayer_Besu:

--- a/docker/test_env/ethereum_env.go
+++ b/docker/test_env/ethereum_env.go
@@ -3,6 +3,7 @@ package test_env
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,14 +21,12 @@ import (
 )
 
 const (
-	CONFIG_ENV_VAR_NAME      = "PRIVATE_ETHEREUM_NETWORK_CONFIG_PATH"
-	EXEC_CLIENT_ENV_VAR_NAME = "ETH2_EL_CLIENT"
+	CONFIG_ENV_VAR_NAME = "PRIVATE_ETHEREUM_NETWORK_CONFIG_PATH"
 )
 
 var (
-	ErrMissingConsensusLayer    = errors.New("consensus layer is required for PoS")
-	ErrConsensusLayerNotAllowed = errors.New("consensus layer is not allowed for PoW")
-	ErrTestConfigNotSaved       = errors.New("could not save test env config")
+	ErrMissingConsensusLayer = errors.New("consensus layer is required for PoS")
+	ErrTestConfigNotSaved    = errors.New("could not save test env config")
 )
 
 var MsgMismatchedExecutionClient = "you provided a custom docker image for %s execution client, but explicitly set a execution client to %s. Make them match or remove one or the other"
@@ -711,6 +710,11 @@ func (en *EthereumNetwork) getExecutionLayerEnvComponentOpts() []EnvComponentOpt
 	opts = append(opts, en.getImageOverride(config.ContainerType_ExecutionLayer)...)
 	opts = append(opts, en.setExistingContainerName(config.ContainerType_ExecutionLayer))
 	opts = append(opts, WithLogStream(en.ls))
+
+	if en.NodeLogLevel != nil && *en.NodeLogLevel != "" {
+		opts = append(opts, WithLogLevel(strings.ToLower(*en.NodeLogLevel)))
+	}
+
 	return opts
 }
 

--- a/docker/test_env/ethereum_env.go
+++ b/docker/test_env/ethereum_env.go
@@ -323,6 +323,10 @@ func (b *EthereumNetworkBuilder) autoFill() error {
 		b.ethereumVersion = config.EthereumVersion_Eth2
 	}
 
+	if b.nodeLogLevel == "" {
+		b.nodeLogLevel = config.DefaultNodeLogLevel
+	}
+
 	return nil
 }
 

--- a/docker/test_env/geth_base.go
+++ b/docker/test_env/geth_base.go
@@ -252,3 +252,22 @@ func (g *Geth) getWebsocketEnabledMessage() (string, error) {
 
 	return "WebSocket enabled", nil
 }
+
+func (g *Geth) logLevelToVerbosity() (int, error) {
+	switch g.LogLevel {
+	case "trace":
+		return 5, nil
+	case "debug":
+		return 4, nil
+	case "info":
+		return 3, nil
+	case "warn":
+		return 2, nil
+	case "error":
+		return 1, nil
+	case "silent":
+		return 0, nil
+	default:
+		return -1, fmt.Errorf("unknown log level: %s", g.LogLevel)
+	}
+}

--- a/docker/test_env/geth_eth2.go
+++ b/docker/test_env/geth_eth2.go
@@ -131,7 +131,12 @@ func (g *Geth) buildEth2dInitScript() (string, error) {
 		--authrpc.addr=0.0.0.0 --authrpc.jwtsecret={{.JwtFileLocation}} --datadir={{.ExecutionDir}} \
 		--rpc.allow-unprotected-txs --rpc.txfeecap=0 --allow-insecure-unlock \
 		--password={{.PasswordFileLocation}} --nodiscover --syncmode=full --networkid={{.ChainID}} \
-		--graphql --graphql.corsdomain=* --unlock=0x123463a4b065722e99115d6c222f267d9cabb524`
+		--graphql --graphql.corsdomain=* --unlock=0x123463a4b065722e99115d6c222f267d9cabb524 --verbosity={{.Verbosity}}`
+
+	verbosity, err := g.logLevelToVerbosity()
+	if err != nil {
+		return "", err
+	}
 
 	data := struct {
 		HttpPort             string
@@ -142,6 +147,7 @@ func (g *Geth) buildEth2dInitScript() (string, error) {
 		PasswordFileLocation string
 		KeystoreDirLocation  string
 		ExecutionDir         string
+		Verbosity            int
 	}{
 		HttpPort:             DEFAULT_EVM_NODE_HTTP_PORT,
 		WsPort:               DEFAULT_EVM_NODE_WS_PORT,
@@ -151,6 +157,7 @@ func (g *Geth) buildEth2dInitScript() (string, error) {
 		PasswordFileLocation: ACCOUNT_PASSWORD_FILE_INSIDE_CONTAINER,
 		KeystoreDirLocation:  KEYSTORE_DIR_LOCATION_INSIDE_CONTAINER,
 		ExecutionDir:         "/execution-data",
+		Verbosity:            verbosity,
 	}
 
 	t, err := template.New("init").Parse(initTemplate)

--- a/docker/test_env/nethermind_eth1.go
+++ b/docker/test_env/nethermind_eth1.go
@@ -137,6 +137,7 @@ func (g *Nethermind) getEth1ContainerRequest() (*tc.ContainerRequest, error) {
 			"--Mining.Enabled=true",
 			"--Init.PeerManagerEnabled=false",
 			"--HealthChecks.Enabled=true", // default slug /health
+			fmt.Sprintf("--log=%s", strings.ToUpper(g.LogLevel)),
 		},
 		Files: []tc.ContainerFile{
 			{

--- a/docker/test_env/nethermind_eth2.go
+++ b/docker/test_env/nethermind_eth2.go
@@ -92,6 +92,7 @@ func (g *Nethermind) getEth2ContainerRequest() (*tc.ContainerRequest, error) {
 			"--Network.MaxActivePeers=0",
 			"--Network.OnlyStaticPeers=true",
 			"--HealthChecks.Enabled=true", // default slug /health
+			fmt.Sprintf("--log=%s", strings.ToUpper(g.LogLevel)),
 		},
 		Files: []tc.ContainerFile{
 			{

--- a/docker/test_env/nethermind_eth2.go
+++ b/docker/test_env/nethermind_eth2.go
@@ -18,7 +18,7 @@ import (
 )
 
 // NewNethermindEth2 starts a new Nethermin Eth2 node running in Docker
-func NewNethermindEth2(networks []string, generatedDataHostDir string, consensusLayer config.ConsensusLayer, opts ...EnvComponentOption) (*Nethermind, error) {
+func NewNethermindEth2(networks []string, chainConfig *config.EthereumChainConfig, generatedDataHostDir string, consensusLayer config.ConsensusLayer, opts ...EnvComponentOption) (*Nethermind, error) {
 	parts := strings.Split(defaultNethermindEth2Image, ":")
 	g := &Nethermind{
 		EnvComponent: EnvComponent{
@@ -28,6 +28,7 @@ func NewNethermindEth2(networks []string, generatedDataHostDir string, consensus
 			ContainerVersion: parts[1],
 		},
 		generatedDataHostDir: generatedDataHostDir,
+		chainConfig:          chainConfig,
 		consensusLayer:       consensusLayer,
 		l:                    logging.GetTestLogger(nil),
 		ethereumVersion:      config.EthereumVersion_Eth2,
@@ -59,6 +60,37 @@ func (g *Nethermind) getEth2ContainerRequest() (*tc.ContainerRequest, error) {
 		return nil, err
 	}
 
+	command := []string{
+		"--datadir=/nethermind",
+		"--config=/none.cfg",
+		fmt.Sprintf("--Init.ChainSpecPath=%s/chainspec.json", GENERATED_DATA_DIR_INSIDE_CONTAINER),
+		"--Init.DiscoveryEnabled=false",
+		"--Init.WebSocketsEnabled=true",
+		fmt.Sprintf("--JsonRpc.WebSocketsPort=%s", DEFAULT_EVM_NODE_WS_PORT),
+		fmt.Sprintf("--Blocks.SecondsPerSlot=%d", g.chainConfig.SecondsPerSlot),
+		"--JsonRpc.Enabled=true",
+		"--JsonRpc.EnabledModules=net,eth,consensus,subscribe,web3,admin,txpool,debug,trace",
+		"--JsonRpc.Host=0.0.0.0",
+		fmt.Sprintf("--JsonRpc.Port=%s", DEFAULT_EVM_NODE_HTTP_PORT),
+		"--JsonRpc.EngineHost=0.0.0.0",
+		"--JsonRpc.EnginePort=" + ETH2_EXECUTION_PORT,
+		fmt.Sprintf("--JsonRpc.JwtSecretFile=%s", JWT_SECRET_FILE_LOCATION_INSIDE_CONTAINER),
+		fmt.Sprintf("--KeyStore.KeyStoreDirectory=%s", KEYSTORE_DIR_LOCATION_INSIDE_CONTAINER),
+		"--KeyStore.BlockAuthorAccount=0x123463a4b065722e99115d6c222f267d9cabb524",
+		"--KeyStore.UnlockAccounts=0x123463a4b065722e99115d6c222f267d9cabb524",
+		fmt.Sprintf("--KeyStore.PasswordFiles=%s", ACCOUNT_PASSWORD_FILE_INSIDE_CONTAINER),
+		"--Network.MaxActivePeers=0",
+		"--Network.OnlyStaticPeers=true",
+		"--HealthChecks.Enabled=true", // default slug /health
+		fmt.Sprintf("--log=%s", strings.ToUpper(g.LogLevel)),
+	}
+
+	if g.LogLevel == "trace" {
+		command = append(command, "--TraceStore.Enabled=true")
+		command = append(command, "--Network.DiagTracerEnabled=true")
+		command = append(command, "--TxPool.ReportMinutes=1")
+	}
+
 	return &tc.ContainerRequest{
 		Name:            g.ContainerName,
 		Image:           g.GetImageWithVersion(),
@@ -71,29 +103,7 @@ func (g *Nethermind) getEth2ContainerRequest() (*tc.ContainerRequest, error) {
 				WithStartupTimeout(120 * time.Second).
 				WithPollInterval(1 * time.Second),
 		),
-		Cmd: []string{
-			"--datadir=/nethermind",
-			"--config=/none.cfg",
-			fmt.Sprintf("--Init.ChainSpecPath=%s/chainspec.json", GENERATED_DATA_DIR_INSIDE_CONTAINER),
-			"--Init.DiscoveryEnabled=false",
-			"--Init.WebSocketsEnabled=true",
-			fmt.Sprintf("--JsonRpc.WebSocketsPort=%s", DEFAULT_EVM_NODE_WS_PORT),
-			"--JsonRpc.Enabled=true",
-			"--JsonRpc.EnabledModules=net,eth,consensus,subscribe,web3,admin,txpool,debug,trace",
-			"--JsonRpc.Host=0.0.0.0",
-			fmt.Sprintf("--JsonRpc.Port=%s", DEFAULT_EVM_NODE_HTTP_PORT),
-			"--JsonRpc.EngineHost=0.0.0.0",
-			"--JsonRpc.EnginePort=" + ETH2_EXECUTION_PORT,
-			fmt.Sprintf("--JsonRpc.JwtSecretFile=%s", JWT_SECRET_FILE_LOCATION_INSIDE_CONTAINER),
-			fmt.Sprintf("--KeyStore.KeyStoreDirectory=%s", KEYSTORE_DIR_LOCATION_INSIDE_CONTAINER),
-			"--KeyStore.BlockAuthorAccount=0x123463a4b065722e99115d6c222f267d9cabb524",
-			"--KeyStore.UnlockAccounts=0x123463a4b065722e99115d6c222f267d9cabb524",
-			fmt.Sprintf("--KeyStore.PasswordFiles=%s", ACCOUNT_PASSWORD_FILE_INSIDE_CONTAINER),
-			"--Network.MaxActivePeers=0",
-			"--Network.OnlyStaticPeers=true",
-			"--HealthChecks.Enabled=true", // default slug /health
-			fmt.Sprintf("--log=%s", strings.ToUpper(g.LogLevel)),
-		},
+		Cmd: command,
 		Files: []tc.ContainerFile{
 			{
 				HostFilePath:      noneCfg.Name(),

--- a/utils/templates/geth.go
+++ b/utils/templates/geth.go
@@ -18,32 +18,6 @@ fi
 geth "$@"
 `
 
-var BootnodeScript = `
-#!/bin/bash
-
-echo "Starting bootnode"
-bootnode --genkey=/root/.ethereum/node.key
-echo "Bootnode key generated"
-
-echo "Bootnode address written to file"
-bootnode -writeaddress --nodekey=/root/.ethereum/node.key > /root/.ethereum/bootnodes
-cat /root/.ethereum/bootnodes
-
-echo "Starting Bootnode"
-bootnode --nodekey=/root/.ethereum/node.key --verbosity=6 --addr :30301
-`
-
-var InitNonDevGethScript = `
-#!/bin/bash
-
-echo "Starting geth"
-geth --datadir=/root/.ethereum init /root/genesis.json
-
-bootnode_enode=$(cat /root/.ethereum/keystore/password.txt)
-echo "Bootnode enode: $bootnode_enode"
-geth "$@"
-`
-
 var GenesisJson = `
 {
 	"config": {
@@ -88,29 +62,6 @@ var funcMap = template.FuncMap{
 	"decrement": func(i int) int {
 		return i - 1
 	},
-}
-
-func BuildGenesisJsonForNonDevChain(chainId string, accountAddr []string, extraData string) (string, error) {
-	data := struct {
-		AccountAddr []string
-		ChainId     string
-		ExtraData   string
-	}{
-		AccountAddr: accountAddr,
-		ChainId:     chainId,
-		ExtraData:   extraData,
-	}
-
-	t, err := template.New("genesis-json").Funcs(funcMap).Parse(GenesisJson)
-	if err != nil {
-		fmt.Println("Error parsing template:", err)
-		os.Exit(1)
-	}
-
-	var buf bytes.Buffer
-	err = t.Execute(&buf, data)
-
-	return buf.String(), err
 }
 
 type GenesisConsensus = string


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce the ability to set and validate node log levels for Ethereum networks within the testing framework, ensuring greater control and flexibility over logging during tests. They also integrate log level configuration into various Ethereum client containers, allowing for dynamic adjustment of verbosity in blockchain simulations.

## What
- **config/private_ethereum_network.go**
  - Added `strings` package import for string manipulation.
  - Introduced `DefaultNodeLogLevel` variable to define a default log level.
  - Added `NodeLogLevel` field to `EthereumNetworkConfig` struct to allow configuration of node log level.
  - Updated `Validate` method to ensure `NodeLogLevel` is set to a default value if not specified and to validate log level strings.

- **config/tomls/default_ethereum_env.toml**
  - Added `node_log_level` configuration with a default value of "info".

- **docker/test_env/besu_eth1.go & besu_eth2.go**
  - Modified container request to configure logging verbosity based on the `LogLevel` field from the environment configuration.

- **docker/test_env/env_component.go**
  - Added `LogLevel` field to `EnvComponent` struct to store log level configuration.
  - Introduced `WithLogLevel` function to configure log level for environment components.

- **docker/test_env/erigon_eth1.go & erigon_eth2.go**
  - Adjusted container request and initialization scripts to use the configured log level.
  - For Eth2, added logic to enable trace logging for specified senders if log level is set to trace.

- **docker/test_env/ethereum_env.go**
  - Added logic to include log level configuration when building environment components for the execution layer.

- **docker/test_env/ethereum_env_test.go**
  - Added tests to verify default log level behavior, trace log level configuration, and validation of invalid log levels.

- **docker/test_env/geth_base.go**
  - Introduced `logLevelToVerbosity` method to convert log level strings to Geth verbosity levels.

- **docker/test_env/geth_eth2.go**
  - Updated container request to configure Geth verbosity based on the log level.

- **docker/test_env/nethermind_eth1.go & nethermind_eth2.go**
  - Adjusted container request to configure logging based on the `LogLevel` field.

- **utils/templates/geth.go**
  - Removed unused bootnode and non-dev geth initialization scripts.
