### PR TITLE
increase executions for fail fast case

### DIFF
--- a/concurrency/executor_test.go
+++ b/concurrency/executor_test.go
@@ -169,7 +169,7 @@ func TestExecuteFailFast(t *testing.T) {
 				errCh <- errors.New("always fail")
 			}
 
-			expectedExecutions := 100
+			expectedExecutions := 1000
 
 			configs := []config{}
 			for i := 0; i < expectedExecutions; i++ {


### PR DESCRIPTION
so that there's always enough time for circuit breaker to act
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The pull request increases the number of executions in the `TestExecuteFailFast` test case from 100 to 1000. This change aims to enhance the test's robustness by using a larger dataset, which may better simulate real-world usage and stress test the fail-fast functionality more effectively.

## What
- **concurrency/executor_test.go**
  - Increased the value of `expectedExecutions` from 100 to 1000 in `TestExecuteFailFast`.
    - This change affects how many times the `processorFn` function is called, potentially altering the behavior of the fail-fast feature during testing.
