### PR TITLE
support --max-persisted-states in foundry/anvil

### DIFF
--- a/charts/foundry/Chart.yaml
+++ b/charts/foundry/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: foundry
 description: A Helm chart for foundry, mostly used to run Anvil node
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 'latest'

--- a/charts/foundry/templates/deployment.yaml
+++ b/charts/foundry/templates/deployment.yaml
@@ -122,6 +122,10 @@ spec:
             - "--transaction-block-keeper"
             - {{ .Values.anvil.blocksToKeepInMemory | quote }}
             {{- end }}
+            {{- if .Values.anvil.maxPersistedStates }}
+            - "--max-persisted-states"
+            - {{ .Values.anvil.maxPersistedStates | quote }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
Updated the Foundry chart to include a new feature for managing persisted states, enhancing the Anvil node's functionality. The version bump reflects minor improvements and additional functionality without breaking changes.

## What
- **charts/foundry/Chart.yaml**
  - Updated `version` from `0.2.1` to `0.2.2`. This change indicates a minor version bump to reflect new features or improvements without breaking changes.
- **charts/foundry/templates/deployment.yaml**
  - Added a new command line argument `--max-persisted-states` with a configurable value. This allows users to specify the maximum number of persisted states, enhancing control over state management for the Anvil node.
