### PR TITLE
[TT-1259] postgresdb logstrem functional option

### DIFF
--- a/docker/test_env/postgres.go
+++ b/docker/test_env/postgres.go
@@ -2,7 +2,6 @@ package test_env
 
 import (
 	"fmt"
-	"github.com/smartcontractkit/chainlink-testing-framework/logstream"
 	"io"
 	"net/url"
 	"os/exec"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-testing-framework/docker"
 	"github.com/smartcontractkit/chainlink-testing-framework/logging"
+	"github.com/smartcontractkit/chainlink-testing-framework/logstream"
 	"github.com/smartcontractkit/chainlink-testing-framework/mirror"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/testcontext"
 )

--- a/docker/test_env/postgres.go
+++ b/docker/test_env/postgres.go
@@ -2,6 +2,7 @@ package test_env
 
 import (
 	"fmt"
+	"github.com/smartcontractkit/chainlink-testing-framework/logstream"
 	"io"
 	"net/url"
 	"os/exec"
@@ -53,6 +54,12 @@ func WithPostgresImageName(imageName string) PostgresDbOption {
 		if imageName != "" {
 			c.ContainerImage = imageName
 		}
+	}
+}
+
+func WithPostgresDbLogStream(ls *logstream.LogStream) PostgresDbOption {
+	return func(c *PostgresDb) {
+		c.LogStream = ls
 	}
 }
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce additional functionality to the PostgresDb configuration within a Docker testing environment for better log management and flexibility. By adding the `WithPostgresDbLogStream` function, it allows the passing of a `LogStream` object to the `PostgresDb` struct. This enhances the ability to stream logs for the Postgres database containers, which can be crucial for debugging and monitoring in automated testing environments.

## What
- **docker/test_env/postgres.go**
  - Added an import statement for `github.com/smartcontractkit/chainlink-testing-framework/logstream`.
    - This allows the file to use the `LogStream` struct within the `WithPostgresDbLogStream` function.
  - Added the `WithPostgresDbLogStream` function.
    - This function provides an option to include a `LogStream` object in the `PostgresDb` configuration, which is designed to facilitate streaming of logs from the Postgres container.
