### PR TITLE
Add dashboard UID field to GrafanaConfig struct

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -91,6 +91,7 @@ func (l *LokiConfig) Validate() error {
 type GrafanaConfig struct {
 	BaseUrl      *string `toml:"base_url"`
 	DashboardUrl *string `toml:"dashboard_url"`
+	DashboardUID *string `toml:"dashboard_uid"` // UID of the dashboard to put annotations on
 	BearerToken  *string `toml:"bearer_token_secret"`
 }
 


### PR DESCRIPTION
dashboard_uid can be optionall used as the dashboard id to put annotations on. 

This is needed for https://github.com/smartcontractkit/chainlink/pull/13624
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new configuration option for specifying the UID of a dashboard in the Grafana configuration. This addition allows for more precise targeting of dashboards for annotations, ensuring that configurations are both flexible and explicit.

## What
- **config/logging.go**
  - Added a new field `DashboardUID *string` to the `GrafanaConfig` struct. This allows specifying the UID of a dashboard for annotations, enhancing targeting accuracy.
