### PR TITLE
Enables Mode

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -799,6 +799,34 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	ModeSepolia = blockchain.EVMNetwork{
+		Name:                      "Mode Sepolia",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   919,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
+	ModeMainnet = blockchain.EVMNetwork{
+		Name:                      "Mode Mainnet",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   34443,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           6000000,
+	}
+
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
 		"SIMULATED_1":             SimulatedEVMNonDev1,
@@ -855,6 +883,8 @@ var (
 		"NEXON_STAGE":           NexonStage,
 		"GNOSIS_CHIADO":         GnosisChiado,
 		"GNOSIS_MAINNET":        GnosisMainnet,
+		"MODE_SEPOLIA":          ModeSepolia,
+		"MODE_MAINNET":          ModeMainnet,
 	}
 )
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The update adds two new EVM networks to the known networks configuration: Mode Sepolia and Mode Mainnet. These additions enable support for these networks within the application, allowing for interactions with smart contracts and blockchain transactions on the Mode Sepolia and Mode Mainnet networks.

## What
- **File:** `networks/known_networks.go`
  - Added `ModeSepolia` EVM network configuration with ChainID 919, supporting EIP1559, and other relevant configurations such as ChainlinkTransactionLimit set to 5000 and a Timeout set to 2 minutes.
  - Added `ModeMainnet` EVM network configuration with ChainID 34443, supporting EIP1559, along with similar configurations as Mode Sepolia including ChainlinkTransactionLimit set to 5000 and a Timeout set to 2 minutes.
  - Updated `MappedNetworks` to include `ModeSepolia` and `ModeMainnet` with their corresponding configurations.
