### PR TITLE
[TT-1138] Increase how often we update our internal mirrors

### DIFF
--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -4,8 +4,8 @@ on:
     tags:
       - main
   workflow_dispatch:
-  schedule: # add schecule for once a week on saturday
-    - cron: '0 0 * * 6'
+  schedule: # Schedule to run twice a day at 8:00 AM and 8:00 PM
+    - cron: '0 8,20 * * *'
 
 concurrency:
   group: update-mirrors-${{ github.ref }}


### PR DESCRIPTION
Now updates twice a day at 8 am and 8 pm
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
Increased frequency of mirror updates to ensure more up-to-date synchronizations which enhances the reliability and consistency across development environments.

## What
- **.github/workflows/update-internal-mirrors.yaml**
  - Modified the cron schedule under `schedule:` from once a week to twice daily at 8:00 AM and 8:00 PM. This change aims to improve the timeliness of mirror updates.
