### PR TITLE
Add `get-latest-ethereum-client-version` command to CTF Utils CMD Tool

### DIFF
--- a/utils/cmd/internal/get_latest_version_commands.go
+++ b/utils/cmd/internal/get_latest_version_commands.go
@@ -14,7 +14,7 @@ var GetLatestEthereumClientVersionCmd = &cobra.Command{
 	Short: "Get the latest Ethereum client release version from Github",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return fmt.Errorf("please provide the repository in the format 'owner/repo:tag'")
+			return fmt.Errorf("please provide the repository in the format 'org/repo:tag'")
 		}
 
 		repo := args[0]

--- a/utils/cmd/internal/get_latest_version_commands.go
+++ b/utils/cmd/internal/get_latest_version_commands.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/docker/test_env"
+)
+
+var GetLatestEthereumClientVersionCmd = &cobra.Command{
+	Use:   "get-latest-ethereum-client-version",
+	Short: "Get the latest Ethereum client release version from Github",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("please provide the repository in the format 'owner/repo:tag'")
+		}
+
+		repo := args[0]
+
+		latest, err := test_env.FetchLatestEthereumClientDockerImageVersionIfNeed(repo)
+		if err != nil {
+			return fmt.Errorf("error fetching release information: %v", err)
+		}
+
+		fmt.Println(strings.Split(latest, ":")[1])
+		return nil
+	},
+}

--- a/utils/cmd/main.go
+++ b/utils/cmd/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/utils/cmd/internal"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "ctf-utils",
+	Short: "CTF Utils Tool",
+}
+
+func init() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*1)
+	defer cancel()
+
+	internal.GetLatestEthereumClientVersionCmd.SetContext(ctx)
+
+	rootCmd.AddCommand(internal.GetLatestEthereumClientVersionCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Required for https://github.com/smartcontractkit/chainlink/pull/13271
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new command-line utility for the Chainlink Testing Framework (CTF) that fetches the latest Ethereum client version from a specified GitHub repository. This utility aims to streamline the process of obtaining the most recent version of an Ethereum client for testing purposes, enhancing the efficiency of setting up test environments.

## What
- **utils/cmd/internal/get_latest_version_commands.go**:  
  - New file created.  
  - Adds a new Cobra command `GetLatestEthereumClientVersionCmd` to fetch the latest Ethereum client release version from GitHub.  
  - Validates the input format and prints the fetched version.
- **utils/cmd/main.go**:  
  - New file created.  
  - Initializes a new Cobra root command `ctf-utils` with a short description.  
  - Registers `GetLatestEthereumClientVersionCmd` as a subcommand and sets a context with a 1-minute timeout for its execution.
