### PR TITLE
Load .testsecrets from kube secret in the remote runner

### DIFF
--- a/config/testconfig.go
+++ b/config/testconfig.go
@@ -409,9 +409,8 @@ func LoadSecretEnvsFromFiles() error {
 			if os.IsNotExist(err) {
 				logger.Debug().Msgf("No test secrets file found at %s", path)
 				continue
-			} else {
-				return errors.Wrapf(err, "error reading test secrets file at %s", path)
 			}
+			return errors.Wrapf(err, "error reading test secrets file at %s", path)
 		}
 
 		// Set env vars from file only if they are not already set

--- a/config/testconfig.go
+++ b/config/testconfig.go
@@ -382,24 +382,8 @@ func readEnvVarValue(envVarName string, valueType EnvValueType) (interface{}, er
 	}
 }
 
-func LoadSecretEnvsFromFile() error {
+func LoadSecretEnvsFromFiles() error {
 	logger := logging.GetTestLogger(nil)
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return errors.Wrapf(err, "error getting user home directory")
-	}
-	path := fmt.Sprintf("%s/.testsecrets", homeDir)
-
-	// Check if the file exists
-	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		logger.Debug().Msgf("No test secrets file found at %s", path)
-		return nil
-	}
-	if info.IsDir() {
-		return errors.Errorf("%s file is a directory but should be a file", path)
-	}
 
 	// Load existing environment variables into a map
 	existingEnv := make(map[string]string)
@@ -408,19 +392,36 @@ func LoadSecretEnvsFromFile() error {
 		existingEnv[pair[0]] = pair[1]
 	}
 
-	// Load variables from the env file
-	envMap, err := godotenv.Read(path)
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return errors.Wrapf(err, "error loading %s file with test secrets", path)
+		return errors.Wrapf(err, "error getting user home directory")
 	}
+	homePath := fmt.Sprintf("%s/.testsecrets", homeDir)
+	etcPath := "/etc/e2etests/.testsecrets"
+	testsecretsPath := []string{etcPath, homePath}
 
-	// Set env vars from file only if they are not already set
-	for key, value := range envMap {
-		if _, exists := existingEnv[key]; !exists {
-			logger.Debug().Msgf("Setting env var %s from %s file", key, path)
-			os.Setenv(key, value)
-		} else {
-			logger.Debug().Msgf("Env var %s already set, not overriding it from %s file", key, path)
+	for _, path := range testsecretsPath {
+		logger.Debug().Msgf("Checking for test secrets file at %s", path)
+
+		// Load variables from the env file
+		envMap, err := godotenv.Read(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logger.Debug().Msgf("No test secrets file found at %s", path)
+				continue
+			} else {
+				return errors.Wrapf(err, "error reading test secrets file at %s", path)
+			}
+		}
+
+		// Set env vars from file only if they are not already set
+		for key, value := range envMap {
+			if _, exists := existingEnv[key]; !exists {
+				logger.Debug().Msgf("Setting env var %s from %s file", key, path)
+				os.Setenv(key, value)
+			} else {
+				logger.Debug().Msgf("Env var %s already set, not overriding it from %s file", key, path)
+			}
 		}
 	}
 


### PR DESCRIPTION
This updates remote runner to load .testsecrets file from `/etc/e2etests/.testsecrets` (set as kube secret) instead of env vars.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the flexibility and security of handling environment variables and secrets within test configurations and Kubernetes job setups. By loading secrets from multiple standard locations, it ensures that test environments can adapt to various deployment scenarios. Additionally, the introduction of a Kubernetes secret for storing environment variables enhances the security and manageability of sensitive information used in tests.

## What
- **config/testconfig.go**
  - Renamed `LoadSecretEnvsFromFile` to `LoadSecretEnvsFromFiles` and modified to load environment variables from multiple files, enhancing flexibility in configuration management.
  - Added logic to check for secrets in both the home directory and a system-wide configuration path, improving adaptability to different deployment environments.
  - Introduced error handling for file existence and readability to improve robustness and user feedback during configuration loading.
- **k8s/environment/runner.go**
  - Added an import for `bytes` to support in-memory data manipulation.
  - Introduced a new function `kubeSecret` to create a Kubernetes secret from environment variables prefixed with a specific prefix, enhancing the security of sensitive data handling.
  - Modified the `job` function to include a volume attached to the newly created Kubernetes secret, ensuring that test secrets are accessible within the Kubernetes job environment.
  - Added a new function `createTestSecretsDotenvFromEnvVars` to generate a dotenv-format string from environment variables, facilitating easier injection of configuration into Kubernetes jobs.
  - Updated the `container` function to mount the dotenv file from the Kubernetes secret into the job's container, allowing the test environment to access configured secrets.
  - Removed forwarding of E2E test-specific environment variables directly within the `jobEnvVars` function, as these are now handled through the Kubernetes secret mechanism.
