### PR TITLE
[TT-1278] exclude spaces or dashes when matching network names

### DIFF
--- a/utils/seth/seth.go
+++ b/utils/seth/seth.go
@@ -2,6 +2,7 @@ package seth
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -170,7 +171,7 @@ func MergeSethAndEvmNetworkConfigs(evmNetwork blockchain.EVMNetwork, sethConfig 
 			// Merge all other simulated Geth networks
 			sethNetwork = mergeSimulatedNetworks(evmNetwork, *conf)
 			break
-		} else if strings.EqualFold(conf.Name, fmt.Sprint(evmNetwork.Name)) {
+		} else if isSameNetwork(conf, evmNetwork) {
 			conf.PrivateKeys = evmNetwork.PrivateKeys
 			if len(conf.URLs) == 0 {
 				conf.URLs = evmNetwork.URLs
@@ -285,4 +286,16 @@ func AvailableSethKeyNum(client *pkg_seth.Client) int {
 		return client.AnySyncedKey()
 	}
 	return RootKeyNum
+}
+
+func isSameNetwork(conf *pkg_seth.Network, network blockchain.EVMNetwork) bool {
+	if strings.EqualFold(conf.Name, fmt.Sprint(network.Name)) {
+		return true
+	}
+
+	re := regexp.MustCompile(`[\s-]+`)
+	cleanSethName := re.ReplaceAllString(conf.Name, "_")
+	cleanNetworkName := re.ReplaceAllString(fmt.Sprint(network.Name), "_")
+
+	return strings.EqualFold(cleanSethName, cleanNetworkName)
 }


### PR DESCRIPTION
Why? Now it's a bit painful to remember that if we use this as network:
```
selected_networks=["POLYGOIN_MANNET"]
```
then we need to define Seth network as:
```
[[Seth.Network]]
name="POLYGON MAINNET"
```

(notice space instead of `_`) 

That because currently we match by `EVMNetwork`'s `Name` field and not the key under which it's stored in known networks map.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce enhancements in network configuration handling within the Seth module, specifically improving the flexibility and accuracy in matching network names between the EVM and Seth configurations. Additionally, the inclusion of a regular expression utility aims to normalize network name comparisons, ensuring more reliable and consistent configuration merging processes.

## What
- **`utils/seth/seth.go`**
  - Added `regexp` package import to utilize regular expression capabilities for network name normalization.
  - Modified `MergeSethAndEvmNetworkConfigs` function to utilize a new helper function `isSameNetwork` for network name comparison, replacing a case-insensitive string comparison. This change aims to improve the logic for matching network names by considering variations in naming conventions (e.g., differences in whitespace or hyphens).
  - Added `isSameNetwork` function which normalizes network names by converting spaces and hyphens to underscores before performing a case-insensitive comparison. This ensures a more accurate and flexible way of determining if a given EVM network and Seth network configuration refer to the same underlying network, accounting for minor variations in how network names might be presented or formatted.
