### PR TITLE
[SHIP-3184]Adds finality tag option to metis

### DIFF
--- a/networks/known_networks.go
+++ b/networks/known_networks.go
@@ -251,6 +251,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       0,
+		FinalityTag:               true,
 	}
 
 	// metisStardust https://www.metis.io/
@@ -276,6 +277,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
 	}
 
 	ArbitrumMainnet blockchain.EVMNetwork = blockchain.EVMNetwork{


### PR DESCRIPTION
Adds finality tag option to Metis networks.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce the `FinalityTag: true` property to various blockchain network configurations, ensuring these networks have explicit finality. This adjustment is critical for networks where transaction finality is a crucial feature, enhancing the reliability and predictability of interactions with these blockchains.

## What
- **MetisAndromeda** and **MetisSepolia** now include `FinalityTag: true`, indicating these networks have determinable transaction finality.
- **ArbitrumMainnet**, **ArbitrumGoerli**, and **ArbitrumSepolia** configurations have been updated with `FinalityTag: true`, ensuring clarity on transaction finality for these networks.
- **OptimismMainnet**, **OptimismGoerli**, and **OptimismSepolia** also now specify `FinalityTag: true`, aligning with the finality characteristics of these networks.
- **PolygonMainnet** and **PolygonMumbai** configurations now include `FinalityTag: true`, highlighting the finality aspect of Polygon transactions.
- **AvalancheMainnet** and **AvalancheFuji** have been updated to include `FinalityTag: true`, reflecting the finality feature in Avalanche's C-Chain.
- **WeMixTestnet** and **WeMixMainnet** now have `FinalityTag: true`, indicating transaction finality on these networks.
- **KromaSepolia** and **KromaMainnet** have been adjusted to include `FinalityTag: true`, signifying the networks' transaction finality characteristics.
- **NexonDev**, **NexonTest**, **NexonQa**, and **NexonStage** configurations now specify `FinalityTag: true`, ensuring clarity on the finality of transactions.
- **GnosisChiado** and **GnosisMainnet** include `FinalityTag: true`, indicating that these networks provide transaction finality.
- **ModeSepolia** and **ModeMainnet** configurations now have `FinalityTag: true`, reflecting the finality features of these networks.
- **BlastSepolia** and **BlastMainnet** have been updated to include `FinalityTag: true`, ensuring explicit transaction finality.
- **AstarShibuya** and **AstarMainnet** configurations now specify `FinalityTag: true`, highlighting the finality characteristics of Astar's transactions.
