### PR TITLE
Release v1.50.12

### DIFF
--- a/lib/.changeset/v1.50.12.md
+++ b/lib/.changeset/v1.50.12.md
@@ -1,0 +1,6 @@
+- Fixes to common release pipeline that cover a case, when only 1 tag is present
+- Fixed low RPS bug in WASP
+- Updated `slack-go` library to latest version, which supports new file upload API
+- Enabled user indexes collector in Postgres exporter
+- Removed unnecessary replaces and exclusion from Havoc's `go.mod`
+- Bumped k3d and Helm to newer versions


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes aim to address specific bugs and enhancements in the release pipeline, WASP functionality, and dependencies updates. Additionally, they enhance monitoring capabilities and keep the project's dependencies up to date.

## What
- **lib/.changeset/v1.50.12.md**
  - Added a note about fixing the release pipeline for a scenario with only one tag present. This ensures smoother CI/CD operations.
  - Fixed a bug related to low RPS in WASP, improving performance and reliability.
  - Updated the `slack-go` library to the latest version, enabling support for the new file upload API and ensuring compatibility with Slack's current features.
  - Enabled user indexes collector in Postgres exporter, enhancing the monitoring and observability of Postgres databases.
  - Removed unnecessary replaces and exclusion from Havoc's `go.mod`, cleaning up dependencies and potentially improving build times and reliability.
  - Bumped k3d and Helm to newer versions, keeping the project up to date with these dependencies and benefiting from their latest features and fixes.
