### PR TITLE
add TLS ignore in order to connect to CRIB, add debug

### DIFF
--- a/client/miner.go
+++ b/client/miner.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"net/http"
 	"strconv"
 	"time"
 
@@ -18,9 +19,9 @@ type RemoteAnvilMiner struct {
 }
 
 // NewRemoteAnvilMiner creates a new remote miner client
-func NewRemoteAnvilMiner(url string) *RemoteAnvilMiner {
+func NewRemoteAnvilMiner(url string, headers http.Header) *RemoteAnvilMiner {
 	return &RemoteAnvilMiner{
-		Client: NewRPCClient(url),
+		Client: NewRPCClient(url, headers),
 		stop:   make(chan struct{}),
 	}
 }

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -2,8 +2,11 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -24,8 +27,21 @@ type RPCClient struct {
 }
 
 // NewRPCClient creates Anvil client
-func NewRPCClient(url string) *RPCClient {
-	return &RPCClient{URL: url, client: resty.New()}
+func NewRPCClient(url string, headers http.Header) *RPCClient {
+	isDebug := os.Getenv("RESTY_DEBUG") == "true"
+	h := make(map[string]string)
+	for k, v := range headers {
+		h[k] = v[0]
+	}
+	// TODO: use proper certificated in CRIB
+	//nolint
+	return &RPCClient{
+		URL: url,
+		client: resty.New().
+			SetDebug(isDebug).
+			SetHeaders(h).
+			SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}),
+	}
 }
 
 // AnvilMine calls "evm_mine", mines one or more blocks, see the reference on RPCClient

--- a/client/rpc_suite_test.go
+++ b/client/rpc_suite_test.go
@@ -20,7 +20,7 @@ func TestRPCSuite(t *testing.T) {
 		require.NoError(t, err)
 		printGasPrices(t, client)
 		// set a base fee
-		anvilClient := NewRPCClient(ac.URL)
+		anvilClient := NewRPCClient(ac.URL, nil)
 		// set fee for the next block
 		err = anvilClient.AnvilSetNextBlockBaseFeePerGas([]interface{}{"2000000000"})
 		require.NoError(t, err)

--- a/client/rpc_test.go
+++ b/client/rpc_test.go
@@ -104,7 +104,7 @@ func TestRPCAPI(t *testing.T) {
 		bnBefore, err := client.BlockNumber(context.Background())
 		require.NoError(t, err)
 
-		ac := NewRPCClient(url)
+		ac := NewRPCClient(url, nil)
 		err = ac.GethSetHead(10)
 		require.NoError(t, err)
 		bnAfter, err := client.BlockNumber(context.Background())
@@ -121,7 +121,7 @@ func TestRPCAPI(t *testing.T) {
 		tx, err := sendTestTransaction(t, client, big.NewInt(1e9), big.NewInt(1e9), false)
 		require.NoError(t, err)
 
-		anvilClient := NewRPCClient(ac.URL)
+		anvilClient := NewRPCClient(ac.URL, nil)
 		err = anvilClient.AnvilDropTransaction([]interface{}{tx.Hash().String()})
 		require.NoError(t, err)
 		status, err := anvilClient.AnvilTxPoolStatus(nil)
@@ -136,7 +136,7 @@ func TestRPCAPI(t *testing.T) {
 		client, err := ethclient.Dial(ac.URL)
 		require.NoError(t, err)
 
-		anvilClient := NewRPCClient(ac.URL)
+		anvilClient := NewRPCClient(ac.URL, nil)
 		err = anvilClient.AnvilSetBlockGasLimit([]interface{}{"1"})
 		require.NoError(t, err)
 
@@ -157,7 +157,7 @@ func TestRPCAPI(t *testing.T) {
 		require.NoError(t, err)
 		printGasPrices(t, client)
 
-		anvilClient := NewRPCClient(ac.URL)
+		anvilClient := NewRPCClient(ac.URL, nil)
 		err = anvilClient.AnvilSetNextBlockBaseFeePerGas([]interface{}{"10000000000"})
 		require.NoError(t, err)
 		printGasPrices(t, client)
@@ -182,7 +182,7 @@ func TestRPCAPI(t *testing.T) {
 		require.NoError(t, err)
 		client, err := ethclient.Dial(ac.URL)
 		require.NoError(t, err)
-		pm := NewRemoteAnvilMiner(ac.URL)
+		pm := NewRemoteAnvilMiner(ac.URL, nil)
 		pm.MinePeriodically(500 * time.Millisecond)
 		time.Sleep(period * time.Duration(iterations))
 		pm.Stop()
@@ -201,7 +201,7 @@ func TestRPCAPI(t *testing.T) {
 		client, err := ethclient.Dial(ac.URL)
 		require.NoError(t, err)
 		stopTxns, errCh := sendTestTransactions(t, client, sendTransactionEvery, big.NewInt(1e9), big.NewInt(1e9), false)
-		pm := NewRemoteAnvilMiner(ac.URL)
+		pm := NewRemoteAnvilMiner(ac.URL, nil)
 		pm.MineBatch(txnInBlock, 1*time.Second, 1*time.Minute)
 		time.Sleep(sendTransactionEvery * time.Duration(iterations) * 2)
 		pm.Stop()


### PR DESCRIPTION
This is a temporary solution to unblock testing CRIBs with RPC chaos (Geth, Anvil)

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the RPC client and miner functionalities within a blockchain testing framework, introducing HTTP header support for RPC client requests and adjusting the miner to accept HTTP headers. These modifications aim to improve flexibility in interacting with blockchain nodes for testing purposes, allowing for more precise control over the test environment setup, including security and debug configurations.

## What
- **client/miner.go**
  - Added `http` import to support HTTP operations.
  - Modified the `NewRemoteAnvilMiner` function to accept `http.Header` as a parameter, enabling the passing of custom HTTP headers during miner initialization.
  
- **client/rpc.go**
  - Introduced imports for `crypto/tls`, `net/http`, and `os` to support new features.
  - Adjusted `NewRPCClient` to accept `http.Header` and `isDebug` flag from environment variable `RESTY_DEBUG`, enhancing the client with HTTP headers and debug mode based on environment settings.
  - Added TLS configuration with `InsecureSkipVerify: true` to bypass certificate validation, noted with a TODO to implement proper certificate handling in the future.
  
- **client/rpc_suite_test.go** & **client/rpc_test.go**
  - Updated calls to `NewRPCClient` and `NewRemoteAnvilMiner` to comply with the new signature that includes the `http.Header` parameter, passing `nil` for tests that do not require custom headers. This change ensures that the test suite remains compatible with the updated functions.
