### PR TITLE
[TT-1348] add fields to config representing deployed CL node details [WIP]

### DIFF
--- a/config/node.go
+++ b/config/node.go
@@ -4,4 +4,15 @@ type NodeConfig struct {
 	BaseConfigTOML           string            `toml:",omitempty"`
 	CommonChainConfigTOML    string            `toml:",omitempty"`
 	ChainConfigTOMLByChainID map[string]string `toml:",omitempty"` // key is chainID
+	NumberOfNodes            *int              `toml:",omitempty"`
+	UseExisting              *bool             `toml:"use_existing,omitempty"`
+	Nodes                    []NodeDetails     `toml:"Node,omitempty"`
+	Namespace                *string           `toml:"namespace,omitempty"`
+}
+
+type NodeDetails struct {
+	URL        *string `toml:"url,omitempty"`
+	InternalIP *string `toml:"internal_ip,omitempty"`
+	Email      *string
+	Password   *string
 }


### PR DESCRIPTION
option to pass mockserver url, if empty, but namespace is present build it based on namespace (it has a static url). we could think about doing same for CL nodes.

Also, think whether we should support a situation, where a test is runner and in the background someone adds more nodes to the DON. As long as their URLs follow the same convention (and they all use the same url/pass) we could see if we can find them and connect to them (as another step in some test loop? or during test setup?)

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce configuration options for defining node details and deployment preferences, allowing for more flexibility in configuring blockchain nodes. This includes the ability to specify the number of nodes, whether to use existing nodes, detailed node configurations, and namespace specifications.

## What
- **config/node.go**
  - Added `NumberOfNodes *int` to allow specifying the number of nodes to be deployed.
  - Added `UseExisting *bool` to specify whether to use existing nodes instead of creating new ones.
  - Added a `Nodes` array to contain configurations for individual nodes, including URL, internal IP, email, and password.
  - Introduced `Namespace *string` to allow setting a namespace for node deployment, providing a way to group or isolate nodes within a particular context.
