### PR TITLE
[TT-1275] Add retreiving of requests from killgrave

### DIFF
--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -24,7 +24,7 @@ jobs:
           - name: ethereum/client-go
             expression: '^(alltools-v|v)[0-9]\.[0-9]+\.[0-9]+$'
           - name: friendsofgo/killgrave
-            expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
+            expression: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
           - name: mockserver/mockserver
             expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
           - name: testcontainers/ryuk

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ chaosmesh: ## there is currently a bug on JS side to import all CRDs from one ya
 gotestloghelper_build:
 	cd ./tools/gotestloghelper && go build -o ../../gotestloghelper . && cd -
 
+.PHONY: typos
+typos:
+	pre-commit run detect-typos --all-files --show-diff-on-failure --color=always
+
 .PHONY: nix_shell
 nix_shell:
 	nix develop


### PR DESCRIPTION
Temporary usage of fork branch at: https://github.com/friendsofgo/killgrave/pull/170 
To unblock teams we have pushed up temporary dockerhub and ecr images that contain the code above that allows requests to be pulled and used in tests. [TT-1290](https://smartcontract-it.atlassian.net/browse/TT-1290) has been made to clean this up once the code is merged on the killgrave side.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes aim to enhance the project's capability to handle version expressions more flexibly, introduce typos detection, and improve the test environment by updating the version of Killgrave to support request dumping. These updates are essential for keeping the project compatible with external dependencies, ensuring code quality, and enhancing testing capabilities.

## What
- `.github/workflows/update-internal-mirrors.yaml`
  - Modified the `expression` for `friendsofgo/killgrave` to support versions with an optional 'v' prefix. This change broadens the range of acceptable version formats, making the workflow more versatile.
- `Makefile`
  - Added a new target `typos` to run the `detect-typos` pre-commit hook against all files, thereby automating the detection of typos within the project.
- `docker/test_env/killgrave.go`
  - Updated `defaultKillgraveImage` to use a newer version (`v0.5.1-request-dump`) that supports request dumping, enhancing the testing environment.
  - Added `requestDumpDirBinding` field to `Killgrave` struct to manage the binding for request dump directory.
  - Introduced `setupRequestDump` method to create a temporary directory for request dumps, facilitating better testing by allowing inspection of received requests.
  - Modified `getContainerRequest` to include a new bind mount for the request dump directory, ensuring that request data is accessible for testing purposes.
  - Added `GetReceivedRequests` method to read and parse the request dump, enabling tests to assert on the incoming requests to Killgrave.
- `docker/test_env/killgrave_test.go`
  - Added `TestKillgraveRequestDump` to test the request dump functionality by asserting on the body of received requests, demonstrating the utility of the new feature in testing scenarios.


[TT-1290]: https://smartcontract-it.atlassian.net/browse/TT-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ