### PR TITLE
Update networks

### DIFF
--- a/lib/networks/known_networks.go
+++ b/lib/networks/known_networks.go
@@ -513,6 +513,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       0,
+		FinalityDepth:             400,
+		DefaultGasLimit:           6000000,
 	}
 
 	ScrollMainnet = blockchain.EVMNetwork{
@@ -524,6 +526,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       0,
+		FinalityDepth:             400,
+		DefaultGasLimit:           6000000,
 	}
 
 	CeloAlfajores = blockchain.EVMNetwork{
@@ -615,6 +619,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      0,
 		GasEstimationBuffer:       1000,
+		FinalityDepth:             200,
+		DefaultGasLimit:           6000000,
 	}
 
 	LineaMainnet blockchain.EVMNetwork = blockchain.EVMNetwork{
@@ -627,6 +633,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       1000,
+		FinalityDepth:             200,
+		DefaultGasLimit:           6000000,
 	}
 
 	PolygonZkEvmGoerli = blockchain.EVMNetwork{
@@ -651,6 +659,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: time.Minute},
 		MinimumConfirmations:      0,
 		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           8000000,
 	}
 
 	PolygonZkEvmCardona = blockchain.EVMNetwork{
@@ -663,6 +673,8 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: time.Minute},
 		MinimumConfirmations:      0,
 		GasEstimationBuffer:       1000,
+		FinalityTag:               true,
+		DefaultGasLimit:           8000000,
 	}
 
 	WeMixTestnet blockchain.EVMNetwork = blockchain.EVMNetwork{
@@ -964,6 +976,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       10000,
+		FinalityTag:               true,
 		DefaultGasLimit:           6000000,
 	}
 
@@ -977,6 +990,7 @@ var (
 		Timeout:                   blockchain.StrDuration{Duration: 3 * time.Minute},
 		MinimumConfirmations:      1,
 		GasEstimationBuffer:       10000,
+		FinalityTag:               true,
 		DefaultGasLimit:           6000000,
 	}
 
@@ -1059,8 +1073,8 @@ var (
 		"ASTAR_SHIBUYA":         AstarShibuya,
 		"ASTAR_MAINNET":         AstarMainnet,
 		"HEDERA_TESTNET":        HederaTestnet,
-		"X_LAYER_SEPOLIA":       XLayerSepolia,
-		"X_LAYER_MAINNET":       XLayerMainnet,
+		"XLAYER_SEPOLIA":        XLayerSepolia,
+		"XLAYER_MAINNET":        XLayerMainnet,
 		"TREASURE_RUBY":         TreasureRuby,
 	}
 )


### PR DESCRIPTION
Add finality tag / depth to Linea, Scroll, XLayer, Polygon zkEVM
Update naming for XLayer testnet/mainnet
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes are primarily focused on adding new configurations and updating existing ones to support new EVM-compatible networks and their specific settings such as `FinalityDepth` and `DefaultGasLimit`. This ensures the library stays up to date with the evolving blockchain ecosystem, accommodating various networks' unique requirements for seamless integration and interaction.

## What
- **lib/networks/known_networks.go**
  - Added `FinalityDepth` and `DefaultGasLimit` configurations to `ScrollSepolia`, `ScrollMainnet`, `LineaSepolia`, `LineaMainnet`, `PolygonZkEvmMainnet`, `PolygonZkEvmCardona`, and adjusted naming convention for `XLayerSepolia` and `XLayerMainnet` from `X_LAYER_SEPOLIA` and `X_LAYER_MAINNET` to `XLAYER_SEPOLIA` and `XLAYER_MAINNET`.
  - These changes introduce specific network settings crucial for transaction processing and finality guarantees, ensuring compatibility and optimal operation within the respective networks.
