### PR TITLE
Add GethReorgConfig to Network 

### DIFF
--- a/config/network.go
+++ b/config/network.go
@@ -41,6 +41,8 @@ type NetworkConfig struct {
 	// AnvilConfigs is the configuration for forking from a node,
 	// key is the network name as declared in selected_networks slice
 	AnvilConfigs map[string]*AnvilConfig `toml:"AnvilConfigs,omitempty"`
+	// GethReorgConfig is the configuration for handling reorgs on Simulated Geth
+	GethReorgConfig ReorgConfig `toml:"GethReorgConfig,omitempty"`
 	// RpcHttpUrls is the RPC HTTP endpoints for each network,
 	// key is the network name as declared in selected_networks slice
 	RpcHttpUrls map[string][]string `toml:"RpcHttpUrls,omitempty"`
@@ -50,6 +52,21 @@ type NetworkConfig struct {
 	// WalletKeys is the private keys for the funding wallets for each network,
 	// key is the network name as declared in selected_networks slice
 	WalletKeys map[string][]string `toml:"WalletKeys,omitempty"`
+}
+
+type ReorgConfig struct {
+	Enabled     bool                   `toml:"enabled,omitempty"`
+	Depth       int                    `toml:"depth,omitempty"`
+	DelayCreate blockchain.StrDuration `toml:"delay_create,omitempty"` // Delay before creating, expressed in Go duration format (e.g., "1m", "30s")
+}
+
+func (n NetworkConfig) IsSimulatedGethSelected() bool {
+	for _, network := range n.SelectedNetworks {
+		if strings.ToLower(network) == "simulated" {
+			return true
+		}
+	}
+	return false
 }
 
 func (n *NetworkConfig) applySecrets() error {

--- a/k8s/environment/environment.go
+++ b/k8s/environment/environment.go
@@ -191,13 +191,9 @@ func New(cfg *Config) *Environment {
 		targetCfg.Namespace = fmt.Sprintf("%s-%s", targetCfg.NamespacePrefix, uuid.NewString()[0:5])
 		log.Info().Str("Namespace", targetCfg.Namespace).Msg("Creating new namespace")
 	}
-	jobImage := os.Getenv(config.EnvVarJobImage)
-	if jobImage != "" {
-		targetCfg.JobImage = jobImage
-		targetCfg.detachRunner, _ = strconv.ParseBool(os.Getenv(config.EnvVarDetachRunner))
-	} else {
-		targetCfg.InsideK8s, _ = strconv.ParseBool(os.Getenv(config.EnvVarInsideK8s))
-	}
+	targetCfg.JobImage = os.Getenv(config.EnvVarJobImage)
+	targetCfg.detachRunner, _ = strconv.ParseBool(os.Getenv(config.EnvVarDetachRunner))
+	targetCfg.InsideK8s, _ = strconv.ParseBool(os.Getenv(config.EnvVarInsideK8s))
 
 	c, err := client.NewK8sClient()
 	if err != nil {


### PR DESCRIPTION
1. [Add GethReorgConfig configuration for handling reorgs on Simulated Geth](https://github.com/smartcontractkit/chainlink-testing-framework/commit/e8011d83d1b481ff7cca8c4a1aa2d5df282a4bf1)
2.  [Always set detachRunner and InsideK8s config fields](https://github.com/smartcontractkit/chainlink-testing-framework/commit/438e1437aa27e02c9f66cf525ccfe2f979973c88) Related [Slack conversation](https://chainlink-core.slack.com/archives/C0361N0LJ6A/p1718034213563969)

This is used in https://github.com/smartcontractkit/chainlink/pull/13483

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new configuration for handling reorganizations (reorgs) in simulated Geth environments and streamline the environment setup in Kubernetes by simplifying the handling of job images and Kubernetes inside flags. This enhances the flexibility and configurability of blockchain simulations and deployments.

## What
- **config/network.go**
  - Added `GethReorgConfig` field to `NetworkConfig` for configuring reorg behavior in simulated Geth.
  - Added `ReorgConfig` struct with fields `Enabled`, `Depth`, `DelayCreate` to detail the reorg configuration.
  - Added `IsSimulatedGethSelected` function to determine if a simulated Geth network is selected.
- **k8s/environment/environment.go**
  - Simplified environment variable retrieval for `JobImage`, `detachRunner`, and `InsideK8s`, removing conditional checks that were redundant.
