### PR TITLE
Flakeguard add more logs and fix parsing stderr

### DIFF
--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -55,6 +55,7 @@ type exitCoder interface {
 // runTests runs the tests for a given package and returns the path to the output file.
 func (r *Runner) runTests(packageName string) (string, bool, error) {
 	args := []string{"test", packageName, "-json", "-count=1"} // Enable JSON output
+	args = append(args, "2>/dev/null")                         // Redirect stderr to null
 	if r.UseRace {
 		args = append(args, "-race")
 	}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates aim to enhance error diagnostics and maintain clean test environments. Redirecting stderr to null in test commands reduces clutter, while capturing context around JSON parsing errors in test outputs aids in troubleshooting.

## What
- **tools/flakeguard/runner/runner.go**
  - Added `"2>/dev/null"` to test command arguments to redirect stderr to null. This keeps the test output cleaner and more focused on the relevant information.
  - Introduced variables `precedingLines` and `followingLines` to capture context around JSON parsing errors in test outputs. This change helps in diagnosing issues by providing up to 15 lines before and after the problematic line.
  - Implemented logic to limit the `precedingLines` array to the last 15 lines, ensuring that only relevant context is kept.
  - Modified the error handling to include `precedingLines` and `followingLines` in the error message when JSON parsing fails, offering a detailed view of the problem area in the test outputs.
