### PR TITLE
do not create release without .changeset file

### DIFF
--- a/.github/workflows/release-go-module.yml
+++ b/.github/workflows/release-go-module.yml
@@ -119,7 +119,6 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes focus on refining the GitHub Actions workflow for releasing Go modules. They aim to enhance the automated processes for extracting package names, generating release notes, setting up Go, installing tools, preparing for release, and building binary releases, ensuring a smoother and more reliable release process.

## What
- **.github/workflows/release-go-module.yml**
  - Modified the "Extract Package Name from Tag" step to initialize variables without actual extraction logic, aiming for placeholders for future implementations.
  - Updated the "Find Last Tag for Package and Generate Release Notes" step to include logic for handling the absence of a previous tag and preparing the environment for generating release notes based on commit messages, albeit without specific commit retrieval logic.
  - Adjusted the "Set up Go" step to specify Go version '1.22.6', ensuring consistency with the required Go version for the project.
  - Included a step for installing the `gorelease` tool, which is pivotal for checking for breaking changes between versions.
  - Added steps to read additional release notes from a file if available, enhancing the release notes' detail and accuracy.
  - Changed the "Create GitHub Release" step to conditionally execute based on the always() function, suggesting a refinement in execution strategy but without altering its core functionality.
  - Introduced a check for the existence of the 'cmd' directory to determine the presence of a Go entry point, which is crucial for the subsequent binary build step.
  - Utilized `wangyoucao577/go-release-action@v1` for building binary releases, indicating a streamlined approach to compiling and releasing Go binaries for multiple platforms and architectures.
