### PR TITLE
exclude non-existing Grafana dependency

### DIFF
--- a/havoc/go.mod
+++ b/havoc/go.mod
@@ -77,3 +77,5 @@ require (
 )
 
 replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.19.0
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/k8s-test-runner/go.mod
+++ b/k8s-test-runner/go.mod
@@ -76,3 +76,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -326,3 +326,5 @@ require (
 )
 
 retract v1.50.0
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/lib/grafana/go.mod
+++ b/lib/grafana/go.mod
@@ -8,3 +8,5 @@ require (
 )
 
 require golang.org/x/net v0.17.0 // indirect
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/seth/examples_wasp/go.mod
+++ b/seth/examples_wasp/go.mod
@@ -221,3 +221,5 @@ require (
 )
 
 replace github.com/smartcontractkit/chainlink-testing-framework/seth => ../
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/seth/go.mod
+++ b/seth/go.mod
@@ -56,3 +56,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/asciitable/go.mod
+++ b/tools/asciitable/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/citool/go.mod
+++ b/tools/citool/go.mod
@@ -15,3 +15,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/ecrimagefetcher/go.mod
+++ b/tools/ecrimagefetcher/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/envresolve/go.mod
+++ b/tools/envresolve/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/ghlatestreleasechecker/go.mod
+++ b/tools/ghlatestreleasechecker/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/ghsecrets/go.mod
+++ b/tools/ghsecrets/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/gotestloghelper/go.mod
+++ b/tools/gotestloghelper/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/testlistgenerator/go.mod
+++ b/tools/testlistgenerator/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/tools/workflowresultparser/go.mod
+++ b/tools/workflowresultparser/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/wasp/examples/go.mod
+++ b/wasp/examples/go.mod
@@ -199,3 +199,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74

--- a/wasp/go.mod
+++ b/wasp/go.mod
@@ -210,3 +210,5 @@ require (
 	go4.org/netipx v0.0.0-20230125063823-8449b0a6169f // indirect
 	golang.org/x/arch v0.4.0 // indirect
 )
+
+exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes across multiple `go.mod` files uniformly exclude a specific version of `github.com/sourcegraph/sourcegraph/lib` to avoid potential compatibility issues or conflicts that this version may introduce within the projects.

## What
- **havoc/go.mod, k8s-test-runner/go.mod, lib/go.mod, lib/grafana/go.mod, seth/examples_wasp/go.mod, seth/go.mod, tools/asciitable/go.mod, tools/citool/go.mod, tools/ecrimagefetcher/go.mod, tools/envresolve/go.mod, tools/ghlatestreleasechecker/go.mod, tools/ghsecrets/go.mod, tools/gotestloghelper/go.mod, tools/testlistgenerator/go.mod, tools/workflowresultparser/go.mod, wasp/examples/go.mod, wasp/go.mod**
  - Added `exclude github.com/sourcegraph/sourcegraph/lib v0.0.0-20221216004406-749998a2ac74` to explicitly exclude a specific version of `github.com/sourcegraph/sourcegraph/lib`. This ensures that the excluded version is not used by these modules, potentially avoiding compatibility or conflict issues.
