### PR TITLE
Bump version of gotestloghelper to v1.1.1

### DIFF
--- a/tools/gotestloghelper/package.json
+++ b/tools/gotestloghelper/package.json
@@ -1,5 +1,5 @@
 {
   "name": "gotestloghelper",
   "description": "Tool to clean up go test logs and reduce noise delivered to the developer",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }


### PR DESCRIPTION
Forgot to bump it in the previous commit
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The version of the `gotestloghelper` tool has been incremented to introduce improvements or fixes, ensuring the tool remains up-to-date and functional.

## What
- **tools/gotestloghelper/package.json**
  - Updated the `version` from `1.1.0` to `1.1.1`. This change signifies a minor update, possibly including bug fixes or minor improvements to the tool without introducing any breaking changes.
