### PR TITLE
[TT-1207] Default Seth network

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/common v0.45.0
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890
+	github.com/smartcontractkit/seth v1.0.11
 	github.com/smartcontractkit/wasp v0.4.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -25,10 +25,10 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
-	github.com/prometheus/common v0.44.0
+	github.com/prometheus/common v0.45.0
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/seth v0.1.6-0.20240429143720-cacb8160ecec
+	github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890
 	github.com/smartcontractkit/wasp v0.4.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
@@ -199,7 +199,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/miekg/dns v1.1.56 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
@@ -293,7 +293,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231012201019-e917dd12ba7a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
 	google.golang.org/grpc v1.59.0 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
+	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1032,8 +1032,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ=
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
-github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890 h1:3wvckBhXb28O4v5LJxp2KNwzn6+EKHOq1bQRDV+U7Ag=
-github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890/go.mod h1:fVCE+8LD6AbU7d8BHZ1uS/ceJ+8JO0iVTUcDdQmGPAc=
+github.com/smartcontractkit/seth v1.0.11 h1:Ct8wSifW2ZXnyHtYRKaawBnpW7Ef0m8zItUcqYPallM=
+github.com/smartcontractkit/seth v1.0.11/go.mod h1:fVCE+8LD6AbU7d8BHZ1uS/ceJ+8JO0iVTUcDdQmGPAc=
 github.com/smartcontractkit/wasp v0.4.1 h1:qgIx2s+eCwH0OaBKaHEAHUQ1Z47bAgDu+ICS9IOqvGQ=
 github.com/smartcontractkit/wasp v0.4.1/go.mod h1:3qiofyI3pkbrc48a3CVshbMfgl74SiuPL/tm30d9Wb4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/go.sum
+++ b/go.sum
@@ -801,8 +801,8 @@ github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJK
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
-github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
+github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -955,8 +955,8 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
-github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=
-github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
+github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lneoxM=
+github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdDeppTwGX4=
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/exporter-toolkit v0.10.1-0.20230714054209-2f4150c63f97 h1:oHcfzdJnM/SFppy2aUlvomk37GI33x9vgJULihE5Dt8=
@@ -1032,8 +1032,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ=
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
-github.com/smartcontractkit/seth v0.1.6-0.20240429143720-cacb8160ecec h1:BT1loU6TT2YqMenD7XE+aw7IeeTiC25+r1TLKAySVIg=
-github.com/smartcontractkit/seth v0.1.6-0.20240429143720-cacb8160ecec/go.mod h1:2TMOZQ8WTAw7rR1YBbXpnad6VmT/+xDd/nXLmB7Eero=
+github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890 h1:3wvckBhXb28O4v5LJxp2KNwzn6+EKHOq1bQRDV+U7Ag=
+github.com/smartcontractkit/seth v1.0.10-0.20240527141846-e5cc48324890/go.mod h1:fVCE+8LD6AbU7d8BHZ1uS/ceJ+8JO0iVTUcDdQmGPAc=
 github.com/smartcontractkit/wasp v0.4.1 h1:qgIx2s+eCwH0OaBKaHEAHUQ1Z47bAgDu+ICS9IOqvGQ=
 github.com/smartcontractkit/wasp v0.4.1/go.mod h1:3qiofyI3pkbrc48a3CVshbMfgl74SiuPL/tm30d9Wb4=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1605,8 +1605,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
+google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/k8s/imports/k8s/httpchaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/httpchaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/httpchaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/httpchaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/httpchaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/httpchaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,10 +41,10 @@ func init() {
 		"chaos-meshorg.HttpChaosSpecMode",
 		reflect.TypeOf((*HttpChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": HttpChaosSpecMode_ONE,
-			"ALL": HttpChaosSpecMode_ALL,
-			"FIXED": HttpChaosSpecMode_FIXED,
-			"FIXED_PERCENT": HttpChaosSpecMode_FIXED_PERCENT,
+			"ONE":                HttpChaosSpecMode_ONE,
+			"ALL":                HttpChaosSpecMode_ALL,
+			"FIXED":              HttpChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      HttpChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": HttpChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)
@@ -72,7 +72,7 @@ func init() {
 		"chaos-meshorg.HttpChaosSpecTarget",
 		reflect.TypeOf((*HttpChaosSpecTarget)(nil)).Elem(),
 		map[string]interface{}{
-			"REQUEST": HttpChaosSpecTarget_REQUEST,
+			"REQUEST":  HttpChaosSpecTarget_REQUEST,
 			"RESPONSE": HttpChaosSpecTarget_RESPONSE,
 		},
 	)

--- a/k8s/imports/k8s/httpchaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/httpchaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/httpchaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/httpchaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/internal/types.go
+++ b/k8s/imports/k8s/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/iochaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/iochaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/iochaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/iochaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/iochaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/iochaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,10 +41,10 @@ func init() {
 		"chaos-meshorg.IoChaosSpecAction",
 		reflect.TypeOf((*IoChaosSpecAction)(nil)).Elem(),
 		map[string]interface{}{
-			"LATENCY": IoChaosSpecAction_LATENCY,
-			"FAULT": IoChaosSpecAction_FAULT,
+			"LATENCY":       IoChaosSpecAction_LATENCY,
+			"FAULT":         IoChaosSpecAction_FAULT,
 			"ATTR_OVERRIDE": IoChaosSpecAction_ATTR_OVERRIDE,
-			"MISTAKE": IoChaosSpecAction_MISTAKE,
+			"MISTAKE":       IoChaosSpecAction_MISTAKE,
 		},
 	)
 	_jsii_.RegisterStruct(
@@ -71,7 +71,7 @@ func init() {
 		"chaos-meshorg.IoChaosSpecMistakeFilling",
 		reflect.TypeOf((*IoChaosSpecMistakeFilling)(nil)).Elem(),
 		map[string]interface{}{
-			"ZERO": IoChaosSpecMistakeFilling_ZERO,
+			"ZERO":   IoChaosSpecMistakeFilling_ZERO,
 			"RANDOM": IoChaosSpecMistakeFilling_RANDOM,
 		},
 	)
@@ -79,10 +79,10 @@ func init() {
 		"chaos-meshorg.IoChaosSpecMode",
 		reflect.TypeOf((*IoChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": IoChaosSpecMode_ONE,
-			"ALL": IoChaosSpecMode_ALL,
-			"FIXED": IoChaosSpecMode_FIXED,
-			"FIXED_PERCENT": IoChaosSpecMode_FIXED_PERCENT,
+			"ONE":                IoChaosSpecMode_ONE,
+			"ALL":                IoChaosSpecMode_ALL,
+			"FIXED":              IoChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      IoChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": IoChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)

--- a/k8s/imports/k8s/iochaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/iochaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/iochaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/iochaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/k8s.go
+++ b/k8s/imports/k8s/k8s.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/internal"
 )
 

--- a/k8s/imports/k8s/networkchaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/networkchaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/networkchaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/networkchaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/networkchaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/networkchaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,11 +41,11 @@ func init() {
 		"chaos-meshorg.NetworkChaosSpecAction",
 		reflect.TypeOf((*NetworkChaosSpecAction)(nil)).Elem(),
 		map[string]interface{}{
-			"NETEM": NetworkChaosSpecAction_NETEM,
-			"DELAY": NetworkChaosSpecAction_DELAY,
-			"LOSS": NetworkChaosSpecAction_LOSS,
+			"NETEM":     NetworkChaosSpecAction_NETEM,
+			"DELAY":     NetworkChaosSpecAction_DELAY,
+			"LOSS":      NetworkChaosSpecAction_LOSS,
 			"DUPLICATE": NetworkChaosSpecAction_DUPLICATE,
-			"CORRUPT": NetworkChaosSpecAction_CORRUPT,
+			"CORRUPT":   NetworkChaosSpecAction_CORRUPT,
 			"PARTITION": NetworkChaosSpecAction_PARTITION,
 			"BANDWIDTH": NetworkChaosSpecAction_BANDWIDTH,
 		},
@@ -70,9 +70,9 @@ func init() {
 		"chaos-meshorg.NetworkChaosSpecDirection",
 		reflect.TypeOf((*NetworkChaosSpecDirection)(nil)).Elem(),
 		map[string]interface{}{
-			"TO": NetworkChaosSpecDirection_TO,
-			"FROM": NetworkChaosSpecDirection_FROM,
-			"BOTH": NetworkChaosSpecDirection_BOTH,
+			"TO":     NetworkChaosSpecDirection_TO,
+			"FROM":   NetworkChaosSpecDirection_FROM,
+			"BOTH":   NetworkChaosSpecDirection_BOTH,
 			"VALUE_": NetworkChaosSpecDirection_VALUE_,
 		},
 	)
@@ -88,10 +88,10 @@ func init() {
 		"chaos-meshorg.NetworkChaosSpecMode",
 		reflect.TypeOf((*NetworkChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": NetworkChaosSpecMode_ONE,
-			"ALL": NetworkChaosSpecMode_ALL,
-			"FIXED": NetworkChaosSpecMode_FIXED,
-			"FIXED_PERCENT": NetworkChaosSpecMode_FIXED_PERCENT,
+			"ONE":                NetworkChaosSpecMode_ONE,
+			"ALL":                NetworkChaosSpecMode_ALL,
+			"FIXED":              NetworkChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      NetworkChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": NetworkChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)
@@ -111,10 +111,10 @@ func init() {
 		"chaos-meshorg.NetworkChaosSpecTargetMode",
 		reflect.TypeOf((*NetworkChaosSpecTargetMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": NetworkChaosSpecTargetMode_ONE,
-			"ALL": NetworkChaosSpecTargetMode_ALL,
-			"FIXED": NetworkChaosSpecTargetMode_FIXED,
-			"FIXED_PERCENT": NetworkChaosSpecTargetMode_FIXED_PERCENT,
+			"ONE":                NetworkChaosSpecTargetMode_ONE,
+			"ALL":                NetworkChaosSpecTargetMode_ALL,
+			"FIXED":              NetworkChaosSpecTargetMode_FIXED,
+			"FIXED_PERCENT":      NetworkChaosSpecTargetMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": NetworkChaosSpecTargetMode_RANDOM_MAX_PERCENT,
 		},
 	)

--- a/k8s/imports/k8s/networkchaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/networkchaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/networkchaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/networkchaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/podchaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/podchaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podchaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podchaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/podchaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/podchaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,8 +41,8 @@ func init() {
 		"chaos-meshorg.PodChaosSpecAction",
 		reflect.TypeOf((*PodChaosSpecAction)(nil)).Elem(),
 		map[string]interface{}{
-			"POD_KILL": PodChaosSpecAction_POD_KILL,
-			"POD_FAILURE": PodChaosSpecAction_POD_FAILURE,
+			"POD_KILL":       PodChaosSpecAction_POD_KILL,
+			"POD_FAILURE":    PodChaosSpecAction_POD_FAILURE,
 			"CONTAINER_KILL": PodChaosSpecAction_CONTAINER_KILL,
 		},
 	)
@@ -50,10 +50,10 @@ func init() {
 		"chaos-meshorg.PodChaosSpecMode",
 		reflect.TypeOf((*PodChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": PodChaosSpecMode_ONE,
-			"ALL": PodChaosSpecMode_ALL,
-			"FIXED": PodChaosSpecMode_FIXED,
-			"FIXED_PERCENT": PodChaosSpecMode_FIXED_PERCENT,
+			"ONE":                PodChaosSpecMode_ONE,
+			"ALL":                PodChaosSpecMode_ALL,
+			"FIXED":              PodChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      PodChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": PodChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)

--- a/k8s/imports/k8s/podchaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/podchaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/podchaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/podchaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/podiochaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/podiochaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podiochaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podiochaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/podiochaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/podiochaos/chaosmeshorg/chaosmeshorg.init.go
@@ -61,7 +61,7 @@ func init() {
 		"chaos-meshorg.PodIoChaosSpecActionsMistakeFilling",
 		reflect.TypeOf((*PodIoChaosSpecActionsMistakeFilling)(nil)).Elem(),
 		map[string]interface{}{
-			"ZERO": PodIoChaosSpecActionsMistakeFilling_ZERO,
+			"ZERO":   PodIoChaosSpecActionsMistakeFilling_ZERO,
 			"RANDOM": PodIoChaosSpecActionsMistakeFilling_RANDOM,
 		},
 	)

--- a/k8s/imports/k8s/podiochaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/podiochaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/podiochaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/podiochaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/podnetworkchaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/stresschaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/stresschaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/stresschaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/stresschaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/stresschaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/stresschaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,10 +41,10 @@ func init() {
 		"chaos-meshorg.StressChaosSpecMode",
 		reflect.TypeOf((*StressChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": StressChaosSpecMode_ONE,
-			"ALL": StressChaosSpecMode_ALL,
-			"FIXED": StressChaosSpecMode_FIXED,
-			"FIXED_PERCENT": StressChaosSpecMode_FIXED_PERCENT,
+			"ONE":                StressChaosSpecMode_ONE,
+			"ALL":                StressChaosSpecMode_ALL,
+			"FIXED":              StressChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      StressChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": StressChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)

--- a/k8s/imports/k8s/stresschaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/stresschaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/stresschaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/stresschaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/k8s/imports/k8s/timechaos/chaosmeshorg/chaosmeshorg.go
+++ b/k8s/imports/k8s/timechaos/chaosmeshorg/chaosmeshorg.go
@@ -3,10 +3,12 @@ package chaosmeshorg
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
+
 	_init_ "github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/timechaos/chaosmeshorg/jsii"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/imports/k8s/timechaos/chaosmeshorg/internal"
 )
 

--- a/k8s/imports/k8s/timechaos/chaosmeshorg/chaosmeshorg.init.go
+++ b/k8s/imports/k8s/timechaos/chaosmeshorg/chaosmeshorg.init.go
@@ -41,10 +41,10 @@ func init() {
 		"chaos-meshorg.TimeChaosSpecMode",
 		reflect.TypeOf((*TimeChaosSpecMode)(nil)).Elem(),
 		map[string]interface{}{
-			"ONE": TimeChaosSpecMode_ONE,
-			"ALL": TimeChaosSpecMode_ALL,
-			"FIXED": TimeChaosSpecMode_FIXED,
-			"FIXED_PERCENT": TimeChaosSpecMode_FIXED_PERCENT,
+			"ONE":                TimeChaosSpecMode_ONE,
+			"ALL":                TimeChaosSpecMode_ALL,
+			"FIXED":              TimeChaosSpecMode_FIXED,
+			"FIXED_PERCENT":      TimeChaosSpecMode_FIXED_PERCENT,
 			"RANDOM_MAX_PERCENT": TimeChaosSpecMode_RANDOM_MAX_PERCENT,
 		},
 	)

--- a/k8s/imports/k8s/timechaos/chaosmeshorg/internal/types.go
+++ b/k8s/imports/k8s/timechaos/chaosmeshorg/internal/types.go
@@ -1,5 +1,7 @@
 package internal
+
 import (
 	"github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2"
 )
+
 type Type__cdk8sApiObject = cdk8s.ApiObject

--- a/k8s/imports/k8s/timechaos/chaosmeshorg/jsii/jsii.go
+++ b/k8s/imports/k8s/timechaos/chaosmeshorg/jsii/jsii.go
@@ -5,12 +5,12 @@
 package jsii
 
 import (
-	_          "embed"
+	_ "embed"
 
-	_jsii_     "github.com/aws/jsii-runtime-go/runtime"
+	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
 
 	constructs "github.com/aws/constructs-go/constructs/v10/jsii"
-	cdk8s      "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
+	cdk8s "github.com/cdk8s-team/cdk8s-core-go/cdk8s/v2/jsii"
 )
 
 //go:embed chaos-meshorg-0.0.0.tgz

--- a/utils/seth/seth.go
+++ b/utils/seth/seth.go
@@ -3,6 +3,7 @@ package seth
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -13,16 +14,16 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/environment"
 )
 
-var INSUFFICIENT_EPHEMERAL_KEYS = `
+var ErrInsufficientEphemeralKeys = `
 Error: Insufficient Ephemeral Addresses for Simulated Network
 
 To operate on a simulated network, you must configure at least one ephemeral address. Currently, %d ephemeral address(es) are set. Please update your TOML configuration file as follows to meet this requirement:
 [Seth] ephemeral_addresses_number = 1
 
-This adjustment ensures that your setup is minimaly viable. Although it is highly recommended to use at least 20 ephemeral addresses.
+This adjustment ensures that your setup is minimally viable. Although it is highly recommended to use at least 20 ephemeral addresses.
 `
 
-var INSUFFICIENT_STATIC_KEYS = `
+var ErrInsufficientStaticKeys = `
 Error: Insufficient Private Keys for Live Network
 
 To run this test on a live network, you must either:
@@ -49,7 +50,7 @@ var OneEphemeralKeysLiveTestnetCheckFn = func(sethCfg *pkg_seth.Config) error {
 
 	if sethCfg.IsSimulatedNetwork() {
 		if concurrency < 1 {
-			return fmt.Errorf(INSUFFICIENT_EPHEMERAL_KEYS, 0)
+			return fmt.Errorf(ErrInsufficientEphemeralKeys, 0)
 		}
 
 		return nil
@@ -70,7 +71,7 @@ var OneEphemeralKeysLiveTestnetCheckFn = func(sethCfg *pkg_seth.Config) error {
 	}
 
 	if concurrency < 1 {
-		return fmt.Errorf(INSUFFICIENT_STATIC_KEYS, len(sethCfg.Network.PrivateKeys))
+		return fmt.Errorf(ErrInsufficientStaticKeys, len(sethCfg.Network.PrivateKeys))
 	}
 
 	return nil
@@ -83,7 +84,7 @@ var OneEphemeralKeysLiveTestnetAutoFixFn = func(sethCfg *pkg_seth.Config) error 
 
 	if sethCfg.IsSimulatedNetwork() {
 		if concurrency < 1 {
-			return fmt.Errorf(INSUFFICIENT_EPHEMERAL_KEYS, 0)
+			return fmt.Errorf(ErrInsufficientEphemeralKeys, 0)
 		}
 
 		return nil
@@ -95,7 +96,7 @@ var OneEphemeralKeysLiveTestnetAutoFixFn = func(sethCfg *pkg_seth.Config) error 
 	}
 
 	if concurrency < 1 {
-		return fmt.Errorf(INSUFFICIENT_STATIC_KEYS, len(sethCfg.Network.PrivateKeys))
+		return fmt.Errorf(ErrInsufficientStaticKeys, len(sethCfg.Network.PrivateKeys))
 	}
 
 	return nil
@@ -110,7 +111,7 @@ func GetChainClient(c config.SethConfig, network blockchain.EVMNetwork) (*pkg_se
 func GetChainClientWithConfigFunction(c config.SethConfig, network blockchain.EVMNetwork, configFn ConfigFunction) (*pkg_seth.Client, error) {
 	readSethCfg := c.GetSethConfig()
 	if readSethCfg == nil {
-		return nil, fmt.Errorf("Seth config not found")
+		return nil, errors.New("seth config not found")
 	}
 
 	sethCfg, err := MergeSethAndEvmNetworkConfigs(network, *readSethCfg)
@@ -165,7 +166,7 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 				sethNetwork = conf
 				break
 			}
-		} else if conf.ChainID == fmt.Sprint(evmNetwork.ChainID) {
+		} else if strings.EqualFold(conf.Name, fmt.Sprint(evmNetwork.Name)) {
 			conf.PrivateKeys = evmNetwork.PrivateKeys
 			if len(conf.URLs) == 0 {
 				conf.URLs = evmNetwork.URLs
@@ -178,7 +179,7 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 
 	if sethNetwork == nil {
 		for _, conf := range sethConfig.Networks {
-			if conf.ChainID == fmt.Sprint(pkg_seth.DefaultChainID) {
+			if conf.Name == fmt.Sprint(pkg_seth.DefaultNetworkName) {
 				conf.Name = evmNetwork.Name
 				conf.ChainID = fmt.Sprint(evmNetwork.ChainID)
 				conf.PrivateKeys = evmNetwork.PrivateKeys
@@ -193,9 +194,9 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 			msg := `Failed to build network config for chain ID %d. This could be the result of various reasons:
 1. You are running tests for a network that hasn't been defined in known_networks.go and you have not defined it under [Network.EVMNetworks.NETWORK_NAME] in TOML
 3. You have not defined Seth network settings for the chain ID %d in TOML under [Seth.Networks]
-2. You have not defined a Seth Default network in your TOML config file under [Seth.Networks] using chain ID %s and name %s`
+2. You have not defined a Seth Default network in your TOML config file under [Seth.Networks] using name %s`
 
-			return pkg_seth.Config{}, fmt.Errorf(msg, evmNetwork.ChainID, evmNetwork.ChainID, pkg_seth.DefaultChainID, pkg_seth.DefaultNetworkName)
+			return pkg_seth.Config{}, fmt.Errorf(msg, evmNetwork.ChainID, evmNetwork.ChainID, pkg_seth.DefaultNetworkName)
 		}
 	}
 
@@ -237,40 +238,40 @@ func MustReplaceSimulatedNetworkUrlWithK8(l zerolog.Logger, network blockchain.E
 // ValidateSethNetworkConfig validates the Seth network config
 func ValidateSethNetworkConfig(cfg *pkg_seth.Network) error {
 	if cfg == nil {
-		return fmt.Errorf("Network cannot be nil")
+		return errors.New("network cannot be nil")
 	}
 	if cfg.ChainID == "" {
-		return fmt.Errorf("ChainID is required")
+		return errors.New("chainID is required")
 	}
 	_, err := strconv.Atoi(cfg.ChainID)
 	if err != nil {
-		return fmt.Errorf("ChainID needs to be a number")
+		return errors.New("chainID needs to be a number")
 	}
 	if cfg.URLs == nil || len(cfg.URLs) == 0 {
-		return fmt.Errorf("URLs are required")
+		return errors.New("url is required")
 	}
 	if cfg.PrivateKeys == nil || len(cfg.PrivateKeys) == 0 {
-		return fmt.Errorf("PrivateKeys are required")
+		return errors.New("private keys are required")
 	}
 	if cfg.TransferGasFee == 0 {
-		return fmt.Errorf("TransferGasFee needs to be above 0. It's the gas fee for a simple transfer transaction")
+		return errors.New("transferGasFee needs to be above 0. It's the gas fee for a simple transfer transaction")
 	}
 	if cfg.TxnTimeout.Duration() == 0 {
-		return fmt.Errorf("TxnTimeout needs to be above 0. It's the timeout for a transaction")
+		return errors.New("txnTimeout needs to be above 0. It's the timeout for a transaction")
 	}
 	if cfg.EIP1559DynamicFees {
 		if cfg.GasFeeCap == 0 {
-			return fmt.Errorf("GasFeeCap needs to be above 0. It's the maximum fee per gas for a transaction (including tip)")
+			return errors.New("gas fee cap needs to be above 0. It's the maximum fee per gas for a transaction (including tip)")
 		}
 		if cfg.GasTipCap == 0 {
-			return fmt.Errorf("GasTipCap needs to be above 0. It's the maximum tip per gas for a transaction")
+			return errors.New("gas tip cap needs to be above 0. It's the maximum tip per gas for a transaction")
 		}
 		if cfg.GasFeeCap <= cfg.GasTipCap {
-			return fmt.Errorf("GasFeeCap needs to be above GasTipCap (as it is base fee + tip cap)")
+			return errors.New("gas fee cap needs to be above GasTipCap (as it is base fee + tip cap)")
 		}
 	} else {
 		if cfg.GasPrice == 0 {
-			return fmt.Errorf("GasPrice needs to be above 0. It's the price of gas for a transaction")
+			return errors.New("gas price needs to be above 0. It's the price of gas for a transaction")
 		}
 	}
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce version updates for dependencies in the `go.mod` and `go.sum` files to ensure compatibility and leverage new features or bug fixes. Corrections in spelling and additional handling for network configurations in the `utils/seth/seth.go` file aim to improve clarity in error messages and enhance the flexibility in network configuration management, especially for cases involving new or undefined EVM networks.

## What
- `go.mod`
  - Updated `github.com/prometheus/common` from `v0.44.0` to `v0.45.0`
  - Updated `github.com/smartcontractkit/seth` from `v0.1.6-0.20240429143720-cacb8160ecec` to `v1.0.10-0.20240527141846-e5cc48324890`
  - Updated `github.com/matttproud/golang_protobuf_extensions` from `v1.0.4` to `v2.0.0`
- `go.sum`
  - Updated checksums for `github.com/prometheus/common`, `github.com/smartcontractkit/seth`, and `github.com/matttproud/golang_protobuf_extensions` to match the versions specified in `go.mod`.
- `utils/seth/seth.go`
  - Corrected a spelling mistake from "epehemeral" to "ephemeral" in two instances.
  - Added a new handling case in `MergeSethAndEvmNetworkConfigs` function for when a matching EVM network configuration is not found, providing a detailed error message and attempting to use a default network configuration if available.
  - Introduced `const RootKeyNum` and `func AvailableSethKeyNum` to improve key management and selection logic.
