### PR TITLE
Bump go version to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-testing-framework
 
-go 1.21
+go 1.22.5
 
 require (
 	dario.cat/mergo v1.0.0

--- a/k8s/Dockerfile.base
+++ b/k8s/Dockerfile.base
@@ -1,5 +1,5 @@
 # base test for all k8s test runs
-FROM golang:1.21-bullseye
+FROM golang:1.22-bullseye
 
 ARG BASE_URL
 ARG HELM_VERSION


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
Upgrading the Go version to ensure compatibility and leverage improvements and security fixes in the latest version.

## What
- **go.mod**: Updated the Go language version from `1.21` to `1.22.5`. This change ensures that the project uses the latest stable Go version, which could include performance improvements, security patches, and new features.
- **k8s/Dockerfile.base**: Changed the base image from `golang:1.21-bullseye` to `golang:1.22-bullseye`. This adjustment ensures that Docker builds for Kubernetes tests are carried out with the same Go version, maintaining consistency and potentially benefiting from improvements in the Go release.
