### PR TITLE
Fix MergeSethAndEvmNetworkConfigs for Anvil and Geth networks

### DIFF
--- a/utils/seth/seth.go
+++ b/utils/seth/seth.go
@@ -147,24 +147,29 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 
 	var sethNetwork *pkg_seth.Network
 
+	mergeSimulatedNetworks := func(evmNetwork blockchain.EVMNetwork, sethNetwork pkg_seth.Network) *pkg_seth.Network {
+		sethNetwork.PrivateKeys = evmNetwork.PrivateKeys
+		if len(sethNetwork.URLs) == 0 {
+			sethNetwork.URLs = evmNetwork.URLs
+		}
+		// important since Besu doesn't support EIP-1559, but other EVM clients do
+		sethNetwork.EIP1559DynamicFees = evmNetwork.SupportsEIP1559
+		// might be needed for cases, when node is incapable of estimating gas limit (e.g. Geth < v1.10.0)
+		if evmNetwork.DefaultGasLimit != 0 {
+			sethNetwork.GasLimit = evmNetwork.DefaultGasLimit
+		}
+		return &sethNetwork
+	}
+
 	for _, conf := range sethConfig.Networks {
-		if evmNetwork.Simulated {
-			if conf.Name == pkg_seth.GETH || conf.Name == pkg_seth.ANVIL {
-				conf.PrivateKeys = evmNetwork.PrivateKeys
-				if len(conf.URLs) == 0 {
-					conf.URLs = evmNetwork.URLs
-				}
-				// important since Besu doesn't support EIP-1559, but other EVM clients do
-				conf.EIP1559DynamicFees = evmNetwork.SupportsEIP1559
-
-				// might be needed for cases, when node is incapable of estimating gas limit (e.g. Geth < v1.10.0)
-				if evmNetwork.DefaultGasLimit != 0 {
-					conf.GasLimit = evmNetwork.DefaultGasLimit
-				}
-
-				sethNetwork = conf
-				break
-			}
+		if evmNetwork.Simulated && evmNetwork.Name == pkg_seth.ANVIL && conf.Name == pkg_seth.ANVIL {
+			// Merge Anvil network
+			sethNetwork = mergeSimulatedNetworks(evmNetwork, *conf)
+			break
+		} else if evmNetwork.Simulated && conf.Name == pkg_seth.GETH {
+			// Merge all other simulated Geth networks
+			sethNetwork = mergeSimulatedNetworks(evmNetwork, *conf)
+			break
 		} else if strings.EqualFold(conf.Name, fmt.Sprint(evmNetwork.Name)) {
 			conf.PrivateKeys = evmNetwork.PrivateKeys
 			if len(conf.URLs) == 0 {


### PR DESCRIPTION



<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the method for merging simulated network configurations by introducing a dedicated function to handle the merging process. This adjustment improves code readability and maintainability.

## What
- **utils/seth/seth.go**
  - Removed inline code for merging simulated networks within the `MergeSethAndEvmNetworkConfigs` function.
  - Added `mergeSimulatedNetworks` function to handle the merging of simulated network configurations.
  - Adjusted the logic to specifically merge Anvil networks or other Geth simulated networks using the new function, improving the clarity and specificity of the merging process.
  - Ensured that the network merging logic now explicitly checks for Anvil and Geth networks, streamlining the configuration process for these specific scenarios.
