### PR TITLE
Update docs for test secrets

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -40,20 +40,20 @@ E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY=wallet_key
 
 ### All E2E Test Secrets
 
-| Secret                        | Env Var                                                             | Example                                             |
-| ----------------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
-| Chainlink Image               | `E2E_TEST_CHAINLINK_IMAGE`                                          | `E2E_TEST_CHAINLINK_IMAGE=qa_ecr_image_url`         |
-| Chainlink Upgrade Image       | `E2E_TEST_CHAINLINK_UPGRADE_IMAGE`                                  | `E2E_TEST_CHAINLINK_UPGRADE_IMAGE=qa_ecr_image_url` |
-| Wallet Key per network        | `E2E_TEST_(.+)_WALLET_KEY` or `E2E_TEST_(.+)_WALLET_KEY_(\d+)$`     | `E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY=wallet_key`   |
-| RPC HTTP URL per network      | `E2E_TEST_(.+)_RPC_HTTP_URL` or `E2E_TEST_(.+)_RPC_HTTP_URL_(\d+)$` | `E2E_TEST_ARBITRUM_SEPOLIA_RPC_HTTP_URL=url`        |
-| RPC WebSocket URL per network | `E2E_TEST_(.+)_RPC_WS_URL` or `E2E_TEST_(.+)_RPC_WS_URL_(\d+)$`     | `E2E_TEST_ARBITRUM_RPC_WS_URL=ws_url`               |
-| Loki Tenant ID                | `E2E_TEST_LOKI_TENANT_ID`                                           | `E2E_TEST_LOKI_TENANT_ID=tenant_id`                 |
-| Loki Endpoint                 | `E2E_TEST_LOKI_ENDPOINT`                                            | `E2E_TEST_LOKI_ENDPOINT=url`                        |
-| Loki Basic Auth               | `E2E_TEST_LOKI_BASIC_AUTH`                                          | `E2E_TEST_LOKI_BASIC_AUTH=token`                    |
-| Loki Bearer Token             | `E2E_TEST_LOKI_BEARER_TOKEN`                                        | `E2E_TEST_LOKI_BEARER_TOKEN=token`                  |
-| Grafana Bearer Token          | `E2E_TEST_GRAFANA_BEARER_TOKEN`                                     | `E2E_TEST_GRAFANA_BEARER_TOKEN=token`               |
-| Pyroscope Server URL          | `E2E_TEST_PYROSCOPE_SERVER_URL`                                     | `E2E_TEST_PYROSCOPE_SERVER_URL=url`                 |
-| Pyroscope Key                 | `E2E_TEST_PYROSCOPE_KEY`                                            | `E2E_TEST_PYROSCOPE_KEY=key`                        |
+| Secret                        | Env Var                                                             | Example                                                                                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chainlink Image               | `E2E_TEST_CHAINLINK_IMAGE`                                          | `E2E_TEST_CHAINLINK_IMAGE=qa_ecr_image_url`                                                                                                                                                     |
+| Chainlink Upgrade Image       | `E2E_TEST_CHAINLINK_UPGRADE_IMAGE`                                  | `E2E_TEST_CHAINLINK_UPGRADE_IMAGE=qa_ecr_image_url`                                                                                                                                             |
+| Wallet Key per network        | `E2E_TEST_(.+)_WALLET_KEY` or `E2E_TEST_(.+)_WALLET_KEY_(\d+)$`     | `E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY=wallet_key` or `E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY_1=wallet_key_1`, `E2E_TEST_ARBITRUM_SEPOLIA_WALLET_KEY_2=wallet_key_2` for multiple keys per network |
+| RPC HTTP URL per network      | `E2E_TEST_(.+)_RPC_HTTP_URL` or `E2E_TEST_(.+)_RPC_HTTP_URL_(\d+)$` | `E2E_TEST_ARBITRUM_SEPOLIA_RPC_HTTP_URL=url` or `E2E_TEST_ARBITRUM_SEPOLIA_RPC_HTTP_URL_1=url`, `E2E_TEST_ARBITRUM_SEPOLIA_RPC_HTTP_URL_2=url` for multiple http urls per network               |
+| RPC WebSocket URL per network | `E2E_TEST_(.+)_RPC_WS_URL` or `E2E_TEST_(.+)_RPC_WS_URL_(\d+)$`     | `E2E_TEST_ARBITRUM_RPC_WS_URL=ws_url` or `E2E_TEST_ARBITRUM_RPC_WS_URL_1=ws_url_1`, `E2E_TEST_ARBITRUM_RPC_WS_URL_2=ws_url_2` for multiple ws urls per network                                  |
+| Loki Tenant ID                | `E2E_TEST_LOKI_TENANT_ID`                                           | `E2E_TEST_LOKI_TENANT_ID=tenant_id`                                                                                                                                                             |
+| Loki Endpoint                 | `E2E_TEST_LOKI_ENDPOINT`                                            | `E2E_TEST_LOKI_ENDPOINT=url`                                                                                                                                                                    |
+| Loki Basic Auth               | `E2E_TEST_LOKI_BASIC_AUTH`                                          | `E2E_TEST_LOKI_BASIC_AUTH=token`                                                                                                                                                                |
+| Loki Bearer Token             | `E2E_TEST_LOKI_BEARER_TOKEN`                                        | `E2E_TEST_LOKI_BEARER_TOKEN=token`                                                                                                                                                              |
+| Grafana Bearer Token          | `E2E_TEST_GRAFANA_BEARER_TOKEN`                                     | `E2E_TEST_GRAFANA_BEARER_TOKEN=token`                                                                                                                                                           |
+| Pyroscope Server URL          | `E2E_TEST_PYROSCOPE_SERVER_URL`                                     | `E2E_TEST_PYROSCOPE_SERVER_URL=url`                                                                                                                                                             |
+| Pyroscope Key                 | `E2E_TEST_PYROSCOPE_KEY`                                            | `E2E_TEST_PYROSCOPE_KEY=key`                                                                                                                                                                    |
 
 ### Run GitHub Workflow with Your Test Secrets
 
@@ -69,10 +69,15 @@ By default, GitHub workflows execute with a set of predefined secrets. However, 
      go install github.com/smartcontractkit/chainlink-testing-framework/tools/ghsecrets@latest
      ```
    - **Upload Secrets:**
-     Use `ghsecrets set` to upload the content of your `~/.testsecrets` file to the GitHub Secrets Vault and generate a unique identifier (referred to as `your_ghsecret_id`).
-     ```bash
-     ghsecrets set
-     ```
+     Run `ghsecrets set` from local core repo to upload the content of your `~/.testsecrets` file to the GitHub Secrets Vault and generate a unique identifier (referred to as `your_ghsecret_id`).
+
+   ```bash
+   cd path-to-chainlink-core-repo
+   ```
+
+   ```bash
+   ghsecrets set
+   ```
 
 2. **Execute the Workflow with Custom Secrets:**
    - To use the custom secrets in your GitHub Actions workflow, pass the `-f test_secrets_override_key={your_ghsecret_id}` flag when running the `gh workflow` command.

--- a/config/README.md
+++ b/config/README.md
@@ -65,10 +65,12 @@ By default, GitHub workflows execute with a set of predefined secrets. However, 
 
    - **Install `ghsecrets` tool:**
      Install the `ghsecrets` tool to manage GitHub Secrets more efficiently.
+
      ```bash
      go install github.com/smartcontractkit/chainlink-testing-framework/tools/ghsecrets@latest
      ```
-	 If you use `asdf`, run `asdf reshim`
+
+     If you use `asdf`, run `asdf reshim`
 
    - **Upload Secrets:**
      Run `ghsecrets set` from local core repo to upload the content of your `~/.testsecrets` file to the GitHub Secrets Vault and generate a unique identifier (referred to as `your_ghsecret_id`).

--- a/config/README.md
+++ b/config/README.md
@@ -68,6 +68,8 @@ By default, GitHub workflows execute with a set of predefined secrets. However, 
      ```bash
      go install github.com/smartcontractkit/chainlink-testing-framework/tools/ghsecrets@latest
      ```
+	 If you use `asdf`, run `asdf reshim`
+
    - **Upload Secrets:**
      Run `ghsecrets set` from local core repo to upload the content of your `~/.testsecrets` file to the GitHub Secrets Vault and generate a unique identifier (referred to as `your_ghsecret_id`).
 
@@ -78,6 +80,8 @@ By default, GitHub workflows execute with a set of predefined secrets. However, 
    ```bash
    ghsecrets set
    ```
+
+   For more details about `ghsecrets`, visit https://github.com/smartcontractkit/chainlink-testing-framework/tree/main/tools/ghsecrets#faq
 
 2. **Execute the Workflow with Custom Secrets:**
    - To use the custom secrets in your GitHub Actions workflow, pass the `-f test_secrets_override_key={your_ghsecret_id}` flag when running the `gh workflow` command.


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The modifications enhance documentation clarity and expand on the configuration details for easier setup of E2E tests. Specifically, the updates cater to handling multiple wallet keys and URLs per network, which reflects a more flexible testing environment. Additionally, the guidance on using the `ghsecrets` tool is made more explicit by directing users to execute commands within the context of their local Chainlink core repository, reducing potential confusion.

## What
- **config/README.md**
  - Expanded examples for `E2E_TEST_(.+)_WALLET_KEY` and `E2E_TEST_(.+)_RPC_HTTP_URL`/`E2E_TEST_(.+)_RPC_WS_URL` to include cases with multiple keys/URLs per network. This change makes it clearer how to configure tests involving multiple accounts or endpoints.
  - Clarified instructions for uploading secrets using `ghsecrets set`, including navigating to the local Chainlink core repository before running the command. This ensures users are in the correct directory, which is a prerequisite for the command to succeed.
