### PR TITLE
return error on teardown if any err logs instead of failing the test

### DIFF
--- a/testreporters/reporter_model.go
+++ b/testreporters/reporter_model.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 
@@ -63,7 +64,10 @@ func WriteTeardownLogs(
 			return VerifyLogFile(file, failingLogLevel, 1)
 		})
 	}
-	assert.NoError(t, verifyLogsGroup.Wait(), "Found a concerning log")
+	err = verifyLogsGroup.Wait()
+	if err != nil {
+		return errors.Wrap(err, "found a concerning log")
+	}
 
 	if t.Failed() || optionalTestReporter != nil {
 		if err := SendReport(t, env.Cfg.Namespace, logsPath, optionalTestReporter, grafanaUrlProvider); err != nil {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve error handling and dependency management in the `testreporters` package. By replacing `assert.NoError` with a direct error check and leveraging `github.com/pkg/errors` for wrapping, it enhances how errors are handled and reported, making it easier to understand the context of failures.

## What
- **testreporters/reporter_model.go**
  - Added `github.com/pkg/errors` import for enhanced error wrapping.
  - Removed `github.com/stretchr/testify/assert` import to replace the assertion with standard error handling.
  - Modified `WriteTeardownLogs` function to use error wrapping instead of asserting no error, providing more detailed error context when log verification fails.
