### PR TITLE
Fix prysm charts by using relative path

### DIFF
--- a/lib/charts/besu-prysm/Chart.yaml
+++ b/lib/charts/besu-prysm/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 description: Eth2 private network with Besu and Prysm
 name: besu-prysm
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: eth2-common
     version: 0.6.0
-    repository: "file://../eth2-common"
-#    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'
+    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/lib/charts/besu-prysm/Chart.yaml
+++ b/lib/charts/besu-prysm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Eth2 private network with Besu and Prysm
 name: besu-prysm
-version: 0.3.0
+version: 0.3.1
 dependencies:
   - name: eth2-common
     version: 0.6.0

--- a/lib/charts/besu-prysm/Chart.yaml
+++ b/lib/charts/besu-prysm/Chart.yaml
@@ -5,4 +5,5 @@ version: 0.3.0
 dependencies:
   - name: eth2-common
     version: 0.6.0
-    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'
+    repository: "file://../eth2-common"
+#    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/lib/charts/geth-prysm/Chart.yaml
+++ b/lib/charts/geth-prysm/Chart.yaml
@@ -5,4 +5,5 @@ version: 0.2.3
 dependencies:
   - name: eth2-common
     version: 0.6.0
-    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'
+    repository: "file://../eth2-common"
+    # repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/lib/charts/geth-prysm/Chart.yaml
+++ b/lib/charts/geth-prysm/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 description: Eth2 private network with Geth and Prysm
 name: geth-prysm
-version: 0.3.1
+version: 0.3.2
 dependencies:
   - name: eth2-common
     version: 0.6.0
-    repository: "file://../eth2-common"
-    # repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'
+    repository: 'https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/'

--- a/lib/charts/geth-prysm/Chart.yaml
+++ b/lib/charts/geth-prysm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Eth2 private network with Geth and Prysm
 name: geth-prysm
-version: 0.2.3
+version: 0.3.1
 dependencies:
   - name: eth2-common
     version: 0.6.0


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the chart versions for both `besu-prysm` and `geth-prysm` to 0.3.1, and switch the dependency repository for `eth2-common` from a remote URL to a local file path. This suggests an effort to standardize versioning across related charts and to utilize local dependencies for easier management and development.

## What
- **lib/charts/besu-prysm/Chart.yaml**  
  - Updated `version` from `0.3.0` to `0.3.1`. This increment indicates a minor change or patch has been made.  
  - Changed `dependencies.repository` for `eth2-common` from a remote URL to `"file://../eth2-common"`, and commented out the previous remote URL. This change points to using a local version of the dependency for development or testing purposes.

- **lib/charts/geth-prysm/Chart.yaml**  
  - Updated `version` from `0.2.3` to `0.3.1`. Similar to the `besu-prysm` chart, this indicates a minor change or patch.  
  - Changed `dependencies.repository` for `eth2-common` from a remote URL to `"file://../eth2-common"`, with the previous URL commented out. This aligns with the change made in the `besu-prysm` chart, indicating a shift towards using local dependencies.
