### PR TITLE
gotestloghelper: fix validate issues when -ci is passed but -json is not

### DIFF
--- a/tools/gotestloghelper/gotestevent/gotestevent.go
+++ b/tools/gotestloghelper/gotestevent/gotestevent.go
@@ -343,23 +343,23 @@ func (c *TestLogModifierConfig) Validate() error {
 		if c.HidePassingTests.Value || c.OnlyErrors.Value {
 			return fmt.Errorf("-hidepassinglogs flag is not compatible with -hidepassingtests or -onlyerrors flags")
 		}
-		if !*c.IsJsonInput {
-			return fmt.Errorf("hidepassinglogs flag is only valid when run with -json flag")
+		if !*c.IsJsonInput && !*c.CI {
+			return fmt.Errorf("-hidepassinglogs flag is only valid when run with -json flag")
 		}
 	}
 	if c.OnlyErrors.Value {
-		if !*c.IsJsonInput {
+		if !*c.IsJsonInput && !*c.CI {
 			return fmt.Errorf("-onlyerrors flag is only valid when run with -json flag")
 		}
 		c.HidePassingTests = c.OnlyErrors
 	}
 	if c.HidePassingTests.Value {
-		if !*c.IsJsonInput {
+		if !*c.IsJsonInput && !*c.CI {
 			return fmt.Errorf("-hidepassingtests flag is only valid when run with -json flag")
 		}
 	}
 	if *c.ErrorAtTopLength < 0 {
-		return fmt.Errorf("ErrorAtTopLength must be greater than or equal to 0")
+		return fmt.Errorf("-errorattoplength must be greater than or equal to 0")
 	}
 	return nil
 }


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve error messaging and validation logic in the configuration of a Go test log helper tool, ensuring clearer guidance for users and support for CI environments.

## What
- **tools/gotestloghelper/gotestevent/gotestevent.go**  
  - Modified validation error messages to include flag prefixes for consistency and clarity.  
  - Updated validation logic to allow `-hidepassinglogs`, `-onlyerrors`, and `-hidepassingtests` flags to be valid when either `-json` flag is used or in CI environments, expanding the tool's flexibility and usability in automated settings.  
  - Changed the `ErrorAtTopLength` validation error message to align with flag naming conventions.  
