### PR TITLE
flakeguard: Add support for go projects and add test duration to results

### DIFF
--- a/tools/flakeguard/cmd/find.go
+++ b/tools/flakeguard/cmd/find.go
@@ -30,7 +30,7 @@ var FindTestsCmd = &cobra.Command{
 		// Find all changes in test files and get their package names
 		var changedTestPkgs []string
 		if findByTestFilesDiff {
-			changedTestFiles, err := git.FindChangedFiles(baseRef, "grep '_test\\.go$'", excludes)
+			changedTestFiles, err := git.FindChangedFiles(projectPath, baseRef, "grep '_test\\.go$'")
 			if err != nil {
 				log.Fatalf("Error finding changed test files: %v", err)
 			}

--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -15,6 +15,7 @@ var RunTestsCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run tests to check if they are flaky",
 	Run: func(cmd *cobra.Command, args []string) {
+		projectPath, _ := cmd.Flags().GetString("project-path")
 		testPackagesJson, _ := cmd.Flags().GetString("test-packages-json")
 		testPackagesArg, _ := cmd.Flags().GetStringSlice("test-packages")
 		runCount, _ := cmd.Flags().GetInt("run-count")
@@ -34,10 +35,11 @@ var RunTestsCmd = &cobra.Command{
 		}
 
 		runner := runner.Runner{
-			Verbose:  true,
-			RunCount: runCount,
-			UseRace:  useRace,
-			FailFast: threshold == 1.0, // Fail test on first test run if threshold is 1.0
+			ProjectPath: projectPath,
+			Verbose:     true,
+			RunCount:    runCount,
+			UseRace:     useRace,
+			FailFast:    threshold == 1.0, // Fail test on first test run if threshold is 1.0
 		}
 
 		testResults, err := runner.RunTests(testPackages)
@@ -82,6 +84,7 @@ var RunTestsCmd = &cobra.Command{
 }
 
 func init() {
+	RunTestsCmd.Flags().StringP("project-path", "r", ".", "The path to the Go project. Default is the current directory. Useful for subprojects.")
 	RunTestsCmd.Flags().String("test-packages-json", "", "JSON-encoded string of test packages")
 	RunTestsCmd.Flags().StringSlice("test-packages", nil, "Comma-separated list of test packages to run")
 	RunTestsCmd.Flags().IntP("run-count", "c", 1, "Number of times to run the tests")

--- a/tools/flakeguard/reports/reports.go
+++ b/tools/flakeguard/reports/reports.go
@@ -4,9 +4,10 @@ type TestResult struct {
 	TestName    string
 	TestPackage string
 	PassRatio   float64
+	Skipped     bool // Indicates if the test was skipped
 	Runs        int
-	Outputs     []string // Stores outputs for a test
-	Skipped     bool     // Indicates if the test was skipped
+	Outputs     []string  // Stores outputs for a test
+	Durations   []float64 // Stores elapsed time in seconds for each run of the test
 }
 
 // FilterFailedTests returns a slice of TestResult where the pass ratio is below the specified threshold.

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -91,10 +91,11 @@ func parseTestResults(datas [][]byte) ([]reports.TestResult, error) {
 		scanner := bufio.NewScanner(bytes.NewReader(data))
 		for scanner.Scan() {
 			var entry struct {
-				Action  string `json:"Action"`
-				Test    string `json:"Test"`
-				Package string `json:"Package"`
-				Output  string `json:"Output"`
+				Action  string  `json:"Action"`
+				Test    string  `json:"Test"`
+				Package string  `json:"Package"`
+				Output  string  `json:"Output"`
+				Elapsed float64 `json:"Elapsed"`
 			}
 			if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 				return nil, fmt.Errorf("failed to parse json test output: %s, err: %w", scanner.Text(), err)
@@ -122,13 +123,16 @@ func parseTestResults(datas [][]byte) ([]reports.TestResult, error) {
 				result.Runs++
 			case "pass":
 				result.PassRatio = (result.PassRatio*float64(result.Runs-1) + 1) / float64(result.Runs)
+				result.Durations = append(result.Durations, entry.Elapsed)
 			case "output":
 				result.Outputs = append(result.Outputs, entry.Output)
 			case "fail":
 				result.PassRatio = (result.PassRatio * float64(result.Runs-1)) / float64(result.Runs)
+				result.Durations = append(result.Durations, entry.Elapsed)
 			case "skip":
 				result.Skipped = true
 				result.Runs++
+				result.Durations = append(result.Durations, entry.Elapsed)
 			}
 		}
 

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -14,10 +14,11 @@ import (
 )
 
 type Runner struct {
-	Verbose  bool // If true, provides detailed logging.
-	RunCount int  // Number of times to run the tests.
-	UseRace  bool // Enable race detector.
-	FailFast bool // Stop on first test failure.
+	ProjectPath string // Path to the Go project directory.
+	Verbose     bool   // If true, provides detailed logging.
+	RunCount    int    // Number of times to run the tests.
+	UseRace     bool   // Enable race detector.
+	FailFast    bool   // Stop on first test failure.
 }
 
 // RunTests executes the tests for each provided package and aggregates all results.
@@ -58,6 +59,7 @@ func (r *Runner) runTestPackage(testPackage string) ([]byte, bool, error) {
 		log.Printf("Running command: go %s\n", strings.Join(args, " "))
 	}
 	cmd := exec.Command("go", args...)
+	cmd.Dir = r.ProjectPath
 
 	// cmd.Env = append(cmd.Env, "GOFLAGS=-extldflags=-Wl,-ld_classic") // Ensure modules are enabled
 	var out bytes.Buffer


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The modifications enhance the flakeguard tool's functionality by refining how test files changes are detected and how test execution results are handled. The changes aim to provide more accurate and detailed analysis for identifying flaky tests, improving the tool's utility for developers.

## What
- **`tools/flakeguard/cmd/find.go`**
  - Modified `FindChangedFiles` function call to include `projectPath` as an additional argument. This change allows the function to more accurately identify changed test files within the project's scope.
- **`tools/flakeguard/cmd/run.go`**
  - Added a new flag `project-path` to specify the Go project's path, enhancing the flexibility in running tests across different project structures.
  - Updated `Runner` struct initialization to include `ProjectPath`, ensuring test commands are executed in the correct project directory.
- **`tools/flakeguard/git/git.go`**
  - Updated `FindChangedFiles` to accept `rootGoModPath` and utilize a new function `buildExcludeStringForGoModDirs` for excluding directories with a `go.mod` file, except the root if applicable. This optimizes the detection of relevant file changes by considering Go module boundaries.
  - Added `buildExcludeStringForGoModDirs` function to generate exclusion strings for `git diff`, avoiding unnecessary examination of submodules or vendor directories.
- **`tools/flakeguard/reports/reports.go`**
  - Added `Durations` field to `TestResult` struct to store the elapsed time for each test run, providing deeper insights into test performance and potential flakiness.
- **`tools/flakeguard/runner/runner.go`**
  - Included `ProjectPath` in `Runner` struct and adjusted `runTestPackage` to execute tests within the specified project path, ensuring accurate environment and dependency resolution.
  - Enhanced `parseTestResults` to record elapsed time (`Elapsed`) for each test action, contributing to a more comprehensive analysis of test execution.
