### PR TITLE
flakeguard: Do not fail when test skipped and fail fast if threshold=100%

### DIFF
--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -47,15 +47,19 @@ var RunTestsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Filter out failed tests based on the threshold
+		passedTests := reports.FilterPassedTests(testResults, threshold)
 		failedTests := reports.FilterFailedTests(testResults, threshold)
+		skippedTests := reports.FilterSkippedTests(testResults)
+
 		if len(failedTests) > 0 {
 			jsonData, err := json.MarshalIndent(failedTests, "", "  ")
 			if err != nil {
 				log.Fatalf("Error marshaling test results to JSON: %v", err)
 			}
-			fmt.Printf("Threshold for flaky tests: %.2f\n%d failed tests:\n%s\n", threshold, len(failedTests), string(jsonData))
+			fmt.Printf("PassRatio threshold for flaky tests: %.2f\n%d failed tests:\n%s\n", threshold, len(failedTests), string(jsonData))
 		}
+
+		fmt.Printf("Summary: %d passed, %d skipped, %d failed\n", len(passedTests), len(skippedTests), len(failedTests))
 
 		// Save the test results in JSON format
 		if outputPath != "" && len(testResults) > 0 {
@@ -70,11 +74,10 @@ var RunTestsCmd = &cobra.Command{
 		}
 
 		if len(failedTests) > 0 {
+			// Fail if any tests failed
 			os.Exit(1)
 		} else if len(testResults) == 0 {
 			fmt.Printf("No tests were run for the specified packages.\n")
-		} else {
-			fmt.Printf("All %d tests passed.\n", len(testResults))
 		}
 	},
 }

--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -19,7 +19,6 @@ var RunTestsCmd = &cobra.Command{
 		testPackagesArg, _ := cmd.Flags().GetStringSlice("test-packages")
 		runCount, _ := cmd.Flags().GetInt("run-count")
 		useRace, _ := cmd.Flags().GetBool("race")
-		failFast, _ := cmd.Flags().GetBool("fail-fast")
 		outputPath, _ := cmd.Flags().GetString("output-json")
 		threshold, _ := cmd.Flags().GetFloat64("threshold")
 
@@ -38,7 +37,7 @@ var RunTestsCmd = &cobra.Command{
 			Verbose:  true,
 			RunCount: runCount,
 			UseRace:  useRace,
-			FailFast: failFast,
+			FailFast: threshold == 1.0, // Fail test on first test run if threshold is 1.0
 		}
 
 		testResults, err := runner.RunTests(testPackages)

--- a/tools/flakeguard/reports/reports.go
+++ b/tools/flakeguard/reports/reports.go
@@ -20,7 +20,7 @@ func FilterFailedTests(results []TestResult, threshold float64) []TestResult {
 	return failedTests
 }
 
-// FilterPassedTests returns a slice of TestResult where the tests passed (PassRatio is 1.0) and were not skipped.
+// FilterPassedTests returns a slice of TestResult where the tests passed and were not skipped.
 func FilterPassedTests(results []TestResult, threshold float64) []TestResult {
 	var passedTests []TestResult
 	for _, result := range results {

--- a/tools/flakeguard/reports/reports.go
+++ b/tools/flakeguard/reports/reports.go
@@ -6,15 +6,38 @@ type TestResult struct {
 	PassRatio   float64
 	Runs        int
 	Outputs     []string // Stores outputs for a test
+	Skipped     bool     // Indicates if the test was skipped
 }
 
 // FilterFailedTests returns a slice of TestResult where the pass ratio is below the specified threshold.
 func FilterFailedTests(results []TestResult, threshold float64) []TestResult {
 	var failedTests []TestResult
 	for _, result := range results {
-		if result.PassRatio < threshold {
+		if !result.Skipped && result.PassRatio < threshold {
 			failedTests = append(failedTests, result)
 		}
 	}
 	return failedTests
+}
+
+// FilterPassedTests returns a slice of TestResult where the tests passed (PassRatio is 1.0) and were not skipped.
+func FilterPassedTests(results []TestResult, threshold float64) []TestResult {
+	var passedTests []TestResult
+	for _, result := range results {
+		if !result.Skipped && result.PassRatio >= threshold {
+			passedTests = append(passedTests, result)
+		}
+	}
+	return passedTests
+}
+
+// FilterSkippedTests returns a slice of TestResult where the tests were skipped.
+func FilterSkippedTests(results []TestResult) []TestResult {
+	var skippedTests []TestResult
+	for _, result := range results {
+		if result.Skipped {
+			skippedTests = append(skippedTests, result)
+		}
+	}
+	return skippedTests
 }

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -124,6 +124,9 @@ func parseTestResults(datas [][]byte) ([]reports.TestResult, error) {
 				result.Outputs = append(result.Outputs, entry.Output)
 			case "fail":
 				result.PassRatio = (result.PassRatio * float64(result.Runs-1)) / float64(result.Runs)
+			case "skip":
+				result.Skipped = true
+				result.Runs++
 			}
 		}
 


### PR DESCRIPTION
Skipped tests should not fail the flaky test detector.

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/9edba5a1-550a-4134-927e-fc11f39c84de">

https://github.com/smartcontractkit/chainlink/actions/runs/11596079295/job/32286393819



<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance FlakeGuard's reporting and filtering capabilities, introducing differentiation between passed, failed, and skipped tests based on a threshold. This lets users get a clearer overview of their test suite's health and flakiness levels.

## What
- **tools/flakeguard/cmd/run.go**
  - Added logic to filter and report passed and skipped tests, improving the output's detail for test runs. This includes calculating the number of passed and skipped tests and adjusting the summary output accordingly. 
  - Modified the failure message to include "PassRatio" term for clarity. 
  - Removed the final message stating "All tests passed" for consistency with new summary output logic.
- **tools/flakeguard/reports/reports.go**
  - Added a `Skipped` boolean field to the `TestResult` struct to track skipped tests.
  - Implemented `FilterPassedTests` function to filter out tests with a pass ratio of 1.0 and not skipped.
  - Implemented `FilterSkippedTests` function to return a slice of skipped test results.
  - Modified `FilterFailedTests` function to exclude skipped tests from the failed tests output.
- **tools/flakeguard/runner/runner.go**
  - Updated the `parseTestResults` function to handle "skip" actions by setting the `Skipped` flag and incrementing the run count for skipped tests.
