### PR TITLE
QA-1405: Adding ZKSync network details

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -502,18 +502,6 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
-	CeloAlfajores = blockchain.EVMNetwork{
-		Name:                      "Celo Alfajores",
-		SupportsEIP1559:           false,
-		ClientImplementation:      blockchain.CeloClientImplementation,
-		ChainID:                   44787,
-		Simulated:                 false,
-		ChainlinkTransactionLimit: 5000,
-		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
-		MinimumConfirmations:      1,
-		GasEstimationBuffer:       1000,
-	}
-
 	ScrollSepolia = blockchain.EVMNetwork{
 		Name:                      "Scroll Sepolia",
 		ClientImplementation:      blockchain.ScrollClientImplementation,
@@ -536,6 +524,19 @@ var (
 		GasEstimationBuffer:       0,
 	}
 
+	CeloAlfajores = blockchain.EVMNetwork{
+		Name:                      "Celo Alfajores",
+		SupportsEIP1559:           false,
+		ClientImplementation:      blockchain.CeloClientImplementation,
+		ChainID:                   44787,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       1000,
+		FinalityDepth:             10,
+	}
+
 	CeloMainnet = blockchain.EVMNetwork{
 		Name:                      "Celo",
 		ClientImplementation:      blockchain.CeloClientImplementation,
@@ -545,6 +546,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       1000,
+		FinalityDepth:             10,
 	}
 
 	BaseMainnet blockchain.EVMNetwork = blockchain.EVMNetwork{
@@ -881,6 +883,34 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	ZKSyncSepolia = blockchain.EVMNetwork{
+		Name:                      "ZKSync Sepolia",
+		SupportsEIP1559:           false,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   300,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityDepth:             200,
+		DefaultGasLimit:           6000000,
+	}
+
+	ZKSyncMainnet = blockchain.EVMNetwork{
+		Name:                      "ZKSync Mainnet",
+		SupportsEIP1559:           false,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   324,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityDepth:             1200,
+		DefaultGasLimit:           6000000,
+	}
+
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
 		"ANVIL":                   Anvil,
@@ -942,6 +972,8 @@ var (
 		"BLAST_MAINNET":         BlastMainnet,
 		"MODE_SEPOLIA":          ModeSepolia,
 		"MODE_MAINNET":          ModeMainnet,
+		"ZKSync_SEPOLIA":        ZKSyncSepolia,
+		"ZKSync_MAINNET":        ZKSyncMainnet,
 	}
 )
 

--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -972,8 +972,8 @@ var (
 		"BLAST_MAINNET":         BlastMainnet,
 		"MODE_SEPOLIA":          ModeSepolia,
 		"MODE_MAINNET":          ModeMainnet,
-		"ZKSync_SEPOLIA":        ZKSyncSepolia,
-		"ZKSync_MAINNET":        ZKSyncMainnet,
+		"ZKSYNC_SEPOLIA":        ZKSyncSepolia,
+		"ZKSYNC_MAINNET":        ZKSyncMainnet,
 	}
 )
 


### PR DESCRIPTION
Adding ZKSync network and including finality depth in Celo.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the configuration of blockchain networks by adjusting network parameters and adding new networks, ZKSync Sepolia and ZKSync Mainnet. This updates provide more accurate simulation environments and expanded support for blockchain interoperability testing.

## What
- **networks/known_networks.go**
  - Added `FinalityDepth` to `CeloAlfajores` and `CeloMainnet` to specify the number of confirmations required to consider transactions final, enhancing network simulation accuracy.
  - Introduced `ZKSyncSepolia` and `ZKSyncMainnet` networks with specific configurations including `ChainID`, `SupportsEIP1559`, `ChainlinkTransactionLimit`, `Timeout`, `MinimumConfirmations`, `GasEstimationBuffer`, and `FinalityDepth`. This addition expands the network configurations available for testing, including layer 2 solutions.
  - Updated `MappedNetworks` with `ZKSync_SEPOLIA` and `ZKSync_MAINNET` to include these new networks in the global mapping, ensuring they are recognized and usable within the broader system.
