### PR TITLE
fix base image build

### DIFF
--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -2,7 +2,7 @@ name: (k8s package) Publish Test Base Image
 on:
   push:
     tags:
-      - 'v*'
+      - '*v*'
 
 jobs:
   publish_test_base_image:

--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -2,7 +2,8 @@ name: (k8s package) Publish Test Base Image
 on:
   push:
     tags:
-      - '*v*'
+      # we only need base image for k8s based tests
+      - 'lib/v*'
 
 jobs:
   publish_test_base_image:


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The modification ensures that the GitHub Action workflow triggers not only for tags strictly starting with 'v' but for any tag containing 'v'. This change broadens the range of tags that will initiate the workflow, allowing for more flexible version naming.

## What
- **.github/workflows/k8s-publish-test-base-image.yaml**: Modified the tag pattern for triggering the workflow.  
  - Changed the tag trigger from `- 'v*'` to `- '*v*'`, expanding the scope of tags that can initiate the workflow.
