### PR TITLE
CRIB-317 - Use the kyverno's label instead of kube-janitor's annotation for clean up

### DIFF
--- a/k8s/TUTORIAL.md
+++ b/k8s/TUTORIAL.md
@@ -450,7 +450,7 @@ const (
 ```golang
 // Config is an environment common configuration, labels, annotations, connection types, readiness check, etc.
 type Config struct {
-	// TTL is time to live for the environment, used with kube-janitor
+	// TTL is time to live for the environment, used with kyverno
 	TTL time.Duration
 	// NamespacePrefix is a static namespace prefix
 	NamespacePrefix string

--- a/k8s/environment/environment.go
+++ b/k8s/environment/environment.go
@@ -70,7 +70,7 @@ type ConnectedChart interface {
 
 // Config is an environment common configuration, labels, annotations, connection types, readiness check, etc.
 type Config struct {
-	// TTL is time to live for the environment, used with kube-janitor
+	// TTL is time to live for the environment, used with kyverno
 	TTL time.Duration
 	// NamespacePrefix is a static namespace prefix
 	NamespacePrefix string
@@ -272,11 +272,12 @@ func (m *Environment) initApp() error {
 		}
 	}
 
+	m.Cfg.Labels = append(m.Cfg.Labels, fmt.Sprintf("%s=%s", pkg.TTLLabelKey, *a.ShortDur(m.Cfg.TTL)))
 	nsLabels, err := a.ConvertLabels(m.Cfg.Labels)
 	if err != nil {
 		return err
 	}
-	defaultNamespaceAnnotations[pkg.TTLLabelKey] = a.ShortDur(m.Cfg.TTL)
+
 	m.root = cdk8s.NewChart(m.App, ptr.Ptr(fmt.Sprintf("root-chart-%s", m.Cfg.Namespace)), &cdk8s.ChartProps{
 		Labels:    nsLabels,
 		Namespace: ptr.Ptr(m.Cfg.Namespace),

--- a/k8s/pkg/alias/alias.go
+++ b/k8s/pkg/alias/alias.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/ptr"
 )
 
-// ShortDur is a helper method for kube-janitor duration format
+// ShortDur is a helper method for kyverno duration format
 func ShortDur(d time.Duration) *string {
 	s := d.String()
 	if strings.HasSuffix(s, "m0s") {

--- a/k8s/pkg/common.go
+++ b/k8s/pkg/common.go
@@ -4,7 +4,7 @@ import "github.com/smartcontractkit/chainlink-testing-framework/utils/ptr"
 
 // Common labels for k8s envs
 const (
-	TTLLabelKey       = "janitor/ttl"
+	TTLLabelKey       = "cleanup.kyverno.io/ttl"
 	NamespaceLabelKey = "namespace"
 )
 


### PR DESCRIPTION
### What

Use the kyverno's label instead of kube-janitor's annotation for clean up

### Why

After https://github.com/smartcontractkit/infra-k8s/pull/19756, kyverno is now available in the SDLC cluster as well. And, it's the standard tool in use for CRIB already, we don't need yet another one (kube-janitor), which is currently broken and hasn't been actively developed in a while.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the Kubernetes configurations and associated Go files to switch from using `kube-janitor` to `kyverno` for managing the TTL of environments. This involves updating label keys and adjusting the duration format helper method for consistency with `kyverno`'s requirements.

## What
- **k8s/TUTORIAL.md & k8s/environment/environment.go**
  - Updated the comment for the `TTL` field in the `Config` struct to refer to `kyverno` instead of `kube-janitor`. This change affects how TTL is managed for Kubernetes environments.
  - Added a line to append a formatted TTL label to the `Config`'s Labels slice, using the `pkg.TTLLabelKey` and a newly formatted duration. This label is crucial for `kyverno` to identify and manage the TTL of resources.
  - Removed the explicit setting of the `pkg.TTLLabelKey` in the default namespace annotations, simplifying the management of TTL by directly appending it to the `Config`'s Labels.

- **k8s/pkg/alias/alias.go**
  - Changed the comment for the `ShortDur` function to reference `kyverno` instead of `kube-janitor`, indicating the function's purpose to format durations in a way that is compatible with `kyverno`.

- **k8s/pkg/common.go**
  - Modified the `TTLLabelKey` constant value from `janitor/ttl` to `cleanup.kyverno.io/ttl`. This change aligns the TTL label with `kyverno`'s labeling requirements for resource management.
