### PR TITLE
remove codecov upload

### DIFF
--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -40,11 +40,6 @@ jobs:
           # disabled, because we want to use a multiline output of go list command
           # shellcheck disable=SC2046
           go test -timeout 20m -json -parallel 2 -cover -covermode=atomic -coverprofile=unit-test-coverage.out $(go list ./... | grep /docker/test_env) -run '${{ matrix.test.tests }}' 2>&1 | tee /tmp/gotest.log | ./gotestloghelper -ci
-      - name: Code Coverage
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
-        with:
-          files: ./unit-test-coverage.out
-          name: codecov-umbrella
       - name: Publish Artifacts
         if: failure()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,11 +48,6 @@ jobs:
           # shellcheck disable=SC2046
           nix develop -c sh -c "cd ${{ matrix.project.path }} && \
             make test_unit"
-      - name: Code Coverage
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
-        with:
-          files: ./unit-test-coverage.out
-          name: codecov-umbrella
       - name: Publish Artifacts
         if: failure()
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
we are not using it AFAIK and it errs: https://github.com/smartcontractkit/chainlink-testing-framework/actions/runs/9696645475/job/26759015199
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes remove the Code Coverage steps from both the `docker-test.yaml` and `test.yaml` GitHub workflow files. This indicates a strategic shift in how code coverage metrics are handled or possibly an integration change with the codecov tool.

## What
- **.github/workflows/docker-test.yaml**
  - Removed Code Coverage step using codecov-action@84508663e988701840491b86de86b666e8a86bed.
- **.github/workflows/test.yaml**
  - Removed Code Coverage step using codecov-action@84508663e988701840491b86de86b666e8a86bed.
