### PR TITLE
[TT-1167] shorten grafana url or return empty string

### DIFF
--- a/logstream/grafana.go
+++ b/logstream/grafana.go
@@ -3,7 +3,6 @@ package logstream
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -26,9 +25,6 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 
 	var res *http.Response
 
-	//TODO remove me
-	attempt := 0
-
 	if err := retry.Do(
 		func() error {
 			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%sapi/short-urls", grafanaUrl), bodyReader)
@@ -48,16 +44,8 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 				return err
 			}
 
-			//TODO remove me
-			attempt++
-			if attempt < 3 {
-				return errors.New("on demand")
-			}
-
 			return nil
-		}, retry.OnRetry(func(i uint, _ error) {
-			fmt.Printf("Retrying Grafana URL shortening, attempt %d", i+1)
-		}),
+		},
 		retry.DelayType(retry.FixedDelay),
 		retry.Attempts(10),
 		retry.Delay(time.Duration(1)*time.Second),

--- a/logstream/grafana.go
+++ b/logstream/grafana.go
@@ -3,8 +3,12 @@ package logstream
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/avast/retry-go"
 )
 
 const (
@@ -20,25 +24,43 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 		Url string `json:"url"`
 	}
 
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%sapi/short-urls", grafanaUrl), bodyReader)
-	if err != nil {
+	var res *http.Response
+
+	if err := retry.Do(
+		func() error {
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%sapi/short-urls", grafanaUrl), bodyReader)
+			if err != nil {
+				return err
+			}
+
+			req.Header.Add("Authorization", "Bearer "+bearerToken)
+			req.Header.Add("Content-Type", "application/json")
+
+			res, err = http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+
+			if res.StatusCode != http.StatusOK {
+				return err
+			}
+
+			//TODO remove me
+			return errors.New("on demand")
+
+			//return nil
+		}, retry.OnRetry(func(i uint, _ error) {
+			fmt.Printf("Retrying Grafana URL shortening, attempt %d", i+1)
+		}),
+		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(10),
+		retry.Delay(time.Duration(1)*time.Second),
+	); err != nil {
 		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
-	}
-
-	req.Header.Add("Authorization", "Bearer "+bearerToken)
-	req.Header.Add("Content-Type", "application/json")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%s: status code: %s", ShorteningFailedErr, res.Status)
 	}
 
 	defer res.Body.Close()
-	err = json.NewDecoder(res.Body).Decode(&responseObject)
+	err := json.NewDecoder(res.Body).Decode(&responseObject)
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", ShorteningFailedErr, err)
 	}

--- a/logstream/grafana.go
+++ b/logstream/grafana.go
@@ -26,6 +26,9 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 
 	var res *http.Response
 
+	//TODO remove me
+	attempt := 0
+
 	if err := retry.Do(
 		func() error {
 			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%sapi/short-urls", grafanaUrl), bodyReader)
@@ -46,9 +49,12 @@ func ShortenUrl(grafanaUrl, urlToShorten, bearerToken string) (string, error) {
 			}
 
 			//TODO remove me
-			return errors.New("on demand")
+			attempt++
+			if attempt < 3 {
+				return errors.New("on demand")
+			}
 
-			//return nil
+			return nil
 		}, retry.OnRetry(func(i uint, _ error) {
 			fmt.Printf("Retrying Grafana URL shortening, attempt %d", i+1)
 		}),

--- a/logstream/logstream.go
+++ b/logstream/logstream.go
@@ -425,7 +425,7 @@ func (m *LogStream) SaveLogTargetsLocations(writer LogWriter) {
 		m.consumerMutex.RUnlock()
 		if err != nil {
 			if strings.Contains(err.Error(), ShorteningFailedErr) {
-				m.log.Warn().Str("Handler", name).Err(err).Msg("Failed to shorten Grafana URL, will use original one")
+				m.log.Warn().Str("Handler", name).Err(err).Msg("Failed to shorten Grafana URL, won't output any url")
 			} else {
 				m.log.Error().Str("Handler", name).Err(err).Msg("Failed to get log location")
 				continue

--- a/logstream/logstream_handlers.go
+++ b/logstream/logstream_handlers.go
@@ -163,7 +163,7 @@ func (h *LokiLogHandler) GetLogLocation(consumers map[string]*ContainerLogConsum
 		return "", errors.New("no Loki consumers found")
 	}
 
-	// if no Grafana URL has been set let's at least print query parameters that can be manually added to the dashboard url
+	// if no Grafana URL has been set lets at least print query parameters that can be manually added to the dashboard url
 	baseUrl := ""
 	if h.loggingConfig.Grafana != nil && h.loggingConfig.Grafana.BaseUrl != nil {
 		baseUrl = *h.loggingConfig.Grafana.BaseUrl
@@ -206,18 +206,17 @@ func (h *LokiLogHandler) GetLogLocation(consumers map[string]*ContainerLogConsum
 		sb.WriteString(fmt.Sprintf("&var-test=%s", testName))
 	}
 
-	relativeUrl := sb.String()
-	h.grafanaUrl = baseUrl + sb.String()
-
+	var shorteningErr error
 	// try to shorten the URL only if we have all the required configuration parameters
 	if baseUrl != "" && dabshoardUrl != "" && h.loggingConfig.Grafana.BearerToken != nil {
-		shortened, err := ShortenUrl(baseUrl, relativeUrl, *h.loggingConfig.Grafana.BearerToken)
-		if err == nil {
+		var shortened string
+		shortened, shorteningErr = ShortenUrl(baseUrl, sb.String(), *h.loggingConfig.Grafana.BearerToken)
+		if shorteningErr == nil {
 			h.grafanaUrl = shortened
 		}
 	}
 
-	return h.grafanaUrl, nil
+	return h.grafanaUrl, shorteningErr
 }
 
 func (h LokiLogHandler) GetTarget() LogTarget {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce error handling and retry mechanisms for URL shortening requests to Grafana and modify how errors related to Grafana URL shortening are logged, aiming to improve the robustness and user feedback of the log streaming functionality.

## What
- **logstream/grafana.go**
  - Added `errors` and `time` packages for error handling and timing.
  - Integrated `retry-go` for retrying HTTP requests.
  - Implemented retry logic with a fixed delay for Grafana URL shortening, improving resilience against transient errors.
  - Modified error handling to return a formatted error if retries fail.
- **logstream/logstream.go**
  - Altered the logging message when Grafana URL shortening fails, clarifying that no URL will be outputted instead of implying the original URL will be used.
- **logstream/logstream_handlers.go**
  - Made a textual correction in a comment for clarity.
  - Added error handling for URL shortening failure, allowing the function to return the error alongside the Grafana URL. This change ensures that errors in URL shortening are propagated, allowing for better error handling and logging at higher levels.
