### PR TITLE
Make foundry chart name unique to support multiple releases

### DIFF
--- a/k8s/pkg/helm/foundry/foundry.go
+++ b/k8s/pkg/helm/foundry/foundry.go
@@ -12,6 +12,10 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/environment"
 )
 
+const (
+	ChartName = "foundry" // Chart name as defined in Chart.yaml
+)
+
 type Props struct {
 	Values map[string]interface{}
 }
@@ -56,11 +60,11 @@ func (m Chart) GetValues() *map[string]interface{} {
 func (m *Chart) ExportData(e *environment.Environment) error {
 	appInstance := fmt.Sprintf("%s:0", m.Name) // uniquely identifies an instance of an anvil service running in a pod
 	var err error
-	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, m.GetName(), "http").As(client.LocalConnection, client.HTTP)
+	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
-	m.ForwardedWSURL, err = e.Fwd.FindPort(appInstance, m.GetName(), "http").As(client.LocalConnection, client.WS)
+	m.ForwardedWSURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.WS)
 	if err != nil {
 		return err
 	}

--- a/k8s/pkg/helm/foundry/foundry.go
+++ b/k8s/pkg/helm/foundry/foundry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/client"
@@ -11,16 +12,12 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/environment"
 )
 
-const (
-	ChartName = "foundry"
-)
-
 type Props struct {
 	Values map[string]interface{}
 }
 
 type Chart struct {
-	ServiceName      string
+	Name             string
 	AppLabel         string
 	Path             string
 	Version          string
@@ -37,7 +34,7 @@ func (m Chart) IsDeploymentNeeded() bool {
 }
 
 func (m Chart) GetName() string {
-	return ChartName
+	return m.Name
 }
 
 func (m Chart) GetPath() string {
@@ -57,13 +54,13 @@ func (m Chart) GetValues() *map[string]interface{} {
 }
 
 func (m *Chart) ExportData(e *environment.Environment) error {
-	appInstance := fmt.Sprintf("%s:0", m.ServiceName) // uniquely identifies an instance of an anvil service running in a pod
+	appInstance := fmt.Sprintf("%s:0", m.Name) // uniquely identifies an instance of an anvil service running in a pod
 	var err error
-	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.HTTP)
+	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, m.GetName(), "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {
 		return err
 	}
-	m.ForwardedWSURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.WS)
+	m.ForwardedWSURL, err = e.Fwd.FindPort(appInstance, m.GetName(), "http").As(client.LocalConnection, client.WS)
 	if err != nil {
 		return err
 	}
@@ -108,21 +105,20 @@ func NewVersioned(helmVersion string, props *Props) *Chart {
 	dp := defaultProps()
 	config.MustMerge(dp, props)
 	config.MustMerge(&dp.Values, props.Values)
-	var serviceName, appLabel string
-	// If fullnameOverride is set it is used as the service name and app label
+	var name string
 	if props.Values["fullnameOverride"] != nil {
-		serviceName = dp.Values["fullnameOverride"].(string)
-		appLabel = fmt.Sprintf("app=%s", dp.Values["fullnameOverride"].(string))
+		// If fullnameOverride is set it is used as the service name and app label
+		name = dp.Values["fullnameOverride"].(string)
 	} else {
-		serviceName = ChartName
-		appLabel = fmt.Sprintf("app=%s", ChartName)
+		// Use default name with random suffix to allow multiple charts in the same namespace
+		name = fmt.Sprintf("anvil-%s", uuid.New().String()[0:5])
 	}
 	anvilValues := dp.Values["anvil"].(map[string]any)
 	return &Chart{
-		ServiceName:    serviceName,
-		ClusterWSURL:   fmt.Sprintf("ws://%s:%s", serviceName, anvilValues["port"].(string)),
-		ClusterHTTPURL: fmt.Sprintf("http://%s:%s", serviceName, anvilValues["port"].(string)),
-		AppLabel:       appLabel,
+		Name:           name,
+		AppLabel:       fmt.Sprintf("app=%s", name),
+		ClusterWSURL:   fmt.Sprintf("ws://%s:%s", name, anvilValues["port"].(string)),
+		ClusterHTTPURL: fmt.Sprintf("http://%s:%s", name, anvilValues["port"].(string)),
 		Path:           "chainlink-qa/foundry",
 		Values:         &dp.Values,
 		Props:          dp,

--- a/k8s/pkg/helm/foundry/foundry_test.go
+++ b/k8s/pkg/helm/foundry/foundry_test.go
@@ -1,0 +1,43 @@
+package foundry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChartNameUniqueness(t *testing.T) {
+	props := defaultProps()
+
+	// Create two Chart instances
+	chart1 := NewVersioned("", props)
+	chart2 := NewVersioned("", props)
+
+	// Assert that the names of the charts are unique
+	require.NotEqual(t, chart1.GetName(), chart2.GetName(), "Chart names should be unique")
+}
+
+func TestChartNameWithFullNameOverrideUniqueness(t *testing.T) {
+	// Generate unique names for testing
+	name1 := fmt.Sprintf("custom-%s", uuid.New().String()[0:5])
+	name2 := fmt.Sprintf("custom-%s", uuid.New().String()[0:5])
+
+	// Create two Chart instances with different fullnameOverride
+	chart1 := NewVersioned("", &Props{
+		Values: map[string]interface{}{
+			"fullnameOverride": name1,
+		},
+	})
+	chart2 := NewVersioned("", &Props{
+		Values: map[string]interface{}{
+			"fullnameOverride": name2,
+		},
+	})
+
+	// Assert that the names of the charts are unique and correct
+	require.Equal(t, name1, chart1.GetName(), "Chart name should match the fullnameOverride")
+	require.Equal(t, name2, chart2.GetName(), "Chart name should match the fullnameOverride")
+	require.NotEqual(t, chart1.GetName(), chart2.GetName(), "Chart names should be unique when fullnameOverrides are different")
+}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the flexibility and uniqueness of Helm chart deployments for Foundry by introducing dynamic naming and enhancing test coverage to verify these enhancements. By using unique names based on UUIDs for deployments without a specified override and adjusting the internal references accordingly, these modifications ensure that multiple instances of the Foundry chart can coexist within the same Kubernetes namespace. Additionally, the introduction of unit tests validates the functionality of unique naming, ensuring the robustness of deployments.

## What
- **k8s/pkg/helm/foundry/foundry.go**
  - Removed the `ChartName` constant.
  - Added `github.com/google/uuid` import for generating unique identifiers.
  - Renamed `ServiceName` property to `Name` to generalize its purpose.
  - Updated references from `ChartName` to use `Name` property for dynamic naming.
  - Introduced dynamic naming for charts without a `fullnameOverride`, using a UUID to ensure uniqueness.
  - Adjusted logging and error messages to reflect the change from `ServiceName` to `Name`.
- **k8s/pkg/helm/foundry/foundry_test.go (new file)**
  - Added a new file for testing the Foundry Helm chart functionalities.
  - Implemented tests to ensure the uniqueness of chart names, both with and without the `fullnameOverride` property.
