### PR TITLE
Bump geth and disable enableServiceLinks for geth pod

### DIFF
--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: geth
 description: A simulated go-ethereum network
-version: 0.4.4
-appVersion: '1.12.2'
+version: 0.4.5
+appVersion: '1.13.8'

--- a/charts/geth/templates/geth-deployment.yml
+++ b/charts/geth/templates/geth-deployment.yml
@@ -29,6 +29,7 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       - name: configmap-volume
         configMap:

--- a/docker/test_env/geth_base.go
+++ b/docker/test_env/geth_base.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultGethEth1Image = "ethereum/client-go:v1.12.0"
+	defaultGethEth1Image = "ethereum/client-go:v1.13.8"
 	defaultGethEth2Image = "ethereum/client-go:v1.14.3"
 	gethBaseImageName    = "ethereum/client-go"
 	gethGitRepo          = "ethereum/go-ethereum"

--- a/k8s/pkg/helm/ethereum/geth.go
+++ b/k8s/pkg/helm/ethereum/geth.go
@@ -113,7 +113,7 @@ func defaultProps() *Props {
 			"geth": map[string]interface{}{
 				"image": map[string]interface{}{
 					"image":   gethImage,
-					"version": "v1.12.2",
+					"version": "v1.13.8",
 				},
 			},
 			"resources": map[string]interface{}{


### PR DESCRIPTION
- [Bump geth in k8s to v1.13.8](https://github.com/smartcontractkit/chainlink-testing-framework/commit/1b8f00801d18b7a568285fffda3e87da821f05a1)
- [Bump geth for docker tests to v1.13.8](https://github.com/smartcontractkit/chainlink-testing-framework/pull/986/commits/d3b545451b925cfe01ed2c1fdb694c2f05efb9f7)
- [Disable service environment variables for Geth pod](https://github.com/smartcontractkit/chainlink-testing-framework/commit/f8e0af6df85ca84eb47689a0f27d9bdeb37eee8e) 
   This change stops the creation of the GETH_PORT environment variable by k8s with an invalid value, which breaks Geth command validation. For more, see https://github.com/ethereum/go-ethereum/issues/28210#issuecomment-1738692917
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes make two primary updates to improve the Geth deployment and management within a Kubernetes environment. Firstly, disabling service links in the Geth pod's specification enhances performance by preventing the automatic injection of numerous environment variables, which are often unnecessary for blockchain applications. Secondly, updating the Geth image version to `v1.13.8` ensures that the deployment uses a more current and potentially more secure and efficient version of the Geth software, which could include important bug fixes, security patches, and performance improvements.

## What
- **charts/geth/templates/geth-deployment.yml**
  - Added `enableServiceLinks: false` to the pod `spec`, which disables the generation of environment variables for services.
- **k8s/pkg/helm/ethereum/geth.go**
  - Updated Geth image version from `v1.12.2` to `v1.13.8` in the default properties function (`defaultProps`). This change affects the image version used in deployments.
