### PR TITLE
more readable error

### DIFF
--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -679,11 +679,11 @@ func (e *EthereumClient) CancelFinalityPolling() {
 func (e *EthereumClient) WaitForFinalizedTx(txHash common.Hash) (*big.Int, time.Time, error) {
 	receipt, err := e.Client.TransactionReceipt(context.Background(), txHash)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, fmt.Errorf("error getting receipt: %w in network %s tx %s", err, e.GetNetworkName(), txHash.Hex())
 	}
 	txHdr, err := e.HeaderByNumber(context.Background(), receipt.BlockNumber)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, fmt.Errorf("error getting header: %w in network %s tx %s", err, e.GetNetworkName(), txHash.Hex())
 	}
 	finalizer := NewTransactionFinalizer(e, txHdr, receipt.TxHash)
 	key := "txFinalizer-" + txHash.String()
@@ -691,7 +691,7 @@ func (e *EthereumClient) WaitForFinalizedTx(txHash common.Hash) (*big.Int, time.
 	defer e.DeleteHeaderEventSubscription(key)
 	err = finalizer.Wait()
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, fmt.Errorf("error waiting for finalization: %w in network %s tx %s", err, e.GetNetworkName(), txHash.Hex())
 	}
 	return finalizer.FinalizedBy, finalizer.FinalizedAt, nil
 }
@@ -717,7 +717,7 @@ func (e *EthereumClient) IsTxHeadFinalized(txHdr, header *SafeEVMHeader) (bool, 
 		}
 		return false, latestFinalized, latestFinalizedAt, nil
 	}
-	return false, nil, time.Time{}, fmt.Errorf("no finalized head found. start polling for finalized header")
+	return false, nil, time.Time{}, fmt.Errorf("no finalized head found. start polling for finalized header, network %s", e.GetNetworkName())
 }
 
 // IsTxConfirmed checks if the transaction is confirmed on chain or not

--- a/blockchain/finalized_headers.go
+++ b/blockchain/finalized_headers.go
@@ -108,7 +108,7 @@ func newGlobalFinalizedHeaderManager(evmClient EVMClient) *FinalizedHeader {
 		lastFinalized, err := evmClient.GetLatestFinalizedBlockHeader(ctx)
 		ctxCancel()
 		if err != nil {
-			log.Err(fmt.Errorf("error getting latest finalized block header")).Msg("NewFinalizedHeader")
+			log.Err(fmt.Errorf("error getting latest finalized block header %w", err)).Msg("NewFinalizedHeader")
 			return nil
 		}
 		fHeader = &FinalizedHeader{


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve error reporting by including more context in error messages, specifically mentioning the network and transaction involved. This enhancement aids in debugging by pinpointing the exact transaction and network that encountered the error, thus facilitating quicker identification and resolution of issues.

## What
- **blockchain/ethereum.go:**  
  - Enhanced error messages in `WaitForFinalizedTx` and `IsTxHeadFinalized` functions to include network name and transaction hash or mention of a missing finalized head along with the network name.
- **blockchain/finalized_headers.go:**  
  - Modified the error logging in `newGlobalFinalizedHeaderManager` function to wrap the original error, providing more context for debugging purposes.
