### PR TITLE
adjust tag pattern to match all tags that end with /vX.X.X

### DIFF
--- a/.github/workflows/release-go-module.yml
+++ b/.github/workflows/release-go-module.yml
@@ -6,8 +6,7 @@ name: Release Go module
 on:
   push:
     tags:
-      - '*/v*.*.*' # Trigger only on tags with the format $package/vX.X.X
-      - '*/*/v*.*.*' # Trigger only on tags with the format $package/$subpackage/vX.X.X
+      - '**/v*.*.*' # Trigger on all tags ending with /vX.X.X
 
 permissions:
   contents: write


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes simplify the tag trigger pattern for the Go module release workflow, and remove an obsolete binary tool, enhancing maintainability and clarity in the project's automation and tools setup.

## What
- **.github/workflows/release-go-module.yml**
  - Simplified the tag trigger pattern from two specific formats to a more inclusive single pattern. This change makes it easier to trigger the workflow for any tag following the `/vX.X.X` format, regardless of the tag's hierarchical position.
- **tools/ecrimagefetcher/ecrimagefetcher**
  - Removed the binary file `ecrimagefetcher`. This likely indicates the tool is either deprecated, replaced, or moved, reducing clutter in the project repository.
