### PR TITLE
[TT-1151] use latest stable version of evm node implementations

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -1339,7 +1339,8 @@ func ConnectEVMClient(networkSettings EVMNetwork, logger zerolog.Logger) (EVMCli
 	ecl.DefaultClient = ecl.Clients[0]
 	wrappedClient := wrapMultiClient(networkSettings, ecl)
 	// required in Geth when you need to call "simulate" transactions from nodes
-	if ecl.NetworkSimulated() {
+	// but not in other clients
+	if ecl.NetworkSimulated() && strings.Contains(strings.ToLower(networkSettings.SimulationType), "geth") {
 		zero := common.HexToAddress("0x0")
 		gasEstimations, err := wrappedClient.EstimateGas(ethereum.CallMsg{
 			To: &zero,

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -1339,8 +1339,7 @@ func ConnectEVMClient(networkSettings EVMNetwork, logger zerolog.Logger) (EVMCli
 	ecl.DefaultClient = ecl.Clients[0]
 	wrappedClient := wrapMultiClient(networkSettings, ecl)
 	// required in Geth when you need to call "simulate" transactions from nodes
-	// but not in other clients
-	if ecl.NetworkSimulated() && strings.Contains(strings.ToLower(networkSettings.SimulationType), "geth") {
+	if ecl.NetworkSimulated() {
 		zero := common.HexToAddress("0x0")
 		gasEstimations, err := wrappedClient.EstimateGas(ethereum.CallMsg{
 			To: &zero,

--- a/docker/test_env/besu_base.go
+++ b/docker/test_env/besu_base.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultBesuEth1Image = "hyperledger/besu:22.1.0"
-	defaultBesuEth2Image = "hyperledger/besu:24.1.0"
+	defaultBesuEth2Image = "hyperledger/besu:24.5.1"
 	besuBaseImageName    = "hyperledger/besu"
 	besuGitRepo          = "hyperledger/besu"
 )
@@ -116,6 +116,7 @@ func (g *Besu) StartContainer() (blockchain.EVMNetwork, error) {
 	networkConfig.URLs = []string{g.ExternalWsUrl}
 	networkConfig.HTTPURLs = []string{g.ExternalHttpUrl}
 	networkConfig.GasEstimationBuffer = 10_000_000_000
+	networkConfig.SimulationType = "Besu"
 
 	if g.GetEthereumVersion() == config.EthereumVersion_Eth1 {
 		networkConfig.Name = fmt.Sprintf("Private Eth-1-PoA [besu %s]", g.ContainerVersion)

--- a/docker/test_env/besu_test.go
+++ b/docker/test_env/besu_test.go
@@ -73,7 +73,15 @@ func TestBesuEth2(t *testing.T) {
 	eip1559Network.Name = "Simulated Besu + Prysm (EIP 1559)"
 	eip1559Network.SupportsEIP1559 = true
 	eip1559Network.URLs = eth2.PublicWsUrls()
-	_, err = blockchain.ConnectEVMClient(eip1559Network, l)
-	require.Error(t, err, "Could connect to the evm client")
+	clientTwo, err := blockchain.ConnectEVMClient(eip1559Network, l)
+	require.NoError(t, err, "Couldn't connect to the evm client")
+
+	t.Cleanup(func() {
+		err = clientTwo.Close()
+		require.NoError(t, err, "Couldn't close the client")
+	})
+
+	err = sendAndCompareBalances(testcontext.Get(t), clientTwo, address)
+	require.Error(t, err, "Couldn send EIP-1559 transaction to Besu")
 	require.Contains(t, err.Error(), "Method not found", "Besu should not work EIP-1559 yet")
 }

--- a/docker/test_env/besu_test.go
+++ b/docker/test_env/besu_test.go
@@ -74,7 +74,7 @@ func TestBesuEth2(t *testing.T) {
 	eip1559Network.SupportsEIP1559 = true
 	eip1559Network.URLs = eth2.PublicWsUrls()
 	_, err = blockchain.ConnectEVMClient(eip1559Network, l)
-	require.Error(t, err, "Could connect Besu")
+	require.Error(t, err, "Could not connect to Besu")
 	require.Contains(t, err.Error(), "Method not found", "Besu should not work EIP-1559 yet")
 
 }

--- a/docker/test_env/besu_test.go
+++ b/docker/test_env/besu_test.go
@@ -73,15 +73,8 @@ func TestBesuEth2(t *testing.T) {
 	eip1559Network.Name = "Simulated Besu + Prysm (EIP 1559)"
 	eip1559Network.SupportsEIP1559 = true
 	eip1559Network.URLs = eth2.PublicWsUrls()
-	clientTwo, err := blockchain.ConnectEVMClient(eip1559Network, l)
-	require.NoError(t, err, "Couldn't connect to the evm client")
-
-	t.Cleanup(func() {
-		err = clientTwo.Close()
-		require.NoError(t, err, "Couldn't close the client")
-	})
-
-	err = sendAndCompareBalances(testcontext.Get(t), clientTwo, address)
-	require.Error(t, err, "Couldn send EIP-1559 transaction to Besu")
+	_, err = blockchain.ConnectEVMClient(eip1559Network, l)
+	require.Error(t, err, "Could connect Besu")
 	require.Contains(t, err.Error(), "Method not found", "Besu should not work EIP-1559 yet")
+
 }

--- a/docker/test_env/erigon_base.go
+++ b/docker/test_env/erigon_base.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultErigonEth1Image = "thorax/erigon:v2.40.0"
-	defaultErigonEth2Image = "thorax/erigon:v2.60.0"
+	defaultErigonEth2Image = "thorax/erigon:v2.59.3" // v.2.60.0 is the latest, but gas estimations using zero address are broken
 	erigonBaseImageName    = "thorax/erigon"
 	erigonGitRepo          = "ledgerwatch/erigon"
 )

--- a/docker/test_env/erigon_base.go
+++ b/docker/test_env/erigon_base.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultErigonEth1Image = "thorax/erigon:v2.40.0"
-	defaultErigonEth2Image = "thorax/erigon:v2.56.2"
+	defaultErigonEth2Image = "thorax/erigon:v2.60.0"
 	erigonBaseImageName    = "thorax/erigon"
 	erigonGitRepo          = "ledgerwatch/erigon"
 )
@@ -102,6 +102,7 @@ func (g *Erigon) StartContainer() (blockchain.EVMNetwork, error) {
 	}
 	networkConfig.URLs = []string{g.ExternalWsUrl}
 	networkConfig.HTTPURLs = []string{g.ExternalHttpUrl}
+	networkConfig.SimulationType = "Erigon"
 
 	g.l.Info().Str("containerName", g.ContainerName).
 		Msg("Started Erigon container")

--- a/docker/test_env/geth_base.go
+++ b/docker/test_env/geth_base.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	defaultGethEth1Image = "ethereum/client-go:v1.12.0"
-	defaultGethEth2Image = "ethereum/client-go:v1.13.10"
+	defaultGethEth2Image = "ethereum/client-go:v1.14.3"
 	gethBaseImageName    = "ethereum/client-go"
 	gethGitRepo          = "ethereum/go-ethereum"
 )
@@ -105,6 +105,7 @@ func (g *Geth) StartContainer() (blockchain.EVMNetwork, error) {
 	}
 	networkConfig.URLs = []string{g.ExternalWsUrl}
 	networkConfig.HTTPURLs = []string{g.ExternalHttpUrl}
+	networkConfig.SimulationType = "Geth"
 
 	comparableVersion, err := GetComparableVersionFromDockerImage(g.GetImageWithVersion())
 	if err != nil {

--- a/docker/test_env/nethermind_base.go
+++ b/docker/test_env/nethermind_base.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultNethermindEth1Image = "nethermind/nethermind:1.16.0"
-	defaultNethermindEth2Image = "nethermind/nethermind:1.25.1"
+	defaultNethermindEth2Image = "nethermind/nethermind:1.26.0"
 	nethermindBaseImageName    = "nethermind/nethermind"
 	nethermindGitRepo          = "NethermindEth/nethermind"
 )
@@ -107,6 +107,7 @@ func (g *Nethermind) StartContainer() (blockchain.EVMNetwork, error) {
 	}
 	networkConfig.URLs = []string{g.ExternalWsUrl}
 	networkConfig.HTTPURLs = []string{g.ExternalHttpUrl}
+	networkConfig.SimulationType = "Nethermind"
 
 	g.l.Info().Str("containerName", g.ContainerName).
 		Msg("Started Nethermind container")

--- a/docker/test_env/test_utils.go
+++ b/docker/test_env/test_utils.go
@@ -18,8 +18,16 @@ func sendAndCompareBalances(ctx context.Context, c blockchain.EVMClient, address
 	}
 
 	toSendEth := big.NewFloat(1)
+
+	exp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	toSendEthInt := new(big.Int)
+	_, _ = toSendEth.Int(toSendEthInt)
+	sentInWei := new(big.Int).Mul(toSendEthInt, exp)
+
 	gasEstimations, err := c.EstimateGas(ethereum.CallMsg{
-		To: &address,
+		From:  common.HexToAddress(c.GetDefaultWallet().Address()),
+		To:    &address,
+		Value: sentInWei,
 	})
 	if err != nil {
 		return err
@@ -33,11 +41,6 @@ func sendAndCompareBalances(ctx context.Context, c blockchain.EVMClient, address
 	if err != nil {
 		return err
 	}
-
-	exp := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	toSendEthInt := new(big.Int)
-	_, _ = toSendEth.Int(toSendEthInt)
-	sentInWei := new(big.Int).Mul(toSendEthInt, exp)
 
 	expected := big.NewInt(0).Add(balanceBefore, sentInWei)
 


### PR DESCRIPTION
+ don't do fake gas estimation for zero address if evm node is not geth
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes focus on updating Ethereum client versions to their latest or more stable releases for multiple clients such as Besu, Erigon, Geth, and Nethermind within a test environment setup. Additionally, there's an enhancement in how gas estimations are handled and a minor correction in a test case to improve clarity and testing accuracy.

## What
- **docker/test_env/besu_base.go**
  - Updated `defaultBesuEth2Image` to `"hyperledger/besu:24.5.1"`. This change ensures the use of the latest Besu version for Ethereum 2.0 simulations, likely bringing in performance improvements and bug fixes.
  - Added `networkConfig.SimulationType = "Besu"` to clearly indicate the Ethereum client type in simulations, enhancing debuggability and logging.

- **docker/test_env/besu_test.go**
  - Modified error message in `TestBesuEth2` from `"Could connect to the evm client"` to `"Could connect Besu"`, and added a new line at the end of the file. These changes improve the error message's clarity when connections to the Besu client fail during tests.

- **docker/test_env/erigon_base.go**
  - Updated `defaultErigonEth2Image` to `"thorax/erigon:v2.59.3"`. This change updates the Erigon container to a more stable version for Ethereum 2.0 simulations, addressing specific issues like broken gas estimations.
  - Added `networkConfig.SimulationType = "Erigon"` to mark the simulation type explicitly, aiding in identifying the Ethereum client in use during tests.

- **docker/test_env/geth_base.go**
  - Updated `defaultGethEth2Image` to `"ethereum/client-go:v1.14.3"`. This update moves the Geth client to a newer version for Ethereum 2.0 simulations, likely incorporating new features and fixes.
  - Added `networkConfig.SimulationType = "Geth"` to label the type of Ethereum client being simulated, improving the ability to filter logs and debug issues.

- **docker/test_env/nethermind_base.go**
  - Updated `defaultNethermindEth2Image` to `"nethermind/nethermind:1.26.0"`. This update ensures the use of an updated Nethermind version for Ethereum 2.0 simulations, reflecting the latest improvements and bug resolutions.
  - Added `networkConfig.SimulationType = "Nethermind"` to specifically denote the client type in network simulations, facilitating easier identification during testing phases.

- **docker/test_env/test_utils.go**
  - Modified `sendAndCompareBalances` function to include `From` address and `Value` in `ethereum.CallMsg` for gas estimations, and reorganized the code for clarity. This adjustment ensures more accurate gas estimations by considering the transaction's value and sender, leading to more reliable test outcomes.
