### PR TITLE
release wasp v1.50.1

### DIFF
--- a/wasp/.changeset/v1.50.1.md
+++ b/wasp/.changeset/v1.50.1.md
@@ -1,0 +1,3 @@
+- Fixed off-by-one bug for low-load profiles
+
+Now when you run load tests for <=1 RPS ratelimiter is strict (NoSlack) and requests are instantiated correctly only after first segment has started


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the rate limiter behaves correctly under low-load conditions by fixing an off-by-one error, leading to more accurate load testing.

## What
- **wasp/.changeset/v1.50.1.md**
  - Added documentation for the fix of an off-by-one bug in low-load profiles. This ensures that for tests with <=1 RPS, the rate limiter is now strict with no slack, and requests are correctly instantiated only after the first segment has started.
