### PR TITLE
bump all GHA to latest

### DIFF
--- a/.github/actions/update-internal-mirrors/action.yaml
+++ b/.github/actions/update-internal-mirrors/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout the Repo
-      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -22,9 +22,9 @@ jobs:
             tests: TestPostgres|TestMockServer|TestKillgrave
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Go
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           test_download_vendor_packages_command: cd lib && go mod download
           go_mod_path: ./lib/go.mod
@@ -44,7 +44,7 @@ jobs:
           go test -timeout 20m -json -parallel 2 -cover -covermode=atomic -coverprofile=unit-test-coverage.out $(go list ./... | grep /docker/test_env) -run '${{ matrix.test.tests }}' 2>&1 | tee /tmp/gotest.log | ../gotestloghelper -ci
       - name: Publish Artifacts
         if: failure()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-logs
           path: ./lib/logs

--- a/.github/workflows/k8s-e2e.yaml
+++ b/.github/workflows/k8s-e2e.yaml
@@ -25,9 +25,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Build Base Image
-        uses: smartcontractkit/chainlink-github-actions/docker/build-push@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/docker/build-push@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           tags: ${{ env.BASE_IMAGE_NAME }}
           file: lib/k8s/Dockerfile.base
@@ -41,7 +41,7 @@ jobs:
           ### test-base-image image tag for this test run :ship: => \`ci.${{ github.sha }}\`
           EOT
       - name: Build Test Runner
-        uses: smartcontractkit/chainlink-github-actions/docker/build-push@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/docker/build-push@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           tags: ${{ env.ENV_JOB_IMAGE }}
           file: lib/k8s/Dockerfile
@@ -65,15 +65,15 @@ jobs:
     env:
       TEST_SUITE: local-runner
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Nix
-        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Load Nix
         run: nix develop -c sh -c "cd lib &&go mod download"
       - name: Setup environment
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           go_mod_path: go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -83,7 +83,7 @@ jobs:
       - name: Run Tests
         env:
           LOCAL_CHARTS: true
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
           cl_image_tag: ${{ env.CHAINLINK_VERSION }}
@@ -99,7 +99,7 @@ jobs:
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
           run_setup: false
       - name: Upload test log
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: failure()
         with:
           name: test-log
@@ -116,15 +116,15 @@ jobs:
       TEST_SUITE: remote-runner
       TEST_TRIGGERED_BY: chainlink-testing-framework-remote-runner-ci
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Nix
-        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Load Nix
         run: nix develop -c sh -c "cd lib && go mod download"
       - name: Setup environment
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           go_mod_path: go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -132,7 +132,7 @@ jobs:
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
           go_necessary: false
       - name: Run Remote Runner Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
           cl_image_tag: ${{ env.CHAINLINK_VERSION }}
@@ -147,7 +147,7 @@ jobs:
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
           run_setup: false
       - name: Upload test log
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: failure()
         with:
           name: remote-runner-test-log

--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Strip "lib/" from github.ref_name
         run: |
           stripped_ref_name="${GITHUB_REF//refs\/tags\/lib\//}"
+          # disabling as the string containing variable is double-quotted as a whole, no need to quote each variable separately
+          # shellcheck disable=SC2086          
           echo "BASE_IMAGE_TAG=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:$stripped_ref_name" >> $GITHUB_ENV
 
       - name: Build Base Image

--- a/.github/workflows/k8s-publish-test-base-image.yaml
+++ b/.github/workflows/k8s-publish-test-base-image.yaml
@@ -15,7 +15,7 @@ jobs:
     env:
       BASE_IMAGE_TAG: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Strip "lib/" from github.ref_name
         run: |
@@ -23,7 +23,7 @@ jobs:
           echo "BASE_IMAGE_TAG=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image:$stripped_ref_name" >> $GITHUB_ENV
 
       - name: Build Base Image
-        uses: smartcontractkit/chainlink-github-actions/docker/build-push@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/docker/build-push@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           tags: ${{ env.BASE_IMAGE_TAG }}
           file: lib/k8s/Dockerfile.base

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@53c3e3207fe4b8d52e2f1ac9d6eb1d2506f626c0 # v2.0.2
+        uses: sonarsource/sonarqube-scan-action@884b79409bbd464b2a59edc326a4b77dc56b2195 # v3.0.0
         with:
           args: >
             -Dsonar.go.golangci-lint.reportPaths=golangci-lint-report/golangci-lint-report.xml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0 # needed for pre-commit to work correctly
       - name: Install Nix
-        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run pre-commit checks
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Parse tool-versions file
         uses: smartcontractkit/tool-versions-to-env-action@aabd5efbaf28005284e846c5cf3a02f2cba2f4c2 # v1.0.8
         id: tool-versions
@@ -58,9 +58,9 @@ jobs:
             path: ./tools/workflowresultparser/
     steps:
       - name: Check out Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Go
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           test_download_vendor_packages_command: cd ${{ matrix.project.path }} && go mod download
           go_mod_path: ${{ matrix.project.path }}go.mod
@@ -78,7 +78,7 @@ jobs:
         run: test -f ${{ matrix.project.path }}golangci-lint-report.xml || true
       - name: Store lint report artifact
         if: always()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: golangci-lint-report-${{ matrix.project.name }}
           path: ${{ matrix.project.path }}golangci-lint-report.xml
@@ -89,9 +89,9 @@ jobs:
     needs: [tools]
     steps:
       - name: Check out Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Go
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
         with:
           test_download_vendor_packages_command: cd lib && go mod download
           go_mod_path: ./lib/go.mod
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install asdf dependencies
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
 
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           # Without this parameter, the merged commit that CI produces will make it so that ct will
           # not detect a diff even if one exists
@@ -134,9 +134,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@9d8b58041eed1373f173e91b9a3db5a844197236 # v1.44.0
+        uses: reviewdog/action-actionlint@7eeec1dd160c2301eb28e1568721837d084558ad # v1.57.0
 
   sonarqube:
     name: SonarQube Analysis
@@ -144,11 +144,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@53c3e3207fe4b8d52e2f1ac9d6eb1d2506f626c0 # v2.0.2
         with:

--- a/.github/workflows/rc-breaking-changes.yaml
+++ b/.github/workflows/rc-breaking-changes.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: Set up Go 1.22.6
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.22.6'
       - name: Install gorelease tool

--- a/.github/workflows/seth-lint.yml
+++ b/.github/workflows/seth-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -20,7 +20,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-api.yml
+++ b/.github/workflows/seth-test-api.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-bumping.yml
+++ b/.github/workflows/seth-test-bumping.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-cli.yml
+++ b/.github/workflows/seth-test-cli.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-decode-testnet.yml
+++ b/.github/workflows/seth-test-decode-testnet.yml
@@ -19,7 +19,7 @@ jobs:
         network: [Fuji]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -27,7 +27,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-decode.yml
+++ b/.github/workflows/seth-test-decode.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-others.yml
+++ b/.github/workflows/seth-test-others.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/seth-test-trace.yml
+++ b/.github/workflows/seth-test-trace.yml
@@ -17,7 +17,7 @@ jobs:
       SETH_ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - name: Checkout repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Check for changes in Seth project
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
@@ -25,7 +25,7 @@ jobs:
           filters: |
             src:
               - 'seth/**'
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,12 +12,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/init@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           languages: go
       - name: Autobuild
-        uses: github/codeql-action/autobuild@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/autobuild@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
+        uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,11 @@ jobs:
     name: ${{ matrix.project.name }} unit tests
     steps:
       - name: Checkout the Repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install gotestloghelper
         run: cd lib && make gotestloghelper_build
       - name: Install Nix
-        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Load Nix
@@ -50,7 +50,7 @@ jobs:
             make test_unit"
       - name: Publish Artifacts
         if: failure()
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-logs
           path: /tmp/gotest.log

--- a/.github/workflows/wasp-lint.yml
+++ b/.github/workflows/wasp-lint.yml
@@ -18,7 +18,7 @@ jobs:
           filters: |
             src:
               - 'wasp/**'
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/wasp-test-e2e.yml
+++ b/.github/workflows/wasp-test-e2e.yml
@@ -21,7 +21,7 @@ jobs:
           filters: |
             src:
               - 'wasp/**'
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/wasp-test.yml
+++ b/.github/workflows/wasp-test.yml
@@ -17,7 +17,7 @@ jobs:
           filters: |
             src:
               - 'wasp/**'
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         if: steps.changes.outputs.src == 'true'
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates across multiple GitHub Actions workflows and configurations primarily involve upgrading actions to their newer versions, ensuring that the workflows utilize the latest features, security patches, and performance improvements provided by these actions. These changes are aimed at maintaining the CI/CD pipelines' efficiency, security, and reliability.

## What
- **.github/actions/update-internal-mirrors/action.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1 to use the latest features and fixes.
- **.github/workflows/docker-test.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1.
  - Updated `chainlink-github-actions/chainlink-testing-framework/setup-go` from v2.3.16 to v2.3.31.
  - Updated `actions/upload-artifact` from v4.3.3 to v4.4.3 to utilize the latest improvements.
- **.github/workflows/k8s-e2e.yaml**
  - Updated `actions/checkout`, `chainlink-github-actions/docker/build-push`, and `chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment` to their newer versions for all jobs in the workflow.
  - Updated `actions/upload-artifact` from v4.3.3 to v4.4.3.
- **.github/workflows/k8s-publish-test-base-image.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1.
  - Updated `chainlink-github-actions/docker/build-push` from v2.3.16 to v2.3.31.
  - Added a shellcheck disable comment to address linting for double-quoted variables.
- **.github/workflows/lint.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1 across multiple jobs.
  - Updated `cachix/install-nix-action` from v26 to v30.
  - Updated `chainlink-github-actions/chainlink-testing-framework/setup-go` from v2.3.16 to v2.3.31.
  - Updated `actions/upload-artifact` from v4.3.3 to v4.4.3.
  - Updated `reviewdog/action-actionlint` from v1.44.0 to v1.57.0.
- **.github/workflows/rc-breaking-changes.yaml**
  - Updated `actions/setup-go` from v4 to v5 to use a newer version of Go setup action.
- **.github/workflows/seth-*.yml** and **.github/workflows/wasp-*.yml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1 and `cachix/install-nix-action` from v26 to v30 across various workflows to align with the latest versions for improved performance and reliability.
- **.github/workflows/static-analysis.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1.
  - Updated `github/codeql-action` components (`init`, `autobuild`, `analyze`) from v3.25.3 to v3.27.0 to leverage enhancements in the CodeQL analysis process.
- **.github/workflows/test.yaml**
  - Updated `actions/checkout` from v4.1.4 to v4.2.1 and `cachix/install-nix-action` from v26 to v30 for unit test workflows, ensuring the use of updated actions for testing processes.
- **.github/workflows/wasp-lint.yml**, **.github/workflows/wasp-test-e2e.yml**, and **.github/workflows/wasp-test.yml**
  - Updated `cachix/install-nix-action` to v30 for all Wasp related workflows to use the latest Nix setup actions.
