### PR TITLE
rebuild CLI URLs dynamically for ever platform, point to latest release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 jobs:
   build-deploy:

--- a/book/src/framework/components/chainlink/node.md
+++ b/book/src/framework/components/chainlink/node.md
@@ -1,1 +1,106 @@
 # Node
+
+Here we provide *full* configuration parameters for `Node`
+
+<div class="warning">
+Here we provide full configuration reference, if you want to copy and run it, please remove all .out fields before!
+</div>
+
+
+## Configuration
+```toml
+[cl_node]
+  # Optional URL for fake data provider URL
+  # usually set up in test with local mock server
+  data_provider_url = "http://example.com"
+
+  [cl_node.db]
+    # PostgreSQL image version and tag
+    image = "postgres:15.6"
+    # Pulls the image every time if set to 'true', used like that in CI. Can be set to 'false' to speed up local runs
+    pull_image = true
+
+  [cl_node.node]
+    # A list of paths to capability binaries
+    capabilities = ["./capability_1", "./capability_2"]
+    # Default capabilities directory inside container
+    capabilities_container_dir = "/home/capabilities"
+    # Image to use, you can either provide "image" or "docker_file" + "docker_ctx" fields
+    image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+    # Path to your Chainlink Dockerfile
+    docker_file = "../../core/chainlink.Dockerfile"
+    # Path to docker context that should be used to build from
+    docker_ctx = "../.."
+    # Optional name for image we build, default is "ctftmp"
+    docker_image_name = "ctftmp"
+    # Pulls the image every time if set to 'true', used like that in CI. Can be set to 'false' to speed up local runs
+    pull_image = true
+    # Overrides Chainlink node TOML configuration
+    # can be multiline, see example
+    user_config_overrides = """
+      [Log]
+      level = 'info'
+      """
+    # Overrides Chainlink node secrets TOML configuration
+    # you can only add fields, overriding existing fields is prohibited by Chainlink node
+    user_secrets_overrides = """
+      [AnotherSecret]
+      mySecret = 'a'
+      """
+
+  # Outputs are the results of deploying a component that can be used by another component
+  [cl_node.out]
+    # If 'use_cache' equals 'true' we skip component setup when we run the test and return the outputs
+    use_cache = true
+    # Describes deployed or external Chainlink node
+    [cl_node.out.node]
+      # Host Docker URLs the test uses
+      # in case of using external component you can replace these URLs with another deployment
+      p2p_url = "http://127.0.0.1:32812"
+      url = "http://127.0.0.1:32847"
+
+    # Describes deployed or external Chainlink node
+    [cl_node.out.postgresql]
+      # PostgreSQL connection string
+      # in case of using external database can be overriden
+      url = "postgresql://chainlink:thispasswordislongenough@127.0.0.1:32846/chainlink?sslmode=disable"
+```
+
+## Usage
+```golang
+package yourpackage_test
+
+import (
+	"fmt"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/clnode"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type Step2Cfg struct {
+	BlockchainA *blockchain.Input `toml:"blockchain_a" validate:"required"`
+	CLNode      *clnode.Input     `toml:"cl_node" validate:"required"`
+}
+
+func TestMe(t *testing.T) {
+	in, err := framework.Load[Step2Cfg](t)
+	require.NoError(t, err)
+
+	bc, err := blockchain.NewBlockchainNetwork(in.BlockchainA)
+	require.NoError(t, err)
+
+	networkCfg, err := clnode.NewNetworkCfgOneNetworkAllNodes(bc)
+	require.NoError(t, err)
+	in.CLNode.Node.TestConfigOverrides = networkCfg
+
+	output, err := clnode.NewNodeWithDB(in.CLNode)
+	require.NoError(t, err)
+
+	t.Run("test something", func(t *testing.T) {
+		fmt.Printf("node url: %s\n", output.Node.HostURL)
+		require.NotEmpty(t, output.Node.HostURL)
+	})
+}
+```

--- a/book/src/framework/getting_started.md
+++ b/book/src/framework/getting_started.md
@@ -6,18 +6,31 @@
 
 ## Test setup
 
-To start writing tests create a directory for your project with `go.mod` and pull the framework
+To start writing tests create a directory for your project with `go.mod` and add a package
 ```
 go get github.com/smartcontractkit/chainlink-testing-framework/framework
 ```
 
-Then download the CLI (runs from the directory where you have `go.mod`)
+Download our [CLI](https://github.com/smartcontractkit/chainlink-testing-framework/releases/tag/framework%2Fv0.1.8)
+
+OS X `arm64` (M1/M2/M3 MacBooks)
 ```
-go get github.com/smartcontractkit/chainlink-testing-framework/framework/cmd && \
-go install github.com/smartcontractkit/chainlink-testing-framework/framework/cmd && \
-mv ~/go/bin/cmd ~/go/bin/ctf
+curl -L https://github.com/smartcontractkit/chainlink-testing-framework/releases/download/framework%2F<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->/framework-<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->-darwin-arm64.tar.gz | tar -xz
 ```
-Or download a binary release [here](https://github.com/smartcontractkit/chainlink-testing-framework/releases/tag/framework%2Fv0.1.7) and rename it to `ctf`
+
+OS X `amd64` (old Intel chips)
+```
+curl -L https://github.com/smartcontractkit/chainlink-testing-framework/releases/download/framework%2F<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->/framework-<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->-darwin-amd64.tar.gz | tar -xz
+```
+Linux `arm64`
+```
+curl -L https://github.com/smartcontractkit/chainlink-testing-framework/releases/download/framework%2F<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->/framework-<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->-linux-arm64.tar.gz | tar -xz
+```
+
+Linux `amd64`
+```
+curl -L https://github.com/smartcontractkit/chainlink-testing-framework/releases/download/framework%2F<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->/framework-<!-- cmdrun git describe --tags --match "framework/v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 | sed 's/^framework\///' -->-linux-amd64.tar.gz | tar -xz
+```
 
 More CLI [docs](./cli.md)
 

--- a/framework/.changeset/v0.1.9.md
+++ b/framework/.changeset/v0.1.9.md
@@ -1,0 +1,2 @@
+- Simplify CLI download, generate URLs for every platform automatically
+- Finalize Node and NodeSet docs


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The pull request updates documentation and simplifies CLI download instructions across different platforms. It finalizes the Node and NodeSet documentation, ensuring users have full configuration parameters and examples at their disposal. Additionally, it aims to make the CLI more accessible by providing direct download links for various operating systems.

## What
- **book/src/framework/components/chainlink/node.md**
  - Added full configuration parameters for `Node` with detailed explanations and default values.
  - Included usage example in Go, demonstrating how to use the configuration in tests.
- **book/src/framework/components/chainlink/nodeset.md**
  - Introduced full configuration parameters for `NodeSet`, similar to `Node` documentation.
  - Added a configuration example for a required Blockchain component.
  - Updated the usage section with a more comprehensive Go example, including blockchain and mock data provider setup.
- **book/src/framework/getting_started.md**
  - Updated the section to add the framework package instead of pulling the framework, reflecting a more streamlined setup process.
  - Replaced the CLI installation steps with download links for specific OS versions, making it easier for users to get started without navigating through the repository.
- **framework/.changeset/v0.1.9.md**
  - Created a new changeset file indicating the simplification of CLI download instructions and the finalization of Node and NodeSet documentation.

These changes ensure users have a clearer understanding of how to configure and utilize Nodes and NodeSets within the testing framework. By providing direct CLI download links for various operating systems, the setup process becomes more straightforward, encouraging more developers to adopt and contribute to the framework.
