### PR TITLE
Fix tag release

### DIFF
--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -17,15 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-      - name: Strip slashes after colon in tag using Python
-        id: strip_tag
+      - name: Strip "lib/" from github.ref_name
         run: |
-          ref_name="${GITHUB_REF##*/}"
-          echo "ref_name: ${ref_name}"
-          # Use Python to replace slashes after the first colon
-          modified_tag=$(python3 -c 'import sys; ref_name = sys.argv[1]; modified = ref_name.split(":")[0] + ":" + ref_name.split(":")[1].replace("/", "-"); print(modified)' "$ref_name")
-          echo "modified tag: ${ref_name}"
-          echo "BASE_IMAGE_TAG=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:$modified_tag" >> $GITHUB_ENV
+          stripped_ref_name="${GITHUB_REF//refs\/tags\/lib\//}"
+          echo "BASE_IMAGE_TAG=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:$stripped_ref_name" >> $GITHUB_ENV
 
       - name: Build Base Image
         uses: smartcontractkit/chainlink-github-actions/docker/build-push@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16

--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -16,6 +16,17 @@ jobs:
       BASE_IMAGE_TAG: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:${{ github.ref_name }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Strip slashes after colon in tag using Python
+        id: strip_tag
+        run: |
+          ref_name="${GITHUB_REF##*/}"
+          echo "ref_name: ${ref_name}"
+          # Use Python to replace slashes after the first colon
+          modified_tag=$(python3 -c 'import sys; ref_name = sys.argv[1]; modified = ref_name.split(":")[0] + ":" + ref_name.split(":")[1].replace("/", "-"); print(modified)' "$ref_name")
+          echo "modified tag: ${ref_name}"
+          echo "BASE_IMAGE_TAG=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:$modified_tag" >> $GITHUB_ENV
+
       - name: Build Base Image
         uses: smartcontractkit/chainlink-github-actions/docker/build-push@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
         with:


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the CI workflow for publishing a test base image by dynamically modifying the image tag to exclude a specific directory prefix from the GitHub reference name. This ensures the image tag is correctly formatted and relevant to its use case.

## What
- **.github/workflows/k8s-publish-test-base-image.yaml**
  - Added a new step to strip "lib/" from `github.ref_name` before using it in the `BASE_IMAGE_TAG` environment variable. This ensures the base image tag does not include the "lib/" directory prefix, making the tag naming convention consistent and predictable.
  - Modified the `env.BASE_IMAGE_TAG` construction to use the modified `github.ref_name` without the "lib/" prefix, improving clarity and relevance of the Docker image tags.
