### PR TITLE
add back error message used by upstream

### DIFF
--- a/seth/.changeset/v1.50.7.md
+++ b/seth/.changeset/v1.50.7.md
@@ -1,0 +1,1 @@
+- Add back error message used by upstream dependencies  

--- a/seth/client.go
+++ b/seth/client.go
@@ -34,6 +34,8 @@ const (
 	ErrRpcHealthCheckFailed     = "RPC health check failed ¯\\_(ツ)_/¯"
 	ErrContractDeploymentFailed = "contract deployment failed"
 	ErrNoPksEphemeralMode       = "no private keys loaded, cannot fund ephemeral addresses"
+	// unused by Seth, but used by upstream
+	ErrNoKeyLoaded = "failed to load private key"
 
 	ErrReadOnlyWithPrivateKeys = "read-only mode is enabled, but you tried to load private keys"
 	ErrReadOnlyEphemeralKeys   = "ephemeral mode is not supported in read-only mode"


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce the restoration of an error message and an update in the error handling mechanism. This ensures compatibility with upstream dependencies and enhances the clarity of error messages for better debugging and maintenance.

## What
- **seth/.changeset/v1.50.7.md**
  - Added a new changeset file for version 1.50.7, indicating the addition of an error message.
- **seth/client.go**
  - Added a new error message `ErrNoKeyLoaded` to the list of constants. This change clarifies the error scenario where a private key fails to load, which is crucial for upstream dependencies even though it's not used directly by Seth.
