### PR TITLE
[TT- 1545] lower the amount of WARN and ERROR logs

### DIFF
--- a/seth/README.md
+++ b/seth/README.md
@@ -34,6 +34,7 @@ Reliable and debug-friendly Ethereum client
 13. [Block Stats](#block-stats)
 14. [Single transaction tracing](#single-transaction-tracing)
 15. [Bulk transaction tracing](#bulk-transaction-tracing)
+16. [RPC traffic logging](#rpc-traffic-logging)
 
 ## Goals
 
@@ -786,3 +787,6 @@ You need to pass a file with a list of transaction hashes to trace. The file sho
 ```
 
 (Note that currently Seth automatically creates `reverted_transactions_<network>_<date>.json` with all reverted transactions, so you can use this file as input for the `trace` command.)
+
+### RPC Traffic logging
+With `SETH_LOG_LEVEL=trace` we will also log to console all traffic between Seth and RPC node. This can be useful for debugging as you can see all the requests and responses.

--- a/seth/client.go
+++ b/seth/client.go
@@ -92,7 +92,7 @@ func NewClientWithConfig(cfg *Config) (*Client, error) {
 		// we don't care about any other keys, only the root key
 		// you should not use ephemeral mode with more than 1 key
 		if len(cfg.Network.PrivateKeys) > 1 {
-			L.Warn().Msg("Ephemeral mode is enabled, but more than 1 key is loaded. Only the first key will be used")
+			L.Debug().Msg("Ephemeral mode is enabled, but more than 1 key is loaded. Only the first key will be used")
 		}
 		cfg.Network.PrivateKeys = cfg.Network.PrivateKeys[:1]
 		pkeys, err := NewEphemeralKeys(*cfg.EphemeralAddrs)
@@ -230,7 +230,7 @@ func NewClientRaw(
 		return nil, errors.New("no RPC URL provided")
 	}
 	if len(cfg.Network.URLs) > 1 {
-		L.Warn().Msg("Multiple RPC URLs provided, only the first one will be used")
+		L.Debug().Msg("Multiple RPC URLs provided, only the first one will be used")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Network.DialTimeout.Duration())
 	defer cancel()
@@ -307,7 +307,7 @@ func NewClientRaw(
 
 	if cfg.CheckRpcHealthOnStart {
 		if c.NonceManager == nil {
-			L.Warn().Msg("Nonce manager is not set, RPC health check will be skipped. Client will most probably fail on first transaction")
+			L.Debug().Msg("Nonce manager is not set, RPC health check will be skipped. Client will most probably fail on first transaction")
 		} else {
 			if err := c.checkRPCHealth(); err != nil {
 				return nil, err
@@ -500,14 +500,13 @@ func (m *Client) WaitMined(ctx context.Context, l zerolog.Logger, b bind.DeployB
 				Str("TX", tx.Hash().String()).
 				Msg("Awaiting transaction")
 		} else {
-			l.Warn().
-				Err(err).
+			l.Debug().
 				Str("TX", tx.Hash().String()).
-				Msg("Failed to get receipt")
+				Msgf("Failed to get receipt due to: %s", err)
 		}
 		select {
 		case <-ctx.Done():
-			l.Error().Err(err).Msg("Transaction context is done")
+			l.Error().Err(err).Str("Tx hash", tx.Hash().Hex()).Msg("Timed out, while waiting for transaction to be mined")
 			return nil, ctx.Err()
 		case <-queryTicker.C:
 		}
@@ -727,7 +726,7 @@ func (m *Client) getNonceStatus(address common.Address) (NonceStatus, error) {
 	defer cancel()
 	pendingNonce, err := m.Client.PendingNonceAt(ctx, address)
 	if err != nil {
-		L.Error().Err(err).Msg("Failed to get pending nonce")
+		L.Error().Err(err).Msg("Failed to get pending nonce from RPC node")
 		return NonceStatus{}, err
 	}
 
@@ -848,7 +847,7 @@ func (m *Client) CalculateGasEstimations(request GasEstimationRequest) GasEstima
 		gasPrice, err := m.GetSuggestedLegacyFees(ctx, request.Priority)
 		if err != nil {
 			disableEstimationsIfNeeded(err)
-			L.Warn().Err(err).Msg("Failed to get suggested Legacy fees. Using hardcoded values")
+			L.Debug().Err(err).Msg("Failed to get suggested Legacy fees. Using hardcoded values")
 			estimations.GasPrice = big.NewInt(request.FallbackGasPrice)
 		} else {
 			estimations.GasPrice = gasPrice
@@ -858,7 +857,7 @@ func (m *Client) CalculateGasEstimations(request GasEstimationRequest) GasEstima
 	if m.Cfg.Network.EIP1559DynamicFees {
 		maxFee, priorityFee, err := m.GetSuggestedEIP1559Fees(ctx, request.Priority)
 		if err != nil {
-			L.Warn().Err(err).Msg("Failed to get suggested EIP1559 fees. Using hardcoded values")
+			L.Debug().Err(err).Msg("Failed to get suggested EIP1559 fees. Using hardcoded values")
 			estimations.GasFeeCap = big.NewInt(request.FallbackGasFeeCap)
 			estimations.GasTipCap = big.NewInt(request.FallbackGasTipCap)
 
@@ -893,7 +892,7 @@ func (m *Client) EstimateGasLimitForFundTransfer(from, to common.Address, amount
 		Value: amount,
 	})
 	if err != nil {
-		L.Warn().Err(err).Msg("Failed to estimate gas for fund transfer.")
+		L.Debug().Msgf("Failed to estimate gas for fund transfer due to: %s", err.Error())
 		return 0, errors.Wrapf(err, "failed to estimate gas for fund transfer")
 	}
 	return gasLimit, nil

--- a/seth/client.go
+++ b/seth/client.go
@@ -92,7 +92,7 @@ func NewClientWithConfig(cfg *Config) (*Client, error) {
 		// we don't care about any other keys, only the root key
 		// you should not use ephemeral mode with more than 1 key
 		if len(cfg.Network.PrivateKeys) > 1 {
-			L.Debug().Msg("Ephemeral mode is enabled, but more than 1 key is loaded. Only the first key will be used")
+			L.Warn().Msg("Ephemeral mode is enabled, but more than 1 key is loaded. Only the first key will be used")
 		}
 		cfg.Network.PrivateKeys = cfg.Network.PrivateKeys[:1]
 		pkeys, err := NewEphemeralKeys(*cfg.EphemeralAddrs)
@@ -230,7 +230,7 @@ func NewClientRaw(
 		return nil, errors.New("no RPC URL provided")
 	}
 	if len(cfg.Network.URLs) > 1 {
-		L.Debug().Msg("Multiple RPC URLs provided, only the first one will be used")
+		L.Warn().Msg("Multiple RPC URLs provided, only the first one will be used")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Network.DialTimeout.Duration())
 	defer cancel()

--- a/seth/config.go
+++ b/seth/config.go
@@ -168,7 +168,7 @@ func ReadConfig() (*Config, error) {
 				cfg.Network.URLs = []string{url}
 
 				if selectedNetwork == "" {
-					L.Warn().Msg("No network name provided, using default network")
+					L.Debug().Msg("No network name provided, using default network")
 					cfg.Network.Name = DefaultNetworkName
 				}
 

--- a/seth/contract_store.go
+++ b/seth/contract_store.go
@@ -174,7 +174,7 @@ func (c *ContractStore) loadGethWrappers(gethWrappersPaths []string) error {
 					if !strings.Contains(err.Error(), ErrNoABIInFile) {
 						return err
 					}
-					L.Debug().Err(err).Msg("ABI not found in file. Skipping")
+					L.Debug().Msgf("ABI not found in file due to: %s. Skipping", err.Error())
 
 					return nil
 				}

--- a/seth/decode.go
+++ b/seth/decode.go
@@ -204,7 +204,7 @@ func (m *Client) waitUntilMined(l zerolog.Logger, tx *types.Transaction) (*types
 		}, retry.OnRetry(func(i uint, retryErr error) {
 			replacementTx, replacementErr := prepareReplacementTransaction(m, tx)
 			if replacementErr != nil {
-				L.Debug().Str("Replacement error", replacementErr.Error()).Str("Current error", retryErr.Error()).Uint("Attempt", i).Msg("Failed to prepare replacement transaction. Retrying without the original one")
+				L.Debug().Str("Replacement error", replacementErr.Error()).Str("Current error", retryErr.Error()).Uint("Attempt", i).Msg("Failed to prepare replacement transaction. Retrying with the original one")
 				return
 			}
 			l.Debug().Str("Current error", retryErr.Error()).Uint("Attempt", i).Msg("Waiting for transaction to be confirmed after gas bump")

--- a/seth/dot_graph.go
+++ b/seth/dot_graph.go
@@ -119,7 +119,7 @@ func (t *Tracer) generateDotGraph(txHash string, calls []*DecodedCall, revertErr
 		_, exists := callHashToID[hash]
 		if exists {
 			// This could be also valid if the same call is present twice in the trace, but in typical scenarios that should not happen
-			L.Warn().Msg("The same call was present twice. This should not happen and might indicate a bug in the tracer. Check debug log for details")
+			L.Warn().Msg("The same call was present twice. This should not happen and might indicate a bug in the tracer. Check debug log for details and contact the Test Tooling team")
 			marshalled, err := json.Marshal(call)
 			if err == nil {
 				L.Debug().Msgf("Call: %v", marshalled)

--- a/seth/gas_adjuster.go
+++ b/seth/gas_adjuster.go
@@ -243,7 +243,11 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 
 	if currentGasTip.Int64() == 0 {
 		L.Debug().
-			Msg("Suggested tip is 0.0. Although not strictly incorrect, it is unusual. Transaction might take much longer to confirm.")
+			Int64("SuggestedTip", currentGasTip.Int64()).
+			Str("Fallback gas tip", fmt.Sprintf("%d wei / %s ether", m.Cfg.Network.GasTipCap, WeiToEther(big.NewInt(m.Cfg.Network.GasTipCap)).Text('f', -1))).
+			Msg("Suggested tip is 0.0. Although not strictly incorrect, it is unusual. Will use fallback value instead")
+
+		currentGasTip = big.NewInt(m.Cfg.Network.GasTipCap)
 	}
 
 	// between 0.8 and 1.5

--- a/seth/http_logging_transport.go
+++ b/seth/http_logging_transport.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -49,7 +50,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 // NewLoggingTransport creates a new logging transport for GAP or default transport
 // controlled by SETH_LOG_LEVEL
 func NewLoggingTransport() http.RoundTripper {
-	if os.Getenv(LogLevelEnvVar) == "debug" {
+	if strings.EqualFold(os.Getenv(LogLevelEnvVar), "trace") {
 		return &LoggingTransport{
 			// TODO: GAP, add proper certificates
 			Transport: &http.Transport{

--- a/seth/http_logging_transport.go
+++ b/seth/http_logging_transport.go
@@ -20,7 +20,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	reqDump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
-		L.Error().Err(err).Msg("Error dumping request")
+		L.Warn().Err(err).Msg("Error dumping request")
 	} else {
 		fmt.Printf("Request:\n%s\n", string(reqDump))
 	}
@@ -37,7 +37,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	respDump, err := httputil.DumpResponse(resp, true)
 	if err != nil {
-		L.Error().Err(err).Msg("Error dumping response")
+		L.Warn().Err(err).Msg("Error dumping response")
 	} else {
 		fmt.Printf("Response:\n%s\n", string(respDump))
 	}

--- a/seth/retry.go
+++ b/seth/retry.go
@@ -104,7 +104,7 @@ var PriorityBasedGasBumpingStrategyFn = func(priority string) GasBumpStrategyFn 
 // prepareReplacementTransaction bumps gas price of the transaction if it wasn't confirmed in time. It returns a signed replacement transaction.
 // Errors might be returned, because transaction was no longer pending, max gas price was reached or there was an error sending the transaction (e.g. nonce too low, meaning that original transaction was mined).
 var prepareReplacementTransaction = func(client *Client, tx *types.Transaction) (*types.Transaction, error) {
-	L.Warn().Msgf("Transaction wasn't confirmed in %s. Bumping gas", client.Cfg.Network.TxnTimeout.String())
+	L.Info().Msgf("Transaction wasn't confirmed in %s. Bumping gas", client.Cfg.Network.TxnTimeout.String())
 
 	ctxPending, cancelPending := context.WithTimeout(context.Background(), client.Cfg.Network.TxnTimeout.Duration())
 	_, isPending, err := client.Client.TransactionByHash(ctxPending, tx.Hash())
@@ -159,7 +159,7 @@ var prepareReplacementTransaction = func(client *Client, tx *types.Transaction) 
 		if err := checkMaxPrice(gasPrice, maxGasPrice); err != nil {
 			return nil, err
 		}
-		L.Warn().Interface("Old gas price", tx.GasPrice()).Interface("New gas price", gasPrice).Msg("Bumping gas price for legacy transaction")
+		L.Debug().Interface("Old gas price", tx.GasPrice()).Interface("New gas price", gasPrice).Msg("Bumping gas price for legacy transaction")
 		txData := &types.LegacyTx{
 			Nonce:    tx.Nonce(),
 			To:       tx.To(),
@@ -175,7 +175,7 @@ var prepareReplacementTransaction = func(client *Client, tx *types.Transaction) 
 		if err := checkMaxPrice(big.NewInt(0).Add(gasFeeCap, gasTipCap), maxGasPrice); err != nil {
 			return nil, err
 		}
-		L.Warn().Interface("Old gas fee cap", tx.GasFeeCap()).Interface("New gas fee cap", gasFeeCap).Interface("Old gas tip cap", tx.GasTipCap()).Interface("New gas tip cap", gasTipCap).Msg("Bumping gas fee cap and tip cap for EIP-1559 transaction")
+		L.Debug().Interface("Old gas fee cap", tx.GasFeeCap()).Interface("New gas fee cap", gasFeeCap).Interface("Old gas tip cap", tx.GasTipCap()).Interface("New gas tip cap", gasTipCap).Msg("Bumping gas fee cap and tip cap for EIP-1559 transaction")
 		txData := &types.DynamicFeeTx{
 			Nonce:     tx.Nonce(),
 			To:        tx.To(),
@@ -198,7 +198,7 @@ var prepareReplacementTransaction = func(client *Client, tx *types.Transaction) 
 			return nil, err
 		}
 
-		L.Warn().Interface("Old gas fee cap", tx.GasFeeCap()).Interface("Old max fee per blob", tx.BlobGasFeeCap()).Interface("New max fee per blob", blobFeeCap).Interface("New gas fee cap", gasFeeCap).Interface("Old gas tip cap", tx.GasTipCap()).Interface("New gas tip cap", gasTipCap).Msg("Bumping gas fee cap and tip cap for Blob transaction")
+		L.Debug().Interface("Old gas fee cap", tx.GasFeeCap()).Interface("Old max fee per blob", tx.BlobGasFeeCap()).Interface("New max fee per blob", blobFeeCap).Interface("New gas fee cap", gasFeeCap).Interface("Old gas tip cap", tx.GasTipCap()).Interface("New gas tip cap", gasTipCap).Msg("Bumping gas fee cap and tip cap for Blob transaction")
 		txData := &types.BlobTx{
 			Nonce:      tx.Nonce(),
 			To:         *tx.To(),
@@ -217,7 +217,7 @@ var prepareReplacementTransaction = func(client *Client, tx *types.Transaction) 
 		if err := checkMaxPrice(gasPrice, maxGasPrice); err != nil {
 			return nil, err
 		}
-		L.Warn().Interface("Old gas price", tx.GasPrice()).Interface("New gas price", gasPrice).Msg("Bumping gas price for access list transaction")
+		L.Debug().Interface("Old gas price", tx.GasPrice()).Interface("New gas price", gasPrice).Msg("Bumping gas price for access list transaction")
 
 		txData := &types.AccessListTx{
 			Nonce:      tx.Nonce(),

--- a/seth/tracing.go
+++ b/seth/tracing.go
@@ -428,11 +428,10 @@ func (t *Tracer) decodeCall(byteSignature []byte, rawCall Call) (*DecodedCall, e
 		} else {
 			defaultCall.Comment = CommentMissingABI
 		}
-		L.Warn().
-			Err(err).
+		L.Debug().
 			Str("Method signature", common.Bytes2Hex(byteSignature)).
 			Str("Contract", rawCall.To).
-			Msg("Method not found in any ABI instance. Unable to provide full tracing information")
+			Msgf("Method not found in any ABI instance. Unable to provide full tracing information. Reason: %s", err.Error())
 
 		// let's not return the error, as we can still provide some information
 		return defaultCall, nil


### PR DESCRIPTION
This PR lowers ERR and WARN level logs to a manageable one and basically only uses that level if user can should take some action or it's a catastrophically failure. Everything else was switched to DEBUG.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve logging and error handling in various parts of the code, making it more appropriate for different scenarios. For instance, changing logging levels in certain situations from warning to debug can help in reducing unnecessary alarm or clutter in the log files under normal circumstances. Also, enhancing error messages with more details improves the ability to diagnose issues.

## What
- **seth/client.go**
  - Changed logging level from `Warn` to `Debug` for messages related to ephemeral mode and multiple RPC URLs to reduce unnecessary warnings.
  - Improved error logging in transaction waiting and nonce management to include more detailed information.
- **seth/config.go**
  - Changed logging level from `Warn` to `Debug` when no network name is provided and the default network is used, to make the log less alarming.
- **seth/contract_store.go**
  - Enhanced logging in ABI loading from Geth wrappers by including the error reason in the debug message when an ABI is not found in a file.
- **seth/decode.go**
  - Modified logging levels and messages for decoding errors and tracing errors to provide more context or to reduce unnecessary alarm.
- **seth/dot_graph.go**
  - Updated a warning message to include contact information for the Test Tooling team in case of unusual occurrences, improving support.
- **seth/gas_adjuster.go**
  - Improved error handling and logging for gas price adjustments and estimation, including more contextual information in debug logs.
- **seth/http_logging_transport.go**
  - Changed error logging to warning when failing to dump HTTP requests or responses, to better reflect the severity of the issue.
- **seth/retry.go**
  - Updated logging level to `Info` when bumping gas for a transaction, reflecting the action's importance without indicating an error.
- **seth/tracing.go**
  - Improved error handling in trace decoding by changing a log level to debug and adding more detailed error messages.

These changes collectively aim to improve the clarity of logs and error messages, making them more useful for debugging and less likely to cause unnecessary concern during normal operations.
