### PR TITLE
enable prune history in anvil

### DIFF
--- a/charts/foundry/Chart.yaml
+++ b/charts/foundry/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: foundry
 description: A Helm chart for foundry, mostly used to run Anvil node
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 'latest'

--- a/charts/foundry/templates/deployment.yaml
+++ b/charts/foundry/templates/deployment.yaml
@@ -104,6 +104,7 @@ spec:
             - "--balance"
             - {{ .Values.anvil.accountBalance | quote }}
             {{- end }}
+            - "--prune-history"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the Helm chart for Foundry to include a new version and enhance the Anvil node deployment with a `--prune-history` command option, optimizing storage use by pruning historical state data.

## What
- **charts/foundry/Chart.yaml**
  - Updated the chart version from `0.1.4` to `0.1.5`.
- **charts/foundry/templates/deployment.yaml**
  - Added the `- "--prune-history"` command to the Anvil node container, enabling the pruning of historical state data to optimize storage usage.
