### PR TITLE
[TT-1180] use RWMutex to protect LogStream's consumer map

### DIFF
--- a/logstream/logprocessor.go
+++ b/logstream/logprocessor.go
@@ -29,12 +29,14 @@ type LogProcessorFn[ReturnType any] func(content LogContent, returnValue *Return
 func (l *LogProcessor[ReturnType]) ProcessContainerLogs(containerName string, processFn func(content LogContent, returnValue *ReturnType) error) (*ReturnType, error) {
 	containerName = strings.Replace(containerName, "/", "", 1)
 	var consumer *ContainerLogConsumer
+	l.logStream.consumerMutex.RLock()
 	for _, c := range l.logStream.consumers {
 		if c.name == containerName {
 			consumer = c
 			break
 		}
 	}
+	l.logStream.consumerMutex.RUnlock()
 
 	if consumer == nil {
 		return new(ReturnType), fmt.Errorf("no consumer found for container %s", containerName)


### PR DESCRIPTION
Tried and tested [here](https://github.com/smartcontractkit/chainlink/pull/13240)

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance thread safety and error handling in the log streaming system. By introducing mutex locking, the code ensures that consumer access is synchronized, preventing data races. The addition of a no-op function for post-disconnect scenarios and the restructuring of shutdown procedures allow for more flexible and error-resilient shutdown logic. These modifications aim to improve the reliability and maintainability of the log streaming system.

## What
- **logstream/logprocessor.go**
  - Added `RLock()` and `RUnlock()` around consumer access to ensure thread safety during log processing.
- **logstream/logstream.go**
  - Introduced a `consumerMutex` of type `sync.RWMutex` to manage concurrent access to the consumer map.
  - Implemented mutex locking (`Lock()` and `Unlock()`) around modifications to the consumers map to prevent data races.
  - Added `RLock()` and `RUnlock()` around read operations on consumers to ensure thread safety.
  - Removed the direct error wrapping logic in `Shutdown` and replaced it with a more structured approach using `shutdownWithFunction`, allowing for additional operations post-disconnection but before Loki shutdown.
  - Added `noOpPostDisconnectFn`, a no-operation function used as a default argument for `shutdownWithFunction` for cases where no additional operations are needed post-disconnection.
  - Modified `FlushAndShutdown` to use `shutdownWithFunction`, incorporating log flushing as the post-disconnect operation.
  - Ensured read locks are applied during operations that read from the consumers map without modifying it, enhancing thread safety without unnecessary write locks.
