### PR TITLE
Added network config var for gauntlet

### DIFF
--- a/gauntlet/gauntlet.go
+++ b/gauntlet/gauntlet.go
@@ -177,6 +177,20 @@ func (g *Gauntlet) WriteNetworkConfigMap(networkDirPath string) error {
 	}
 	return nil
 }
+func (g *Gauntlet) WriteNetworkConfigVar(networkDirPath string, k string, v string) error {
+	file := filepath.Join(networkDirPath, fmt.Sprintf(".env.%s", g.Network))
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	log.Debug().Str(k, v).Msg("Gauntlet .env config value:")
+	_, err = f.WriteString(fmt.Sprintf("\n%s=%s", k, v))
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 // checkForErrors Loops through provided err slice to see if the error exists in the output.
 func checkForErrors(errHandling []string, line string) error {
@@ -210,5 +224,9 @@ func printArgs(args []string) {
 }
 
 func (g *Gauntlet) AddNetworkConfigVar(k string, v string) {
+	if existingVal, exists := g.NetworkConfig[k]; exists && existingVal == v {
+		log.Info().Str("stdout", "gauntlet network").Msg("Skipping adding duplicate key to network config")
+		return
+	}
 	g.NetworkConfig[k] = v
 }


### PR DESCRIPTION
- Added network config var for gauntlet
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce the ability to write individual network configuration variables to a file and enhance the handling of duplicate network configuration variables. This ensures efficient configuration management and prevents duplication in network configurations.

## What
- **gauntlet/gauntlet.go**
  - Added `WriteNetworkConfigVar` function: This function allows writing a single network configuration variable to the `.env` file corresponding to the network. This modular approach facilitates more granular control over network configuration updates.
  - Modified `AddNetworkConfigVar` function: Inserted a check to prevent adding a network configuration variable if it already exists with the same value. This prevents duplicates in the network configuration, ensuring cleaner and more reliable configuration files.
