### PR TITLE
Update Anvil

### DIFF
--- a/charts/foundry/Chart.yaml
+++ b/charts/foundry/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: foundry
 description: A Helm chart for foundry, mostly used to run Anvil node
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: 'latest'

--- a/charts/foundry/templates/_helpers.tpl
+++ b/charts/foundry/templates/_helpers.tpl
@@ -8,18 +8,13 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
 */}}
 {{- define "foundry.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/k8s/pkg/helm/foundry/foundry.go
+++ b/k8s/pkg/helm/foundry/foundry.go
@@ -68,10 +68,10 @@ func (m *Chart) ExportData(e *environment.Environment) error {
 		return err
 	}
 
-	e.URLs[appInstance+"cluster_ws"] = []string{m.ClusterWSURL}
-	e.URLs[appInstance+"cluster_http"] = []string{m.ClusterHTTPURL}
-	e.URLs[appInstance+"forwarded_ws"] = []string{m.ForwardedWSURL}
-	e.URLs[appInstance+"forwarded_http"] = []string{m.ForwardedHTTPURL}
+	e.URLs[appInstance+"_cluster_ws"] = []string{m.ClusterWSURL}
+	e.URLs[appInstance+"_cluster_http"] = []string{m.ClusterHTTPURL}
+	e.URLs[appInstance+"_forwarded_ws"] = []string{m.ForwardedWSURL}
+	e.URLs[appInstance+"_forwarded_http"] = []string{m.ForwardedHTTPURL}
 
 	for k, v := range e.URLs {
 		if strings.Contains(k, appInstance) {

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -148,6 +148,25 @@ var (
 		GasEstimationBuffer:       10000,
 	}
 
+	SimulatedAnvil = blockchain.EVMNetwork{
+		Name:                 "Simulated Anvil",
+		Simulated:            true,
+		SupportsEIP1559:      true,
+		ClientImplementation: blockchain.EthereumClientImplementation,
+		ChainID:              31337,
+		PrivateKeys: []string{
+			"ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+			"59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+			"5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+			"7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+			"47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+		},
+		ChainlinkTransactionLimit: 500000,
+		Timeout:                   blockchain.StrDuration{Duration: 2 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+	}
+
 	EthereumMainnet blockchain.EVMNetwork = blockchain.EVMNetwork{
 		Name:                      "Ethereum Mainnet",
 		SupportsEIP1559:           true,
@@ -859,6 +878,7 @@ var (
 
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
+		"SIMULATED_ANVIL":         SimulatedAnvil,
 		"SIMULATED_1":             SimulatedEVMNonDev1,
 		"SIMULATED_2":             SimulatedEVMNonDev2,
 		"SIMULATED_BESU_NONDEV_1": SimulatedBesuNonDev1,

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -148,8 +148,8 @@ var (
 		GasEstimationBuffer:       10000,
 	}
 
-	SimulatedAnvil = blockchain.EVMNetwork{
-		Name:                 "Simulated Anvil",
+	Anvil = blockchain.EVMNetwork{
+		Name:                 "Anvil",
 		Simulated:            true,
 		SupportsEIP1559:      true,
 		ClientImplementation: blockchain.EthereumClientImplementation,
@@ -878,7 +878,7 @@ var (
 
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
-		"SIMULATED_ANVIL":         SimulatedAnvil,
+		"ANVIL":                   Anvil,
 		"SIMULATED_1":             SimulatedEVMNonDev1,
 		"SIMULATED_2":             SimulatedEVMNonDev2,
 		"SIMULATED_BESU_NONDEV_1": SimulatedBesuNonDev1,

--- a/utils/seth/seth.go
+++ b/utils/seth/seth.go
@@ -211,7 +211,7 @@ func MustReplaceSimulatedNetworkUrlWithK8(l zerolog.Logger, network blockchain.E
 		return network
 	}
 
-	networkKeys := []string{"Simulated Geth", "Simulated-Geth", "simulated-geth_http"}
+	networkKeys := []string{"Simulated Geth", "Simulated-Geth"}
 	var keyToUse string
 
 	for _, key := range networkKeys {

--- a/utils/seth/seth.go
+++ b/utils/seth/seth.go
@@ -149,7 +149,7 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 
 	for _, conf := range sethConfig.Networks {
 		if evmNetwork.Simulated {
-			if conf.Name == pkg_seth.GETH {
+			if conf.Name == pkg_seth.GETH || conf.Name == pkg_seth.ANVIL {
 				conf.PrivateKeys = evmNetwork.PrivateKeys
 				if len(conf.URLs) == 0 {
 					conf.URLs = evmNetwork.URLs
@@ -211,7 +211,7 @@ func MustReplaceSimulatedNetworkUrlWithK8(l zerolog.Logger, network blockchain.E
 		return network
 	}
 
-	networkKeys := []string{"Simulated Geth", "Simulated-Geth"}
+	networkKeys := []string{"Simulated Geth", "Simulated-Geth", "simulated-geth_http"}
 	var keyToUse string
 
 	for _, key := range networkKeys {


### PR DESCRIPTION
1. Add Anvil to known networks.
2. Allow Anvil to run with a custom service name, enabling it to be easily referenced as an RPC in the core node configuration.

This PR was tested with E2E tests from Core: https://github.com/smartcontractkit/chainlink/pull/13415


<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes aim to introduce Anvil support for simulated networks, streamline the Helm chart versioning for Foundry, and enhance the configuration and deployment process for Foundry on Kubernetes. Additionally, the modifications to network configurations facilitate the integration and testing of different EVM networks, including Anvil, by adjusting how network configurations are merged and applied within the testing framework.

## What
- **charts/foundry/Chart.yaml**  
  - Version updated from `0.1.8` to `0.1.9`.  
    This change updates the chart version to reflect new modifications or feature additions.
- **charts/foundry/templates/_helpers.tpl**  
  - Removed conditional block that checks if the release name contains the chart name for fullname definition.  
    Simplifies the template logic for defining the fullname, making it more straightforward and less error-prone.
- **k8s/pkg/helm/foundry/foundry.go**  
  - Removed unused `net/url` package import.  
    Cleans up the import section by removing an unnecessary package, likely improving build times and reducing the binary size.
  - Updated the `Chart` struct to include new fields for service URLs and refactored the `ExportData` function.  
    These changes enable the Foundry chart to dynamically manage service URLs, enhancing its flexibility in different deployment environments.
  - Introduced Anvil specific configurations and updated the logic for creating new Foundry charts to incorporate these settings.  
    Adds support for Anvil, a lightweight Ethereum simulator, facilitating easier and more efficient testing environments.
- **networks/known_networks.go**  
  - Added Anvil as a recognized EVM network with specific configurations.  
    Extends the framework's capability to interact with Anvil, allowing for expanded testing scenarios across various simulated networks.
- **utils/seth/seth.go**  
  - Added a condition to include Anvil (`pkg_seth.ANVIL`) when determining the network configuration for simulated environments.  
    Ensures Anvil is correctly recognized and configured within the context of the Seth utility, enhancing compatibility and configuration accuracy for simulations.
