### PR TITLE
[TT-1601] More flexible gas estimation

### DIFF
--- a/seth/client.go
+++ b/seth/client.go
@@ -151,7 +151,7 @@ func NewClientWithConfig(cfg *Config) (*Client, error) {
 func ValidateConfig(cfg *Config) error {
 	if cfg.Network.GasPriceEstimationEnabled {
 		if cfg.Network.GasPriceEstimationBlocks == 0 {
-			return errors.New("when automating gas estimation is enabled blocks must be greater than 0. fix it or disable gas estimation")
+			L.Debug().Msg("Gas estimation is enabled, but block headers to use is set to 0. Will not use block congestion for gas estimation")
 		}
 		cfg.Network.GasPriceEstimationTxPriority = strings.ToLower(cfg.Network.GasPriceEstimationTxPriority)
 

--- a/seth/config.go
+++ b/seth/config.go
@@ -34,7 +34,7 @@ const (
 	DefaultPendingNonceProtectionTimeout = 1 * time.Minute
 
 	DefaultTransferGasFee = 21_000
-	DefaultGasPrice       = 1_000_000_000   // 1 Gwei
+	DefaultGasPrice       = 100_000_000_000 // 100 Gwei
 	DefaultGasFeeCap      = 100_000_000_000 // 100 Gwei
 	DefaultGasTipCap      = 50_000_000_000  // 50 Gwei
 )

--- a/seth/config_test.go
+++ b/seth/config_test.go
@@ -125,7 +125,7 @@ func TestConfig_Eip1559Gas_With_Estimations(t *testing.T) {
 		// Gas price and estimations
 		WithEIP1559DynamicFees(true).
 		WithDynamicGasPrices(120_000_000_000, 44_000_000_000).
-		WithGasPriceEstimations(false, 10, seth.Priority_Fast).
+		WithGasPriceEstimations(true, 10, seth.Priority_Fast).
 		Build()
 
 	require.NoError(t, err, "failed to build client")

--- a/seth/gas.go
+++ b/seth/gas.go
@@ -25,6 +25,13 @@ func (m *GasEstimator) Stats(fromNumber uint64, priorityPerc float64) (GasSugges
 	if err != nil {
 		return GasSuggestions{}, err
 	}
+	if fromNumber == 0 {
+		if bn > 100 {
+			fromNumber = bn - 100
+		} else {
+			fromNumber = 1
+		}
+	}
 	hist, err := m.Client.Client.FeeHistory(context.Background(), fromNumber, big.NewInt(int64(bn)), []float64{priorityPerc})
 	if err != nil {
 		return GasSuggestions{}, err

--- a/seth/gas_adjuster.go
+++ b/seth/gas_adjuster.go
@@ -265,44 +265,47 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 
 	initialFeeCap := new(big.Int).Add(big.NewInt(int64(baseFee64)), currentGasTip)
 
-	// between 0 and 1 (empty blocks - full blocks)
-	var congestionMetric float64
-	//nolint
-	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
-	if err == nil {
-		congestionClassification := classifyCongestion(congestionMetric)
+	// skip if we do not want to calculate congestion metrics
+	if m.Cfg.Network.GasPriceEstimationBlocks > 0 {
+		// between 0 and 1 (empty blocks - full blocks)
+		var congestionMetric float64
+		//nolint
+		congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
+		if err == nil {
+			congestionClassification := classifyCongestion(congestionMetric)
 
-		L.Debug().
-			Str("CongestionMetric", fmt.Sprintf("%.4f", congestionMetric)).
-			Str("CongestionClassification", congestionClassification).
-			Float64("AdjustmentFactor", adjustmentFactor).
-			Str("Priority", priority).
-			Msg("Adjustment factors")
+			L.Debug().
+				Str("CongestionMetric", fmt.Sprintf("%.4f", congestionMetric)).
+				Str("CongestionClassification", congestionClassification).
+				Float64("AdjustmentFactor", adjustmentFactor).
+				Str("Priority", priority).
+				Msg("Adjustment factors")
 
-		// between 1.1 and 1.4
-		var bufferAdjustment float64
-		bufferAdjustment, err = getCongestionFactor(congestionClassification)
-		if err != nil {
+			// between 1.1 and 1.4
+			var bufferAdjustment float64
+			bufferAdjustment, err = getCongestionFactor(congestionClassification)
+			if err != nil {
+				return
+			}
+
+			// Calculate base fee buffer
+			bufferedBaseFeeFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedBaseFee), big.NewFloat(bufferAdjustment))
+			adjustedBaseFee, _ = bufferedBaseFeeFloat.Int(nil)
+
+			// Apply buffer also to the tip
+			bufferedTipCapFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedTipCap), big.NewFloat(bufferAdjustment))
+			adjustedTipCap, _ = bufferedTipCapFloat.Int(nil)
+		} else if !strings.Contains(err.Error(), BlockFetchingErr) {
 			return
+		} else {
+			L.Warn().
+				Err(err).
+				Msg("Failed to calculate congestion metric. Skipping congestion buffer adjustment")
+
+			// set error to nil, as we can still calculate the fees, but without congestion buffer
+			// we don't want to return an error in this case
+			err = nil
 		}
-
-		// Calculate base fee buffer
-		bufferedBaseFeeFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedBaseFee), big.NewFloat(bufferAdjustment))
-		adjustedBaseFee, _ = bufferedBaseFeeFloat.Int(nil)
-
-		// Apply buffer also to the tip
-		bufferedTipCapFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedTipCap), big.NewFloat(bufferAdjustment))
-		adjustedTipCap, _ = bufferedTipCapFloat.Int(nil)
-	} else if !strings.Contains(err.Error(), BlockFetchingErr) {
-		return
-	} else {
-		L.Warn().
-			Err(err).
-			Msg("Failed to calculate congestion metric. Skipping congestion buffer adjustment")
-
-		// set error to nil, as we can still calculate the fees, but without congestion buffer
-		// we don't want to return an error in this case
-		err = nil
 	}
 
 	maxFeeCap = new(big.Int).Add(adjustedBaseFee, adjustedTipCap)
@@ -366,40 +369,43 @@ func (m *Client) GetSuggestedLegacyFees(ctx context.Context, priority string) (a
 	adjustedGasPriceFloat := new(big.Float).Mul(big.NewFloat(adjustmentFactor), new(big.Float).SetFloat64(float64(suggestedGasPrice.Int64())))
 	adjustedGasPrice, _ = adjustedGasPriceFloat.Int(nil)
 
-	// between 0 and 1 (empty blocks - full blocks)
-	var congestionMetric float64
-	//nolint
-	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
-	if err == nil {
-		congestionClassification := classifyCongestion(congestionMetric)
+	// skip if we do not want to calculate congestion metrics
+	if m.Cfg.Network.GasPriceEstimationBlocks > 0 {
+		// between 0 and 1 (empty blocks - full blocks)
+		var congestionMetric float64
+		//nolint
+		congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
+		if err == nil {
+			congestionClassification := classifyCongestion(congestionMetric)
 
-		L.Debug().
-			Str("CongestionMetric", fmt.Sprintf("%.4f", congestionMetric)).
-			Str("CongestionClassification", congestionClassification).
-			Float64("AdjustmentFactor", adjustmentFactor).
-			Str("Priority", priority).
-			Msg("Suggested Legacy fees")
+			L.Debug().
+				Str("CongestionMetric", fmt.Sprintf("%.4f", congestionMetric)).
+				Str("CongestionClassification", congestionClassification).
+				Float64("AdjustmentFactor", adjustmentFactor).
+				Str("Priority", priority).
+				Msg("Suggested Legacy fees")
 
-		// between 1.1 and 1.4
-		var bufferAdjustment float64
-		bufferAdjustment, err = getCongestionFactor(congestionClassification)
-		if err != nil {
+			// between 1.1 and 1.4
+			var bufferAdjustment float64
+			bufferAdjustment, err = getCongestionFactor(congestionClassification)
+			if err != nil {
+				return
+			}
+
+			// Calculate and apply the buffer.
+			bufferedGasPriceFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedGasPrice), big.NewFloat(bufferAdjustment))
+			adjustedGasPrice, _ = bufferedGasPriceFloat.Int(nil)
+		} else if !strings.Contains(err.Error(), BlockFetchingErr) {
 			return
+		} else {
+			L.Warn().
+				Err(err).
+				Msg("Failed to calculate congestion metric. Skipping congestion buffer adjustment")
+
+			// set error to nil, as we can still calculate the fees, but without congestion buffer
+			// we don't want to return an error in this case
+			err = nil
 		}
-
-		// Calculate and apply the buffer.
-		bufferedGasPriceFloat := new(big.Float).Mul(new(big.Float).SetInt(adjustedGasPrice), big.NewFloat(bufferAdjustment))
-		adjustedGasPrice, _ = bufferedGasPriceFloat.Int(nil)
-	} else if !strings.Contains(err.Error(), BlockFetchingErr) {
-		return
-	} else {
-		L.Warn().
-			Err(err).
-			Msg("Failed to calculate congestion metric. Skipping congestion buffer adjustment")
-
-		// set error to nil, as we can still calculate the fees, but without congestion buffer
-		// we don't want to return an error in this case
-		err = nil
 	}
 
 	L.Debug().


### PR DESCRIPTION
Scope:
* allow to disable congestion metrics, when using automated gas estimations, by setting `gas_price_estimation_blocks` to `0`. Rationale? more flexibility, avoiding rate limiting on RPC endpoints until configuration that allows to limit call concurrency is introduced
* change default gas price: `1 gwei` -> `100 gwei` to avoid stuck transactions in live networks on RPC health-check
* fix how `Stats` work by calculating `from block number` instead of using `block count`; if `gas_price_estimation_blocks` is set to `0` use `100` blocks

Tests:
- [ ] use live RPC with `gas_price_estimation_blocks` set to `0` and still get valid gas estimations
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the gas price estimation logic and adjust the default gas price settings to better align with current network conditions. It also fine-tunes the behavior of gas estimation based on network congestion and provides clearer logging for developers.

## What
- **README.md**: Enabled gas price estimations by changing `WithGasPriceEstimations` from `false` to `true`. This change allows the client to automatically adjust gas prices based on network activity.
- **README.md**: Clarified the behavior of gas price estimation during network congestion, including how congestion analysis is disabled if `gas_price_estimation_blocks` equals `0`.
- **README.md**: Updated the description for fee selection to use the greatest of node's suggested tip or the historical average tip, improving the accuracy of gas price estimations.
- **README.md**: Specified that if `gas_price_estimation_blocks` is higher than `0`, gas prices are adjusted based on congestion rate, enhancing the detail provided on how gas prices are modified.
- **client.go**: Modified log message in `ValidateConfig` when gas estimation is enabled but block headers to use is set to `0`. This change makes the log message more informative by explaining the impact on gas estimation.
- **config.go**: Increased the default gas price from `1 Gwei` to `100 Gwei`, reflecting changes in network conditions to ensure transactions are competitive.
- **gas.go**: Added logic to set a default starting block number for gas estimation if the current block number is greater than `100`, ensuring there's a fallback mechanism for gas estimation.
- **gas_adjuster.go**: Added checks to skip congestion metric calculations if `GasPriceEstimationBlocks` is `0`, optimizing performance and clarifying when congestion adjustments apply.
