### PR TITLE
[TT-1094] reth support update mirrors

### DIFF
--- a/.github/actions/update-internal-mirrors/action.yaml
+++ b/.github/actions/update-internal-mirrors/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Number of tags to return per page'
     required: false
     default: '100'
+  github_token:
+    description: 'Token to use for GitHub API, in most cases github.token'
+    required: true
+
 runs:
   using: 'composite'
   steps:
@@ -38,6 +42,8 @@ runs:
         AWS_REGION: ${{ inputs.aws_region }}
     - name: Update images
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         # Update images
         # Change to the directory where the action is stored

--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -46,11 +46,11 @@ jobs:
             expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: wiremock/wiremock
             expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
-    # disabled until gcloud auth is added
-    # - name: gcr.io/prysmaticlabs/prysm/beacon-chain
-    #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
-    # - name: gcr.io/prysmaticlabs/prysm/validator
-    #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          # disabled until gcloud auth is added
+          # - name: gcr.io/prysmaticlabs/prysm/beacon-chain
+          #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          # - name: gcr.io/prysmaticlabs/prysm/validator
+          #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: tofelb/ethereum-genesis-generator
             expression: '^[0-9]+\.[0-9]+\.[0-9]+(\-slots\-per\-epoch)?'
     # This one only has latest tag, probably only want to update it when we know for sure it's a new version we want
@@ -62,7 +62,7 @@ jobs:
       packages: read
     steps:
       - name: Update image
-        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@ab6c608e317c68224c0581ef4f1dfaa0eaaec14e
+        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@4dcb58fdc5e64465370bf59f4f9a230a0829d118
         with:
           aws_region: ${{ secrets.QA_AWS_REGION }}
           role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -80,7 +80,7 @@ jobs:
       contents: read
     steps:
       - name: Update other images
-        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@ab6c608e317c68224c0581ef4f1dfaa0eaaec14e
+        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@4dcb58fdc5e64465370bf59f4f9a230a0829d118
         with:
           aws_region: ${{ secrets.QA_AWS_REGION }}
           role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -42,24 +42,27 @@ jobs:
             expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: nethermind/nethermind
             expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
+          - name: ghcr.io/paradigmxyz/reth
+            expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: wiremock/wiremock
             expression: '^[0-9]+\.[0-9]+\.[0-9]+$'
-          # disabled until gcloud auth is added
-          # - name: gcr.io/prysmaticlabs/prysm/beacon-chain
-          #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
-          # - name: gcr.io/prysmaticlabs/prysm/validator
-          #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    # disabled until gcloud auth is added
+    # - name: gcr.io/prysmaticlabs/prysm/beacon-chain
+    #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    # - name: gcr.io/prysmaticlabs/prysm/validator
+    #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: tofelb/ethereum-genesis-generator
             expression: '^[0-9]+\.[0-9]+\.[0-9]+(\-slots\-per\-epoch)?'
-          # This one only has latest tag, probably only want to update it when we know for sure it's a new version we want
-          #  - name: protolambda/eth2-val-tools
-          #   expression: 'latest'
+    # This one only has latest tag, probably only want to update it when we know for sure it's a new version we want
+    #  - name: protolambda/eth2-val-tools
+    #   expression: 'latest'
     permissions:
       id-token: write
       contents: read
+      packages: read
     steps:
       - name: Update image
-        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@9190fa16db15bbb7caa5595b347c51acdda9eb3a
+        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@ab6c608e317c68224c0581ef4f1dfaa0eaaec14e
         with:
           aws_region: ${{ secrets.QA_AWS_REGION }}
           role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -67,6 +70,7 @@ jobs:
           image_name: ${{matrix.mirror.name}}
           expression: ${{matrix.mirror.expression}}
           page_size: ${{matrix.mirror.page_size}}
+          github_token: ${{ github.token }}
 
   update-other-images:
     runs-on: ubuntu-latest
@@ -76,7 +80,7 @@ jobs:
       contents: read
     steps:
       - name: Update other images
-        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@9190fa16db15bbb7caa5595b347c51acdda9eb3a
+        uses: smartcontractkit/chainlink-testing-framework/.github/actions/update-internal-mirrors@ab6c608e317c68224c0581ef4f1dfaa0eaaec14e
         with:
           aws_region: ${{ secrets.QA_AWS_REGION }}
           role_to_assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
Caveat: does not work due to problems with github token, but works locally with PAT

Open Github Issue: https://github.com/github/docs/issues/33900
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce support for GitHub Container Registry (GHCR) images and improve the automation process by adding a GitHub token requirement for the action. This enhances the capability to update internal mirrors with GHCR images and ensures secure and authenticated access to GitHub's API for fetching image tags.

## What
- **.github/actions/update-internal-mirrors/action.yaml**
  - Added `github_token` input with description and marked as required. This change ensures that the action can authenticate against GitHub's API.
- **.github/actions/update-internal-mirrors/scripts/update_mirrors.sh**
  - Added a new function `fetch_images_from_gh_container_registry` to handle fetching tags from the GitHub Container Registry based on provided criteria.
  - Modified `push_latest_images_for_expression_from_dockerhub` function to handle GHCR images by checking if the image name starts with `ghcr.io` and then using the new `fetch_images_from_gh_container_registry` function.
- **.github/workflows/update-internal-mirrors.yaml**
  - Added a new mirror entry for `ghcr.io/paradigmxyz/reth` to be updated as part of the workflow.
  - Included `packages: read` permission, required for accessing GHCR images.
  - Updated the action version in steps to use the latest commit hash, ensuring that the workflow uses the version of the action that includes the new changes.
  - Provided `github_token` as an input to the action step, which is necessary for authenticating GitHub API requests within the action.
