### PR TITLE
Fix order of RPC and wallet keys fetched from env vars

### DIFF
--- a/lib/config/env.go
+++ b/lib/config/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -79,7 +80,7 @@ func ReadEnvVarSlice_String(pattern string) []string {
 	re := regexp.MustCompile(pattern)
 	var values []string
 
-	for _, env := range os.Environ() {
+	for _, env := range getSortedEnvs() {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) != 2 {
 			continue
@@ -146,7 +147,7 @@ func readEnvVarValue(envVarName string, valueType EnvValueType) (interface{}, er
 func readEnvVarGroupedMap(pattern string) map[string][]string {
 	re := regexp.MustCompile(pattern)
 	groupedVars := make(map[string][]string)
-	for _, env := range os.Environ() {
+	for _, env := range getSortedEnvs() {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) != 2 {
 			continue
@@ -164,7 +165,7 @@ func readEnvVarGroupedMap(pattern string) map[string][]string {
 func readEnvVarSingleMap(pattern string) map[string]string {
 	re := regexp.MustCompile(pattern)
 	singleVars := make(map[string]string)
-	for _, env := range os.Environ() {
+	for _, env := range getSortedEnvs() {
 		pair := strings.SplitN(env, "=", 2)
 		if len(pair) != 2 {
 			continue
@@ -212,3 +213,13 @@ const (
 	Boolean
 	Float
 )
+
+// getSortedEnvs returns a sorted slice of environment variables
+func getSortedEnvs() []string {
+	envs := os.Environ()
+	// Sort environment variables by key
+	sort.Slice(envs, func(i, j int) bool {
+		return strings.SplitN(envs[i], "=", 2)[0] < strings.SplitN(envs[j], "=", 2)[0]
+	})
+	return envs
+}


### PR DESCRIPTION
This commit refactors the code in `lib/config/env.go` to use sorted keys when handling environment variables. Previously, the code was iterating over the environment variables in an arbitrary order, which could lead to inconsistent behavior. Now, the `getSortedEnvs` function has been added to sort the environment variables by key before processing them.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure consistency and predictability in how environment variables are read and processed by sorting them alphabetically. This facilitates better organization and potentially makes debugging easier when dealing with a large number of environment variables.

## What
- **lib/config/env.go**
  - Added import of `sort` package to enable sorting functionality.
  - Introduced a new utility function `getSortedEnvs` which sorts environment variables by their keys before returning them. This function is now used in place of direct calls to `os.Environ()` in `ReadEnvVarSlice_String`, `readEnvVarGroupedMap`, and `readEnvVarSingleMap` functions.
    - This change ensures that environment variables are processed in a consistent order, which is particularly useful for functions that depend on the order of environment variables, such as when generating slices or maps from them.
