### PR TITLE
[TT-1179] make log scanner more robuts by creating a temporary snapshot

### DIFF
--- a/logstream/logprocessor.go
+++ b/logstream/logprocessor.go
@@ -110,7 +110,8 @@ func createTemporarySnapshot(file *os.File) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	readFile := os.NewFile(uintptr(fd), "name_doesnt_matter.txt")
+	// We are not creating a new file here, but creating a new file descriptor, but filename is still required
+	readFile := os.NewFile(uintptr(fd), "snapshot.txt")
 
 	// Move the cursor of the duplicated file descriptor to the beginning as otherwise, the file will be read from the current cursor position, which is at the end of the file
 	if _, err := readFile.Seek(0, 0); err != nil {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a more robust way to handle log reading during log processing by creating a temporary snapshot of the log file. This method prevents potential data corruption by locking the log file against new writes while the snapshot is created and used for reading.

## What
- `logstream/logprocessor.go`
  - Modified `ProcessContainerLogs` function to use a temporary snapshot for log processing instead of duplicating the file descriptor. This change ensures that the log processing does not interfere with concurrent log writes.
  - Added `createTemporarySnapshot` function that creates a temporary file snapshot of the log file. This function duplicates the file descriptor, creates a temporary file, copies the contents of the original log file to the temporary file, and verifies the integrity of the copied data.
