### PR TITLE
do not extract version & package 2x

### DIFF
--- a/.github/workflows/release-go-module.yml
+++ b/.github/workflows/release-go-module.yml
@@ -30,8 +30,8 @@ jobs:
         id: extract_package_name
         run: |
           TAG_REF="${GITHUB_REF#refs/tags/}"
-          PACKAGE_NAME=$(echo "$TAG_REF" | cut -d'/' -f1)
-          VERSION=$(echo "$TAG_REF" | cut -d'/' -f2)
+          PACKAGE_NAME="${TAG_REF%/*}"
+          VERSION="${TAG_REF##*/}"
           echo "Tag Reference: $TAG_REF"
           echo "Package Name: $PACKAGE_NAME"
           echo "Version: $VERSION"
@@ -41,11 +41,6 @@ jobs:
       - name: Find Last Tag for Package and Generate Release Notes
         id: generate_release_notes
         run: |
-          # Extract the package name and version from the tag
-          TAG_REF="${GITHUB_REF#refs/tags/}"
-          PACKAGE_NAME="${TAG_REF%/*}"
-          VERSION="${TAG_REF##*/}"  
-
           # Find the latest tag for the same package that is not the current tag
           LAST_TAG=$(git describe --abbrev=0 --always --match "$PACKAGE_NAME/v*" --tags $(git rev-list --tags --skip=1 --max-count=1))
           echo "Last tag: ${LAST_TAG}"


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes in the `.github/workflows/release-go-module.yml` file aim to streamline the release process of multi-platform Go modules by improving the extraction of package names and versions from git tags, enhancing the generation of release notes, setting up Go environment, installing necessary tools, and handling the binary release process more efficiently.

## What
- `.github/workflows/release-go-module.yml`
  - Modified the `Extract Package Name from Tag` step to directly assign the package name and version variables using shell parameter expansion, making the extraction process more straightforward and removing unnecessary commands.
  - Removed duplicate code under the `Find Last Tag for Package and Generate Release Notes` step, which was unnecessarily extracting package name and version again.
  - Updated the `Set up Go` step to specify Go version `1.22.6`, ensuring that the workflow uses a specific Go version for consistency and reliability.
  - Added the `Install gorelease tool` and `Run gorelease to check for breaking changes` steps, incorporating the use of the `gorelease` tool to check for potential breaking changes in the release, which aids in maintaining backward compatibility.
  - Enhanced the `Read Additional Release Notes from File` step to include additional release notes from a `.changeset` directory if available, allowing for more detailed release notes that can include manual entries.
  - Added a step to `Create GitHub Release` using the `gh` tool, which automates the release creation process on GitHub, making it more efficient and less prone to errors.
  - Included a step to check if the `cmd` directory exists and set an environment variable accordingly, which is used to conditionally execute the binary release process based on the presence of a Go main package, ensuring that the workflow only attempts to build binaries when appropriate.
  - Utilized the `wangyoucao577/go-release-action` for the `Build binary release` step, automating the compilation and release of Go binaries for multiple platforms, which simplifies the release process for projects that need to provide binaries for different operating systems and architectures.
