### PR TITLE
expose errorReason

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -80,6 +80,7 @@ type EVMClient interface {
 	CancelFinalityPolling()
 	GetTxReceipt(txHash common.Hash) (*types.Receipt, error)
 	RevertReasonFromTx(txHash common.Hash, abiString string) (string, interface{}, error)
+	ErrorReason(b ethereum.ContractCaller, tx *types.Transaction, receipt *types.Receipt) (string, error)
 
 	ParallelTransactions(enabled bool)
 	Close() error

--- a/blockchain/ethereum.go
+++ b/blockchain/ethereum.go
@@ -759,7 +759,7 @@ func (e *EthereumClient) IsTxConfirmed(txHash common.Hash) (bool, error) {
 			if err == nil {
 				from = fromAddr.Hex()
 			}
-			reason, err := e.errorReason(e.Client, tx, receipt)
+			reason, err := e.ErrorReason(e.Client, tx, receipt)
 			if err != nil {
 				e.l.Warn().Str("TX Hash", txHash.Hex()).
 					Str("To", to).
@@ -797,7 +797,7 @@ func (e *EthereumClient) IsEventConfirmed(event *types.Log) (confirmed, removed 
 		return false, event.Removed, err
 	}
 	if eventReceipt.Status == 0 { // Failed event tx
-		reason, err := e.errorReason(e.Client, eventTx, eventReceipt)
+		reason, err := e.ErrorReason(e.Client, eventTx, eventReceipt)
 		if err != nil {
 			e.l.Warn().Str("TX Hash", eventTx.Hash().Hex()).
 				Str("Error extracting reason", err.Error()).
@@ -839,7 +839,7 @@ func (e *EthereumClient) RevertReasonFromTx(txHash common.Hash, abiString string
 	if err != nil {
 		return "", nil, err
 	}
-	errData, err := e.errorReason(e.Client, tx, re)
+	errData, err := e.ErrorReason(e.Client, tx, re)
 	if err != nil {
 		return "", nil, err
 	}
@@ -1730,4 +1730,8 @@ func (e *EthereumMultinodeClient) WaitForEvents() error {
 		})
 	}
 	return g.Wait()
+}
+
+func (e *EthereumMultinodeClient) ErrorReason(b ethereum.ContractCaller, tx *types.Transaction, receipt *types.Receipt) (string, error) {
+	return e.DefaultClient.ErrorReason(b, tx, receipt)
 }

--- a/blockchain/transaction_confirmers.go
+++ b/blockchain/transaction_confirmers.go
@@ -522,8 +522,8 @@ func (e *EthereumClient) receiveHeader(header *SafeEVMHeader) error {
 	return nil
 }
 
-// errorReason decodes tx revert reason
-func (e *EthereumClient) errorReason(
+// ErrorReason decodes tx revert reason
+func (e *EthereumClient) ErrorReason(
 	b ethereum.ContractCaller,
 	tx *types.Transaction,
 	receipt *types.Receipt,


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the Ethereum blockchain client implementation by introducing a new method to extract error reasons from transactions and making it public for broader usage. This facilitates better error handling and debugging across different parts of the blockchain system.

## What
- **blockchain/blockchain.go & blockchain/ethereum.go & blockchain/transaction_confirmers.go**
  - Renamed `errorReason` function to `ErrorReason` and made it public, allowing it to be accessed from other packages.
  - Updated all calls to the renamed `ErrorReason` method to reflect the new name, ensuring consistency and improving the readability and maintainability of the code.
  - Added an implementation of `ErrorReason` in `EthereumMultinodeClient`, ensuring that the multinode client can also use the new functionality to extract error reasons from transactions.
  - These changes streamline error handling by providing a unified method to retrieve detailed error reasons when transactions fail, aiding in troubleshooting and enhancing the overall robustness of the blockchain client implementations.
