### PR TITLE
Adds Anvil Set Storage

### DIFF
--- a/lib/client/rpc.go
+++ b/lib/client/rpc.go
@@ -183,6 +183,25 @@ func (m *RPCClient) AnvilDropTransaction(params []interface{}) error {
 	return nil
 }
 
+// AnvilSetStorageAt sets storage at address
+// API Reference https://book.getfoundry.sh/reference/anvil/
+func (m *RPCClient) AnvilSetStorageAt(params []interface{}) error {
+	rInt, err := rand.Int()
+	if err != nil {
+		return err
+	}
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "anvil_setStorageAt",
+		"params":  params,
+		"id":      rInt,
+	}
+	if _, err := m.client.R().SetBody(payload).Post(m.URL); err != nil {
+		return errors.Wrap(err, "anvil_setStorageAt")
+	}
+	return nil
+}
+
 type CurrentBlockResponse struct {
 	Result string `json:"result"`
 }

--- a/lib/client/rpc_test.go
+++ b/lib/client/rpc_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"math/big"
 	"testing"
 	"time"
@@ -137,15 +138,19 @@ func TestRPCAPI(t *testing.T) {
 		require.NoError(t, err)
 
 		randomAddress := common.HexToAddress("0x0d2026b3EE6eC71FC6746ADb6311F6d3Ba1C000B")
+		storeValue := "0x0000000000000000000000000000000000000000000000000000000000000001"
 
 		anvilClient := NewRPCClient(ac.URL, nil)
-		err = anvilClient.AnvilSetStorageAt([]interface{}{randomAddress, "0x0", "0x420"})
-		require.NoError(t, err)
-		status, err := client.StorageAt(context.Background(), randomAddress, common.HexToHash("0x0"), nil)
-		require.NoError(t, err)
-		require.Equal(t, "0x420", string(status))
+		err = anvilClient.AnvilSetStorageAt([]interface{}{randomAddress.Hex(), "0x0", storeValue})
+		require.NoError(t, err, "unable to set storage at address")
 
-		t.Logf("status: %v", status)
+		value, err := client.StorageAt(context.Background(), randomAddress, common.HexToHash("0x0"), nil)
+		require.NoError(t, err)
+		decodedStoreValue, err := hex.DecodeString(storeValue[2:])
+		require.NoError(t, err, "unable to decode store value")
+		require.Equal(t, decodedStoreValue, value)
+
+		t.Logf("value: %v", value)
 	})
 
 	t.Run("(anvil) test we can shrink the block and control transaction inclusion", func(t *testing.T) {

--- a/lib/client/rpc_test.go
+++ b/lib/client/rpc_test.go
@@ -130,6 +130,24 @@ func TestRPCAPI(t *testing.T) {
 		t.Logf("status: %v", status)
 	})
 
+	t.Run("(anvil) test set storage at address", func(t *testing.T) {
+		ac, err := StartAnvil([]string{"--balance", "1", "--block-time", "5"})
+		require.NoError(t, err)
+		client, err := ethclient.Dial(ac.URL)
+		require.NoError(t, err)
+
+		randomAddress := common.HexToAddress("0x0d2026b3EE6eC71FC6746ADb6311F6d3Ba1C000B")
+
+		anvilClient := NewRPCClient(ac.URL, nil)
+		err = anvilClient.AnvilSetStorageAt([]interface{}{randomAddress, "0x0", "0x420"})
+		require.NoError(t, err)
+		status, err := client.StorageAt(context.Background(), randomAddress, common.HexToHash("0x0"), nil)
+		require.NoError(t, err)
+		require.Equal(t, "0x420", string(status))
+
+		t.Logf("status: %v", status)
+	})
+
 	t.Run("(anvil) test we can shrink the block and control transaction inclusion", func(t *testing.T) {
 		ac, err := StartAnvil([]string{"--balance", "1", "--block-time", "1"})
 		require.NoError(t, err)

--- a/lib/k8s/e2e/common/test_common.go
+++ b/lib/k8s/e2e/common/test_common.go
@@ -111,6 +111,8 @@ func TestConnectWithoutManifest(t *testing.T) {
 		existingEnv = environment.New(existingEnvConfig)
 		l.Info().Str("Namespace", existingEnvConfig.Namespace).Msg("Existing Env Namespace")
 		// deploy environment to use as an existing one for the test
+		require.NotNil(t, existingEnv, "existingEnv is nil")
+		require.NotNil(t, existingEnv.Cfg, "existingEnv.Cfg is nil %v", existingEnv)
 		existingEnv.Cfg.JobImage = ""
 		existingEnv.AddHelm(ethereum.New(nil)).
 			AddHelm(chainlink.New(0, map[string]any{


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new function `AnvilSetStorageAt` in `rpc.go` to modify the storage at a specific address within the Anvil simulation environment, and a corresponding test case in `rpc_test.go`. This enhances the testing capabilities by allowing direct manipulation of account storage for testing smart contracts or blockchain interactions, contributing to more robust test scenarios.

## What
- **lib/client/rpc.go**
  - Added `AnvilSetStorageAt` function which sets storage at a specific address. This function is designed to interact with the Anvil testing environment, allowing users to directly modify the storage values of smart contracts or accounts in a simulated blockchain.
- **lib/client/rpc_test.go**
  - Added a test case for the `AnvilSetStorageAt` function. This test verifies if the storage at a given address can be successfully set and retrieved, ensuring the functionality works as expected within the Anvil environment.
