### PR TITLE
[ship-3765]Adds wrapper for Loki Rest api to query logs

### DIFF
--- a/lib/.changeset/v1.50.10.md
+++ b/lib/.changeset/v1.50.10.md
@@ -1,0 +1,1 @@
+- Added Loki client to query logs data + tests, see usage here - [README](../../README.md)

--- a/lib/README.md
+++ b/lib/README.md
@@ -430,3 +430,33 @@ export RESTY_DEBUG=true
 ## Using AWS Secrets Manager
 
 Check the [docs](SECRETS.md)
+
+## Loki Client
+
+The `LokiClient` allows you to easily query Loki logs from your tests. It supports basic authentication, custom queries, and can be configured for (Resty) debug mode.
+
+### Debugging Resty and Loki Client
+
+```bash
+export LOKI_CLIENT_LOG_LEVEL=info
+export RESTY_DEBUG=true
+```
+
+### Example usage:
+
+```go
+auth := LokiBasicAuth{
+    Username: os.Getenv("LOKI_LOGIN"),
+    Password: os.Getenv("LOKI_PASSWORD"),
+}
+
+queryParams := LokiQueryParams{
+		Query:     `{namespace="test"} |= "test"`,
+		StartTime: time.Now().AddDate(0, 0, -1),
+		EndTime:   time.Now(),
+		Limit:     100,
+	}
+
+lokiClient := NewLokiClient("https://loki.api.url", "my-tenant", auth, queryParams)
+logEntries, err := lokiClient.QueryLogs(context.Background())
+```

--- a/lib/client/loki.go
+++ b/lib/client/loki.go
@@ -24,7 +24,7 @@ func (e *LokiAPIError) Error() string {
 
 // LokiBasicAuth holds the authentication details for Loki
 type LokiBasicAuth struct {
-	Username string
+	Login    string
 	Password string
 }
 
@@ -113,7 +113,7 @@ func (lc *LokiClient) QueryLogs(ctx context.Context) ([]LokiLogEntry, error) {
 	resp, err := lc.RestyClient.R().
 		SetContext(ctx).
 		SetHeader("X-Scope-OrgID", lc.TenantID).
-		SetBasicAuth(lc.BasicAuth.Username, lc.BasicAuth.Password).
+		SetBasicAuth(lc.BasicAuth.Login, lc.BasicAuth.Password).
 		SetQueryParams(params).
 		Get(lc.BaseURL + "/loki/api/v1/query_range")
 

--- a/lib/client/loki.go
+++ b/lib/client/loki.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// LokiResponse represents the structure of the response from Loki
+type LokiResponse struct {
+	Data struct {
+		Result []struct {
+			Stream map[string]string `json:"stream"`
+			Values [][]interface{}   `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+// LokiLogEntry represents a single log entry with a timestamp and raw log message
+type LokiLogEntry struct {
+	Timestamp string
+	Log       string
+}
+
+// LokiClient represents a client to interact with Loki for querying logs
+type LokiClient struct {
+	BaseURL     string
+	TenantID    string
+	BasicAuth   string
+	QueryParams LokiQueryParams
+}
+
+// LokiQueryParams holds the parameters required for querying Loki
+type LokiQueryParams struct {
+	Query     string
+	StartTime time.Time
+	EndTime   time.Time
+	Limit     int
+}
+
+// NewLokiClient creates a new Loki client with the given parameters
+func NewLokiClient(baseURL, tenantID, basicAuth string, queryParams LokiQueryParams) *LokiClient {
+	return &LokiClient{
+		BaseURL:     baseURL,
+		TenantID:    tenantID,
+		BasicAuth:   basicAuth,
+		QueryParams: queryParams,
+	}
+}
+
+// QueryLogs queries Loki logs based on the query parameters and returns the raw log entries
+func (lc *LokiClient) QueryLogs(ctx context.Context) ([]LokiLogEntry, error) {
+	client := resty.New()
+
+	// Build query parameters
+	params := map[string]string{
+		"query": lc.QueryParams.Query,
+		"start": fmt.Sprintf("%d", lc.QueryParams.StartTime.UnixNano()),
+		"end":   fmt.Sprintf("%d", lc.QueryParams.EndTime.UnixNano()),
+		"limit": fmt.Sprintf("%d", lc.QueryParams.Limit),
+	}
+
+	// Send request using Resty
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeader("X-Scope-OrgID", lc.TenantID).
+		SetBasicAuth(lc.BasicAuth, "").
+		SetQueryParams(params).
+		Get(lc.BaseURL + "/loki/api/v1/query_range")
+
+	if err != nil {
+		return nil, fmt.Errorf("error querying Loki: %w", err)
+	}
+
+	// Check response status
+	if resp.StatusCode() != 200 {
+		log.Printf("Loki API returned status code: %d", resp.StatusCode())
+		return nil, fmt.Errorf("unexpected response status: %d", resp.StatusCode())
+	}
+
+	// Parse the response into the LokiResponse struct
+	var lokiResp LokiResponse
+	if err := json.Unmarshal(resp.Body(), &lokiResp); err != nil {
+		return nil, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	// Extract log entries from the response
+	logEntries := lc.extractRawLogEntries(lokiResp)
+	return logEntries, nil
+}
+
+// extractRawLogEntries processes the LokiResponse and returns raw log entries
+func (lc *LokiClient) extractRawLogEntries(lokiResp LokiResponse) []LokiLogEntry {
+	var logEntries []LokiLogEntry
+
+	for _, result := range lokiResp.Data.Result {
+		for _, entry := range result.Values {
+			timestamp := entry[0].(string)
+			logLine := entry[1].(string)
+			logEntries = append(logEntries, LokiLogEntry{
+				Timestamp: timestamp,
+				Log:       logLine,
+			})
+		}
+	}
+
+	return logEntries
+}

--- a/lib/client/loki.go
+++ b/lib/client/loki.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/logging"
 )
 

--- a/lib/client/loki_test.go
+++ b/lib/client/loki_test.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLokiClient_QueryLogs tests the LokiClient's ability to query Loki logs
+func TestLokiClient_SuccessfulQuery(t *testing.T) {
+	// Create a mock Loki server using httptest
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/loki/api/v1/query_range", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"data": {
+				"result": [
+					{
+						"stream": {"namespace": "test"},
+						"values": [
+							["1234567890", "Log message 1"],
+							["1234567891", "Log message 2"]
+						]
+					}
+				]
+			}
+		}`))
+	}))
+	defer mockServer.Close()
+
+	// Create a BasicAuth object for testing
+	auth := LokiBasicAuth{
+		Username: "test-user",
+		Password: "test-password",
+	}
+
+	// Set the query parameters
+	queryParams := LokiQueryParams{
+		Query:     `{namespace="test"}`,
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+		Limit:     100,
+	}
+
+	// Create the Loki client with the mock server URL
+	lokiClient := NewLokiClient(mockServer.URL, "test-tenant", auth, queryParams)
+
+	// Query logs
+	logEntries, err := lokiClient.QueryLogs(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, logEntries, 2)
+
+	// Verify the content of the log entries
+	assert.Equal(t, "1234567890", logEntries[0].Timestamp)
+	assert.Equal(t, "Log message 1", logEntries[0].Log)
+	assert.Equal(t, "1234567891", logEntries[1].Timestamp)
+	assert.Equal(t, "Log message 2", logEntries[1].Log)
+}
+
+func TestLokiClient_AuthenticationFailure(t *testing.T) {
+	// Create a mock Loki server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/loki/api/v1/query_range", r.URL.Path)
+		w.WriteHeader(http.StatusUnauthorized) // Simulate authentication failure
+	}))
+	defer mockServer.Close()
+
+	// Create a Loki client with incorrect credentials
+	auth := LokiBasicAuth{
+		Username: "wrong-user",
+		Password: "wrong-password",
+	}
+	queryParams := LokiQueryParams{
+		Query:     `{namespace="test"}`,
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+		Limit:     100,
+	}
+	lokiClient := NewLokiClient(mockServer.URL, "test-tenant", auth, queryParams)
+
+	// Query logs and expect an error
+	logEntries, err := lokiClient.QueryLogs(context.Background())
+	assert.Nil(t, logEntries)
+	assert.Error(t, err)
+	assert.IsType(t, &LokiAPIError{}, err)
+	assert.Equal(t, http.StatusUnauthorized, err.(*LokiAPIError).StatusCode)
+}
+
+func TestLokiClient_InternalServerError(t *testing.T) {
+	// Create a mock Loki server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/loki/api/v1/query_range", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)           // Simulate server error
+		w.Write([]byte(`{"message": "internal server error"}`)) // Error message in the response body
+	}))
+	defer mockServer.Close()
+
+	// Create a Loki client
+	auth := LokiBasicAuth{
+		Username: "test-user",
+		Password: "test-password",
+	}
+	queryParams := LokiQueryParams{
+		Query:     `{namespace="test"}`,
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+		Limit:     100,
+	}
+	lokiClient := NewLokiClient(mockServer.URL, "test-tenant", auth, queryParams)
+
+	// Query logs and expect an error
+	logEntries, err := lokiClient.QueryLogs(context.Background())
+	assert.Nil(t, logEntries)
+	assert.Error(t, err)
+	assert.IsType(t, &LokiAPIError{}, err)
+	assert.Equal(t, http.StatusInternalServerError, err.(*LokiAPIError).StatusCode)
+}
+
+func TestLokiClient_DebugMode(t *testing.T) {
+	// Set the RESTY_DEBUG environment variable
+	os.Setenv("RESTY_DEBUG", "true")
+	defer os.Unsetenv("RESTY_DEBUG") // Clean up after the test
+
+	// Create a mock Loki server
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/loki/api/v1/query_range", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+            "data": {
+                "result": [
+                    {
+                        "stream": {"namespace": "test"},
+                        "values": [
+                            ["1234567890", "Log message 1"],
+                            ["1234567891", "Log message 2"]
+                        ]
+                    }
+                ]
+            }
+        }`))
+	}))
+	defer mockServer.Close()
+
+	// Create a Loki client
+	auth := LokiBasicAuth{
+		Username: "test-user",
+		Password: "test-password",
+	}
+	queryParams := LokiQueryParams{
+		Query:     `{namespace="test"}`,
+		StartTime: time.Now().Add(-1 * time.Hour),
+		EndTime:   time.Now(),
+		Limit:     100,
+	}
+	lokiClient := NewLokiClient(mockServer.URL, "test-tenant", auth, queryParams)
+
+	// Query logs
+	logEntries, err := lokiClient.QueryLogs(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, logEntries, 2)
+
+	// Check if debug mode was enabled
+	assert.True(t, lokiClient.RestyClient.Debug)
+}

--- a/lib/client/loki_test.go
+++ b/lib/client/loki_test.go
@@ -89,7 +89,6 @@ func TestLokiClient_AuthenticationFailure(t *testing.T) {
 	logEntries, err := lokiClient.QueryLogs(context.Background())
 	assert.Nil(t, logEntries)
 	assert.Error(t, err)
-	assert.Equal(t, http.StatusUnauthorized, err.(*LokiAPIError).StatusCode)
 	var lokiErr *LokiAPIError
 	if errors.As(err, &lokiErr) {
 		assert.Equal(t, http.StatusUnauthorized, lokiErr.StatusCode)
@@ -125,7 +124,6 @@ func TestLokiClient_InternalServerError(t *testing.T) {
 	logEntries, err := lokiClient.QueryLogs(context.Background())
 	assert.Nil(t, logEntries)
 	assert.Error(t, err)
-	assert.Equal(t, http.StatusInternalServerError, err.(*LokiAPIError).StatusCode)
 	var lokiErr *LokiAPIError
 	if errors.As(err, &lokiErr) {
 		assert.Equal(t, http.StatusInternalServerError, lokiErr.StatusCode)

--- a/lib/client/loki_test.go
+++ b/lib/client/loki_test.go
@@ -35,7 +35,7 @@ func TestLokiClient_SuccessfulQuery(t *testing.T) {
 
 	// Create a BasicAuth object for testing
 	auth := LokiBasicAuth{
-		Username: "test-user",
+		Login:    "test-login",
 		Password: "test-password",
 	}
 
@@ -72,7 +72,7 @@ func TestLokiClient_AuthenticationFailure(t *testing.T) {
 
 	// Create a Loki client with incorrect credentials
 	auth := LokiBasicAuth{
-		Username: "wrong-user",
+		Login:    "wrong-login",
 		Password: "wrong-password",
 	}
 	queryParams := LokiQueryParams{
@@ -102,7 +102,7 @@ func TestLokiClient_InternalServerError(t *testing.T) {
 
 	// Create a Loki client
 	auth := LokiBasicAuth{
-		Username: "test-user",
+		Login:    "test-login",
 		Password: "test-password",
 	}
 	queryParams := LokiQueryParams{
@@ -148,7 +148,7 @@ func TestLokiClient_DebugMode(t *testing.T) {
 
 	// Create a Loki client
 	auth := LokiBasicAuth{
-		Username: "test-user",
+		Login:    "test-login",
 		Password: "test-password",
 	}
 	queryParams := LokiQueryParams{

--- a/lib/logging/log.go
+++ b/lib/logging/log.go
@@ -17,6 +17,9 @@ import (
 
 const afterTestEndedMsg = "LOG AFTER TEST ENDED"
 
+// Logger is an alias for zerolog.Logger, exposed through the logging package
+type Logger = zerolog.Logger
+
 // CustomT wraps testing.T for two purposes:
 // 1. it implements Write to override the default logger
 // 2. it implements Printf to implement the testcontainers-go/Logging interface


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new Loki client for querying logs from Loki, a horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus. The client facilitates interactions with Loki to fetch and process log data, making it easier to integrate log querying capabilities within applications.

## What
- **lib/client/loki.go**
  - Added `LokiResponse` struct to model the structure of responses from Loki.
  - Added `LokiLogEntry` struct to represent a single log entry.
  - Added `LokiClient` struct with fields for the base URL, tenant ID, basic auth credentials, and query parameters.
  - Added `LokiQueryParams` struct to hold parameters required for querying Loki.
  - Implemented `NewLokiClient` function to create a new instance of `LokiClient`.
  - Implemented `QueryLogs` method for `LokiClient` to query logs based on provided parameters and return raw log entries.
  - Added private method `extractRawLogEntries` to process the Loki response and extract log entries.
