### PR TITLE
fix off-by-one bug that can be caught on sub-RPS profiles

### DIFF
--- a/wasp/examples/scenario/vu.go
+++ b/wasp/examples/scenario/vu.go
@@ -24,7 +24,7 @@ func NewExampleScenario(target string) *VirtualUser {
 	return &VirtualUser{
 		VUControl: wasp.NewVUControl(),
 		target:    target,
-		rl:        ratelimit.New(10),
+		rl:        ratelimit.New(10, ratelimit.WithoutSlack),
 		client:    resty.New().SetBaseURL(target),
 		Data:      make([]string, 0),
 	}
@@ -34,7 +34,7 @@ func (m *VirtualUser) Clone(_ *wasp.Generator) wasp.VirtualUser {
 	return &VirtualUser{
 		VUControl: wasp.NewVUControl(),
 		target:    m.target,
-		rl:        ratelimit.New(10),
+		rl:        ratelimit.New(10, ratelimit.WithoutSlack),
 		client:    resty.New().SetBaseURL(m.target),
 		Data:      make([]string, 0),
 	}

--- a/wasp/wasp_bench_test.go
+++ b/wasp/wasp_bench_test.go
@@ -21,7 +21,7 @@ func BenchmarkPacedCall(b *testing.B) {
 		Gun:               NewMockGun(&MockGunConfig{}),
 	})
 	require.NoError(b, err)
-	gen.setupSchedule()
+	gen.runExecuteLoop()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		gen.pacedCall()


### PR DESCRIPTION
This fixes a subtle race only when executing a low-load profile.
Added a regression test.