### PR TITLE
[fix] copy wait for finalisation from imported config

### DIFF
--- a/docker/test_env/ethereum_env.go
+++ b/docker/test_env/ethereum_env.go
@@ -223,6 +223,10 @@ func (b *EthereumNetworkBuilder) importExistingConfig() bool {
 	b.ethereumChainConfig = b.existingConfig.EthereumChainConfig
 	b.customDockerImages = b.existingConfig.CustomDockerImages
 
+	if b.existingConfig.WaitForFinalization != nil {
+		b.waitForFinalization = *b.existingConfig.WaitForFinalization
+	}
+
 	if b.existingConfig.NodeLogLevel != nil {
 		b.nodeLogLevel = *b.existingConfig.NodeLogLevel
 	} else {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the `EthereumNetworkBuilder` can now import the `WaitForFinalization` configuration from an existing configuration if provided. This enhances the flexibility and configurability of the Ethereum test environment setup.

## What
- **docker/test_env/ethereum_env.go**
  - Added handling for `WaitForFinalization` in `importExistingConfig` function. Checks if `WaitForFinalization` is not nil in the existing config and sets it accordingly. This allows the builder to respect a specific configuration regarding whether to wait for finalization when setting up the Ethereum network, improving test setup flexibility.
