### PR TITLE
[SHIP-2116] Enables Astar

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -911,6 +911,34 @@ var (
 		DefaultGasLimit:           6000000,
 	}
 
+	AstarShibuya = blockchain.EVMNetwork{
+		Name:                      "Astar Shibuya",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   81,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityDepth:             100,
+		DefaultGasLimit:           8000000,
+	}
+
+	AstarMainnet = blockchain.EVMNetwork{
+		Name:                      "Astar Mainnet",
+		SupportsEIP1559:           true,
+		ClientImplementation:      blockchain.EthereumClientImplementation,
+		ChainID:                   592,
+		Simulated:                 false,
+		ChainlinkTransactionLimit: 5000,
+		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
+		MinimumConfirmations:      1,
+		GasEstimationBuffer:       10000,
+		FinalityDepth:             100,
+		DefaultGasLimit:           8000000,
+	}
+
 	MappedNetworks = map[string]blockchain.EVMNetwork{
 		"SIMULATED":               SimulatedEVM,
 		"ANVIL":                   Anvil,
@@ -974,6 +1002,8 @@ var (
 		"MODE_MAINNET":          ModeMainnet,
 		"ZKSYNC_SEPOLIA":        ZKSyncSepolia,
 		"ZKSYNC_MAINNET":        ZKSyncMainnet,
+		"ASTAR_SHIBUYA":         AstarShibuya,
+		"ASTAR_MAINNET":         AstarMainnet,
 	}
 )
 


### PR DESCRIPTION
### What

SHIP-2116 Enables Astar

### Why

Enables Astar Network
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The update introduces two new blockchain networks to the configuration: Astar Shibuya and Astar Mainnet. These additions expand the network compatibility of the system, providing users with the ability to interact with these networks.

## What
- **networks/known_networks.go**
  - Added `AstarShibuya` configuration to the list of blockchain EVM networks. This includes settings for chain ID, supports EIP1559, client implementation, and various limits and timeouts specific to Astar Shibuya.
  - Added `AstarMainnet` configuration with similar settings tailored for the Astar Mainnet network.
  - Updated `MappedNetworks` to include the newly added `AstarShibuya` and `AstarMainnet`.
