### PR TITLE
Most besu images are tagged x.x but a couple are x.x.x, this handles both

### DIFF
--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -36,7 +36,7 @@ jobs:
           - name: confluentinc/cp-zookeeper
             expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
           - name: hyperledger/besu
-            expression: '^[0-9]+\.[0-9]+$'
+            expression: '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
             page_size: 300
           - name: thorax/erigon
             expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink-testing-framework/actions/runs/9115259310/job/25061137197#step:5:12 for an example run
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The update to the `.github/workflows/update-internal-mirrors.yaml` file enhances the version matching expression for the `hyperledger/besu` mirror. This change allows the script to recognize versions with three segments (`major.minor.patch`) in addition to the previously supported two-segment (`major.minor`) versions.

## What
- `.github/workflows/update-internal-mirrors.yaml`
  - Updated the version expression for `hyperledger/besu` from `'^[0-9]+\.[0-9]+$'` to `'^[0-9]+\.[0-9]+(\.[0-9]+)?$'`. This change means versions with an optional patch number are now matched, broadening the range of recognized versions for updates.
