### PR TITLE
[TT-1390] add karpenter annotations instead of using pod disruption budget

### DIFF
--- a/k8s-test-runner/chart/templates/job.yaml
+++ b/k8s-test-runner/chart/templates/job.yaml
@@ -22,6 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         karpenter.sh/do-not-evict: "true"
+        karpenter.sh/do-not-disrupt: "true"
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:
       serviceAccountName: {{ $.Values.rbac.serviceAccountName }}


### PR DESCRIPTION
Following annotations are added to all pods:
<img width="474" alt="image" src="https://github.com/smartcontractkit/chainlink-testing-framework/assets/20401585/0a4ece3c-f519-46b7-81f2-2b3473f55e09">

---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates enhance Kubernetes job configurations for better resource management and stability. By adding a new annotation, `karpenter.sh/do-not-disrupt: "true"`, we ensure that the jobs are less likely to be disrupted or evicted, improving reliability during execution. Removing the Pod Disruption Budget (PDB) setup for preventing pod eviction simplifies the configuration, relying on annotations to manage eviction policies.

## What
- **k8s-test-runner/chart/templates/job.yaml**
  - Added `karpenter.sh/do-not-disrupt: "true"` to annotations, ensuring jobs are less likely to be disrupted.
- **k8s/environment/environment.go**
  - Removed the Pod Disruption Budget (PDB) setup to streamline configurations. This change makes the deployment process less complex by relying on annotations to prevent pod eviction instead of creating a PDB.
  - Added `karpenter.sh/do-not-disrupt: "true"` to the `markNotSafeToEvict` function, aligning with the job template's approach to handling pod disruption.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the Kubernetes job configuration and environment setup for the test runner, focusing on preventing pod eviction and disruption, which is critical for ensuring that tests run reliably in an environment where resources can be preemptively reclaimed by the cluster autoscaler or Kubernetes scheduler.

## What
- **k8s-test-runner/chart/templates/job.yaml**
  - Added `karpenter.sh/do-not-disrupt: "true"` annotation to the job template to prevent test runner pods from being disrupted.
  
- **k8s/environment/environment.go**
  - Removed the PodDisruptionBudget setup block which was previously used to prevent pod eviction. This suggests a shift towards using annotations for managing pod disruption policies.
  - Added `karpenter.sh/do-not-disrupt: "true"` alongside the existing `karpenter.sh/do-not-evict: "true"` and `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotations in the `markNotSafeToEvict` function. This ensures that both evictions and disruptions are considered when marking pods as not safe for these operations.
