### PR TITLE
Update TestConfig doc about creating new secrets

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -51,13 +51,9 @@ E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY=wallet_key
 | Loki Endpoint                 | `E2E_TEST_LOKI_ENDPOINT`                                            | `E2E_TEST_LOKI_ENDPOINT=url`                        |
 | Loki Basic Auth               | `E2E_TEST_LOKI_BASIC_AUTH`                                          | `E2E_TEST_LOKI_BASIC_AUTH=token`                    |
 | Loki Bearer Token             | `E2E_TEST_LOKI_BEARER_TOKEN`                                        | `E2E_TEST_LOKI_BEARER_TOKEN=token`                  |
-| Grafana Base URL              | `E2E_TEST_GRAFANA_BASE_URL`                                         | `E2E_TEST_GRAFANA_BASE_URL=base_url`                |
-| Grafana Dashboard URL         | `E2E_TEST_GRAFANA_DASHBOARD_URL`                                    | `E2E_TEST_GRAFANA_DASHBOARD_URL=url`                |
 | Grafana Bearer Token          | `E2E_TEST_GRAFANA_BEARER_TOKEN`                                     | `E2E_TEST_GRAFANA_BEARER_TOKEN=token`               |
 | Pyroscope Server URL          | `E2E_TEST_PYROSCOPE_SERVER_URL`                                     | `E2E_TEST_PYROSCOPE_SERVER_URL=url`                 |
 | Pyroscope Key                 | `E2E_TEST_PYROSCOPE_KEY`                                            | `E2E_TEST_PYROSCOPE_KEY=key`                        |
-| Pyroscope Environment         | `E2E_TEST_PYROSCOPE_ENVIRONMENT`                                    | `E2E_TEST_PYROSCOPE_ENVIRONMENT=env`                |
-| Pyroscope Enabled             | `E2E_TEST_PYROSCOPE_ENABLED`                                        | `E2E_TEST_PYROSCOPE_ENABLED=true`                   |
 
 ### Run GitHub Workflow with Your Test Secrets
 

--- a/config/README.md
+++ b/config/README.md
@@ -88,6 +88,16 @@ By default, GitHub workflows execute with a set of predefined secrets. However, 
 
 If the `test_secrets_override_key` is not provided, the workflow will default to using the secrets preconfigured in the CI environment.
 
+### Creating New Test Secrets in TestConfig
+
+When adding a new secret to the `TestConfig`, such as a token or other sensitive information, the method `ReadConfigValuesFromEnvVars()` in `config/testconfig.go` must be extended to include the new secret. Ensure that the new environment variable starts with the `E2E_TEST_` prefix. This prefix is crucial for ensuring that the secret is correctly propagated to Kubernetes tests when using the Remote Runner.
+
+Here’s a quick checklist for adding a new test secret:
+
+- Add the secret to ~/.testsecrets with the `E2E_TEST_` prefix to ensure proper handling.
+- Extend the `config/testconfig.go:ReadConfigValuesFromEnvVars()` method to load the secret in `TestConfig`
+- Add the secrets to [All E2E Test Secrets](https://github.com/smartcontractkit/chainlink-testing-framework/blob/main/config/README.md#all-e2e-test-secrets) table.
+
 ## Working example
 
 For a full working example making use of all the building blocks see [testconfig.go](../config/examples/testconfig.go). It provides methods for reading TOML, applying overrides and validating non-empty config blocks. It supports 4 levels of overrides, in order of precedence:

--- a/tools/ghsecrets/README.md
+++ b/tools/ghsecrets/README.md
@@ -26,7 +26,9 @@ ghsecrets set
 
 This error typically means that the directory where Go installs its binaries is not included in your system's PATH. The binaries are usually installed in $GOPATH/bin or $GOBIN. Here's how you can resolve this issue:
 
-1. Add Go bin directory to PATH:
+1. If you use `asdf` run `asdf reshim golang`
+
+2. Or, add Go bin directory to PATH:
 
 - First, find out where your Go bin directory is by running:
 
@@ -47,7 +49,7 @@ This error typically means that the directory where Go installs its binaries is 
   source ~/.bashrc  # Use the appropriate file like .zshrc if needed
   ```
 
-2. Alternatively, run using the full path:
+3. Alternatively, run using the full path:
 
    If you prefer not to alter your PATH, or if you are troubleshooting temporarily, you can run the tool directly using its full path:
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce documentation for adding new test secrets to the `TestConfig`, ensuring developers understand how to properly add and manage secrets for end-to-end (E2E) testing. This is crucial for maintaining security and consistency across test environments.

## What
- **config/README.md**
  - Added a new section "Creating New Test Secrets in TestConfig" which outlines the steps for adding a new secret to the `TestConfig`. This includes extending the `ReadConfigValuesFromEnvVars()` method in `config/testconfig.go`, adding the secret with an `E2E_TEST_` prefix to `~/.testsecrets`, and documenting the secret in the "All E2E Test Secrets" section. This ensures the seamless integration of new secrets into the automated testing framework, enhancing both security and ease of use.
