### PR TITLE
Fixes Image Pull Policy

### DIFF
--- a/charts/chainlink/Chart.yaml
+++ b/charts/chainlink/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/chainlink/templates/chainlink-deployment.yaml
+++ b/charts/chainlink/templates/chainlink-deployment.yaml
@@ -47,7 +47,7 @@ spec:
             {{- end }}
           {{- end }}
           image: {{ $image }}:{{ $tag }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [ "/bin/bash" ]
           args:
             - "-c"


### PR DESCRIPTION
This pull policy would cause issues for our frequently-updated test tags like `chainlink:develop` that are continuously updated to point to the latest develop image. [According to K8s, this should be reasonably efficient](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy):

> The caching semantics of the underlying image provider make even imagePullPolicy: Always efficient, as long as the registry is reliably accessible. Your container runtime can notice that the image layers already exist on the node so that they don't need to be downloaded again.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The change updates the image pull policy from `IfNotPresent` to `Always` ensuring that the latest version of the container image is always used, which is critical for keeping the deployment up-to-date with the latest features, security patches, and bug fixes.

## What
- **charts/chainlink/templates/chainlink-deployment.yaml**
  - Changed `imagePullPolicy` from `IfNotPresent` to `Always`. This modification ensures that the nodes always pull the latest image version before starting, which is vital for maintaining the security and efficiency of the network.
