### PR TITLE
Adds a Handy Conversion

### DIFF
--- a/config/examples/testconfig.go
+++ b/config/examples/testconfig.go
@@ -176,7 +176,7 @@ func GetConfig(configurationName string, product Product) (TestConfig, error) {
 
 func (c *TestConfig) readNetworkConfiguration() error {
 	// currently we need to read that kind of secrets only for network configuration
-	if c == nil {
+	if c.Network == nil {
 		c.Network = &ctf_config.NetworkConfig{}
 	}
 	err := c.Network.Default()

--- a/utils/conversions/conversions.go
+++ b/utils/conversions/conversions.go
@@ -21,6 +21,15 @@ func PrivateKeyToAddress(privateKey *ecdsa.PrivateKey) (common.Address, error) {
 	return crypto.PubkeyToAddress(*publicKeyECDSA), nil
 }
 
+// PrivateKeyHexToAddress is a handy converter for a string private key to a usable eth address
+func PrivateKeyHexToAddress(privateKeyStr string) (common.Address, error) {
+	privateKey, err := crypto.HexToECDSA(privateKeyStr)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("Error converting private key to ECDSA format: %s", err)
+	}
+	return PrivateKeyToAddress(privateKey)
+}
+
 // Credit to kimxilxyong: https://github.com/ethereum/go-ethereum/issues/21221#issuecomment-802092592
 
 // EtherToWei converts an ETH float amount to wei


### PR DESCRIPTION
And remove nil pointer issue
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the robustness and functionality of the codebase by ensuring network configuration is correctly initialized to avoid nil pointer dereferences and by extending utility functions to support more flexible Ethereum address conversions.

## What
- **config/examples/testconfig.go**
  - Modified the condition to check `c.Network` for nil before assignment to prevent potential nil pointer dereferences.
- **utils/conversions/conversions.go**
  - Added a new function `PrivateKeyHexToAddress` to convert a hexadecimal string representation of a private key into an Ethereum address. This provides a more flexible way to generate addresses from string inputs.
