### PR TITLE
add extra validations to client creation in read-only mode

### DIFF
--- a/seth/.changeset/v1.50.6.md
+++ b/seth/.changeset/v1.50.6.md
@@ -1,0 +1,1 @@
+- Adds `read-only` mode that can be useful if we are interested only in tracing and want to make sure that no write operations can be executed  

--- a/seth/README.md
+++ b/seth/README.md
@@ -813,11 +813,12 @@ With `SETH_LOG_LEVEL=trace` we will also log to console all traffic between Seth
 
 ### Read-only mode
 It's possible to use Seth in read-only mode only for transaction confirmation and tracing. Following operations will fail:
-* contract deployment
-* gas estimations (we need the pk/address to check nonce)
+* contract deployment (we need a pk to sign the transaction)
+* new transaction options (we need the pk/address to check nonce)
 * RPC health check (we need a pk to send a transaction to ourselves)
 * pending nonce protection (we need an address to check pending transactions)
 * ephemeral keys (we need a pk to fund them)
+* gas bumping (we need a pk to sign the transaction)
 
 The easiest way to enable read-only mode is to client via `ClientBuilder`:
 ```go
@@ -831,3 +832,10 @@ The easiest way to enable read-only mode is to client via `ClientBuilder`:
 ```
 
 when builder is called with `WithReadOnlyMode()` it will disable all the operations mentioned above and all the configuration settings related to them.
+
+Additionally, when the client is build anc `cfg.ReadOnly = true` is set, we will validate that:
+* no addresses and private keys are passed
+* no ephemeral addresses are to be created
+* RPC health check is disabled
+* pending nonce protection is disabled
+* gas bumping is disabled

--- a/seth/client_builder.go
+++ b/seth/client_builder.go
@@ -393,6 +393,7 @@ func (c *ClientBuilder) handleReadOnlyMode() {
 		c.config.PendingNonceProtectionEnabled = false
 		c.config.CheckRpcHealthOnStart = false
 		c.config.EphemeralAddrs = nil
+		c.readonly = true
 		if c.config.Network != nil {
 			c.config.Network.GasPriceEstimationEnabled = false
 			c.config.Network.PrivateKeys = []string{}

--- a/seth/config.go
+++ b/seth/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	CheckRpcHealthOnStart         bool              `toml:"check_rpc_health_on_start"`
 	BlockStatsConfig              *BlockStatsConfig `toml:"block_stats"`
 	GasBump                       *GasBumpConfig    `toml:"gas_bump"`
+	ReadOnly                      bool              `toml:"read_only"`
 }
 
 type GasBumpConfig struct {

--- a/seth/seth.toml
+++ b/seth/seth.toml
@@ -55,6 +55,11 @@ experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]
 # to make sure transaction can be submitted and mined
 check_rpc_health_on_start = false
 
+# when enabled, upon creation Seth will validate that there are no private keys set, that node RPC health check is disabled
+# and that gas bumping is disabled, since all of these operations are "write" operations. This is useful for running Seth
+# only for tracing, when you want to make sure that no transactions are sent to the network.
+read_only = false
+
 [gas_bumps]
 # when > 0 then we will bump gas price for transactions that are stuck in the mempool
 # by default the bump step is controlled by gas_price_estimation_tx_priority (check readme.md for more details)


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a `read-only` mode to the Seth client, enhancing its usability for scenarios where only transaction tracing or confirmation is required without the need to execute write operations. This mode ensures that no private keys are loaded, disables RPC health checks, pending nonce protection, gas bumping, and creation of ephemeral addresses, making Seth safer and more flexible for read-only applications.

## What
- **seth/.changeset/v1.50.6.md**
  - Added a new changeset document describing the introduction of `read-only` mode.
- **seth/README.md**
  - Updated documentation to include details and implications of using Seth in `read-only` mode.
  - Clarified the operations that are disabled in `read-only` mode, including contract deployment, new transaction options, gas bumping, and others.
  - Explained how to enable `read-only` mode using `ClientBuilder`.
- **seth/client.go**
  - Introduced validation to prevent loading of private keys, disable ephemeral keys, RPC health check, pending nonce protection, and gas bumping when `read-only` mode is enabled.
  - Added new error messages related to the restrictions imposed by `read-only` mode.
- **seth/client_builder.go**
  - Modified the `handleReadOnlyMode` method to properly configure the client for `read-only` mode by disabling features not compatible with it.
- **seth/config.go**
  - Added a `ReadOnly` boolean field to the `Config` struct to enable the configuration of Seth in `read-only` mode.
- **seth/config_test.go**
  - Added tests to validate the behavior of Seth when configured in `read-only` mode, ensuring that the various restrictions are enforced correctly.
- **seth/seth.toml**
  - Updated the configuration file template to include the `read_only` option, allowing users to enable `read-only` mode through configuration.
