### PR TITLE
Fixing foundry export data logic and add test

### DIFF
--- a/k8s/e2e/common/test_common.go
+++ b/k8s/e2e/common/test_common.go
@@ -462,3 +462,14 @@ func TestReallyLongLogs(t *testing.T) {
 	// this shouldn't hang
 	l.Info().Int("len", len(s)).Str("string", s).Msg("string")
 }
+
+func TestAnvil(t *testing.T) {
+	t.Parallel()
+	testEnvConfig := GetTestEnvConfig(t)
+	e := presets.FoundryNetwork(testEnvConfig)
+	err := e.Run()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, e.Shutdown())
+	})
+}

--- a/k8s/e2e/local-runner/envs_test.go
+++ b/k8s/e2e/local-runner/envs_test.go
@@ -76,3 +76,7 @@ func TestRunTimeout(t *testing.T) {
 func TestReallyLongLogs(t *testing.T) {
 	common.TestReallyLongLogs(t)
 }
+
+func TestWithAnvil(t *testing.T) {
+	common.TestAnvil(t)
+}

--- a/k8s/e2e/remote-runner/remote_runner_envs_test.go
+++ b/k8s/e2e/remote-runner/remote_runner_envs_test.go
@@ -189,3 +189,7 @@ func TestRunTimeout(t *testing.T) {
 func TestReallyLongLogs(t *testing.T) {
 	common.TestReallyLongLogs(t)
 }
+
+func TestWithAnvil(t *testing.T) {
+	common.TestAnvil(t)
+}

--- a/k8s/pkg/helm/foundry/foundry.go
+++ b/k8s/pkg/helm/foundry/foundry.go
@@ -17,7 +17,8 @@ const (
 )
 
 type Props struct {
-	Values map[string]interface{}
+	NetworkName string
+	Values      map[string]interface{}
 }
 
 type Chart struct {
@@ -58,7 +59,7 @@ func (m Chart) GetValues() *map[string]interface{} {
 }
 
 func (m *Chart) ExportData(e *environment.Environment) error {
-	appInstance := fmt.Sprintf("%s:0", m.Name) // uniquely identifies an instance of an anvil service running in a pod
+	appInstance := fmt.Sprintf("%s-%s:0", m.Name, ChartName) // uniquely identifies an instance of an anvil service running in a pod
 	var err error
 	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {
@@ -74,6 +75,15 @@ func (m *Chart) ExportData(e *environment.Environment) error {
 	e.URLs[appInstance+"_forwarded_ws"] = []string{m.ForwardedWSURL}
 	e.URLs[appInstance+"_forwarded_http"] = []string{m.ForwardedHTTPURL}
 
+	// This is required for blockchain.EVMClient to work
+	if e.Cfg.InsideK8s {
+		e.URLs[m.Props.NetworkName] = []string{m.ClusterWSURL}
+		e.URLs[m.Props.NetworkName+"_http"] = []string{m.ClusterHTTPURL}
+	} else {
+		e.URLs[m.Props.NetworkName] = []string{m.ForwardedWSURL}
+		e.URLs[m.Props.NetworkName+"_http"] = []string{m.ForwardedHTTPURL}
+	}
+
 	for k, v := range e.URLs {
 		if strings.Contains(k, appInstance) {
 			log.Info().Str("Name", k).Strs("URLs", v).Msg("Anvil URLs")
@@ -87,14 +97,14 @@ func defaultProps() *Props {
 	return &Props{
 		Values: map[string]any{
 			"replicaCount": "1",
+			// default values for anvil
+			// these can be overridden by setting the values in the Props struct
+			// Try not to provide any fork config here, so that by default anvil can be used for non-forked chains as well
 			"anvil": map[string]any{
-				"host":                      "0.0.0.0",
-				"port":                      "8545",
-				"blockTime":                 1,
-				"forkRetries":               "5",
-				"forkTimeout":               "45000",
-				"forkComputeUnitsPerSecond": "330",
-				"chainId":                   "1337",
+				"host":      "0.0.0.0",
+				"port":      "8545",
+				"blockTime": 1,
+				"chainId":   "1337",
 			},
 		},
 	}
@@ -107,6 +117,9 @@ func New(props *Props) *Chart {
 // NewVersioned enables choosing a specific helm chart version
 func NewVersioned(helmVersion string, props *Props) *Chart {
 	dp := defaultProps()
+	if props == nil {
+		props = &Props{}
+	}
 	config.MustMerge(dp, props)
 	config.MustMerge(&dp.Values, props.Values)
 	var name string

--- a/k8s/pkg/helm/foundry/foundry.go
+++ b/k8s/pkg/helm/foundry/foundry.go
@@ -59,7 +59,7 @@ func (m Chart) GetValues() *map[string]interface{} {
 }
 
 func (m *Chart) ExportData(e *environment.Environment) error {
-	appInstance := fmt.Sprintf("%s-%s:0", m.Name, ChartName) // uniquely identifies an instance of an anvil service running in a pod
+	appInstance := fmt.Sprintf("%s:0", m.Name) // uniquely identifies an instance of an anvil service running in a pod
 	var err error
 	m.ForwardedHTTPURL, err = e.Fwd.FindPort(appInstance, ChartName, "http").As(client.LocalConnection, client.HTTP)
 	if err != nil {

--- a/k8s/presets/presets.go
+++ b/k8s/presets/presets.go
@@ -229,5 +229,9 @@ func EVMSoak(config *environment.Config) *environment.Environment {
 
 func FoundryNetwork(config *environment.Config) *environment.Environment {
 	return environment.New(config).
-		AddHelm(foundry.New(nil))
+		AddHelm(foundry.New(&foundry.Props{
+			Values: map[string]interface{}{
+				"fullnameOverride": "foundry",
+			},
+		}))
 }

--- a/k8s/presets/presets.go
+++ b/k8s/presets/presets.go
@@ -5,6 +5,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/cdk8s/blockscout"
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/ethereum"
+	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/foundry"
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/mockserver"
 	mockservercfg "github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/mockserver-cfg"
 	"github.com/smartcontractkit/chainlink-testing-framework/k8s/pkg/helm/reorg"
@@ -224,4 +225,9 @@ func EVMSoak(config *environment.Config) *environment.Environment {
 				},
 			},
 		}))
+}
+
+func FoundryNetwork(config *environment.Config) *environment.Environment {
+	return environment.New(config).
+		AddHelm(foundry.New(nil))
 }


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The pull request introduces changes to enhance testing capabilities and configurations for Kubernetes environments. It adds a new test for Anvil, a local Ethereum network simulation tool, and updates the Foundry Helm chart to support dynamic network naming and simplified configuration options.

## What
- **k8s/e2e/common/test_common.go**
  - Added `TestAnvil` to initiate parallel testing with Anvil configurations.
- **k8s/e2e/local-runner/envs_test.go & k8s/e2e/remote-runner/remote_runner_envs_test.go**
  - Added `TestWithAnvil` to execute the new Anvil test in both local and remote runner environments.
- **k8s/pkg/helm/foundry/foundry.go**
  - Modified the `Props` struct to include `NetworkName` for dynamic naming.
  - Updated `ExportData` to accommodate dynamic app instance naming and conditional URL exports based on the Kubernetes environment context.
  - Adjusted default properties and `NewVersioned` function to ensure the proper handling of nil `Props` and to merge provided properties with defaults effectively.
- **k8s/presets/presets.go**
  - Introduced `FoundryNetwork` to create an environment preset for Foundry, enabling easy setup of Anvil-based Ethereum network simulations.
