### PR TITLE
Enables Blast

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -799,6 +799,34 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	BlastSepolia = blockchain.EVMNetwork{
+		Name:                      "Blast Sepolia",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   168587773,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
+	BlastMainnet = blockchain.EVMNetwork{
+		Name:                      "Blast Mainnet",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   81457,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
 		"SIMULATED_1":             SimulatedEVMNonDev1,
@@ -855,6 +883,8 @@ var (
 		"NEXON_STAGE":           NexonStage,
 		"GNOSIS_CHIADO":         GnosisChiado,
 		"GNOSIS_MAINNET":        GnosisMainnet,
+		"BLAST_SEPOLIA":         BlastSepolia,
+		"BLAST_MAINNET":         BlastMainnet,
 	}
 )
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce support for two new EVM networks: Blast Sepolia and Blast Mainnet. These additions expand the blockchain networks available for interaction, providing users with more options for deploying and testing their decentralized applications.

## What
- **networks/known_networks.go**
  - Added `BlastSepolia` and `BlastMainnet` to the list of EVM networks. These networks support EIP1559, use the Ethereum client implementation, have specified Chain IDs, are not simulated, have a Chainlink transaction limit of 5000, a timeout of 2 minutes, require at least one confirmation, have a gas estimation buffer of 10000, include a finality tag, and default gas limit of 6000000.
  - Updated `MappedNetworks` to include mappings for "BLAST_SEPOLIA" and "BLAST_MAINNET" to their respective network configurations.
