### PR TITLE
Bump go version to 1.23

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,7 @@ linters:
     - unused
     # extra
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - revive
     - goimports
     - gosec

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.21.9
+golang 1.22.3
 nodejs 18.20.3
 k3d 5.6.3
 act 0.2.52

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ golang 1.22.3
 nodejs 18.20.3
 k3d 5.6.3
 act 0.2.52
-golangci-lint 1.57.2
+golangci-lint 1.62.0
 actionlint 1.6.26
 shellcheck 0.9.0
 helm 3.15.2

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712439257,
-        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {

--- a/lib/.changeset/v1.50.15.md
+++ b/lib/.changeset/v1.50.15.md
@@ -1,0 +1,2 @@
+- Bump Dockerfile.base to go 1.23
+- Bump lib/go.mod to go 1.23

--- a/lib/blockchain/blockchain.go
+++ b/lib/blockchain/blockchain.go
@@ -165,7 +165,7 @@ func (h *SafeEVMHeader) UnmarshalJSON(bs []byte) error {
 
 	h.Hash = jsonHead.Hash
 	h.Number = (*big.Int)(jsonHead.Number)
-	h.Timestamp = time.Unix(int64(jsonHead.Timestamp), 0).UTC()
+	h.Timestamp = time.Unix(int64(jsonHead.Timestamp), 0).UTC() //nolint
 	h.BaseFee = (*big.Int)(jsonHead.BaseFee)
 	return nil
 }

--- a/lib/blockchain/celo.go
+++ b/lib/blockchain/celo.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 
@@ -82,6 +83,9 @@ func (e *CeloClient) TransactionOpts(from *EthereumWallet) (*bind.TransactOpts, 
 	nonce, err := e.GetNonce(context.Background(), common.HexToAddress(from.Address()))
 	if err != nil {
 		return nil, err
+	}
+	if nonce > math.MaxInt64 {
+		return nil, fmt.Errorf("nonce value %d exceeds int64 range", nonce)
 	}
 	opts.Nonce = big.NewInt(int64(nonce))
 

--- a/lib/blockchain/ethereum.go
+++ b/lib/blockchain/ethereum.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"regexp"
 	"strconv"
@@ -263,7 +264,11 @@ func (e *EthereumClient) HeaderTimestampByNumber(ctx context.Context, bn *big.In
 	if err != nil {
 		return 0, err
 	}
-	return uint64(h.Timestamp.UTC().Unix()), nil
+	timestamp := h.Timestamp.UTC().Unix()
+	if timestamp < 0 {
+		return 0, fmt.Errorf("negative timestamp value: %d", timestamp)
+	}
+	return uint64(timestamp), nil
 }
 
 // BlockNumber gets latest block number
@@ -539,7 +544,7 @@ func (e *EthereumClient) TransactionOpts(from *EthereumWallet) (*bind.TransactOp
 	if err != nil {
 		return nil, err
 	}
-	opts.Nonce = big.NewInt(int64(nonce))
+	opts.Nonce = big.NewInt(0).SetUint64(nonce)
 
 	if e.NetworkConfig.MinimumConfirmations <= 0 { // Wait for your turn to send on an L2 chain
 		<-e.NonceSettings.registerInstantTransaction(from.Address(), nonce)
@@ -708,7 +713,7 @@ func (e *EthereumClient) WaitForFinalizedTx(txHash common.Hash) (*big.Int, time.
 func (e *EthereumClient) IsTxHeadFinalized(txHdr, header *SafeEVMHeader) (bool, *big.Int, time.Time, error) {
 	if e.NetworkConfig.FinalityDepth > 0 {
 		if header.Number.Cmp(new(big.Int).Add(txHdr.Number,
-			big.NewInt(int64(e.NetworkConfig.FinalityDepth)))) > 0 {
+			big.NewInt(0).SetUint64(e.NetworkConfig.FinalityDepth))) > 0 {
 			return true, header.Number, header.Timestamp, nil
 		}
 		return false, nil, time.Time{}, nil
@@ -1058,8 +1063,6 @@ func (e *EthereumClient) WaitForEvents() error {
 	g := errgroup.Group{}
 
 	for subName, sub := range queuedEvents {
-		subName := subName
-		sub := sub
 		g.Go(func() error {
 			defer func() {
 				// if the subscription is complete, delete it from the queue
@@ -1100,6 +1103,9 @@ func (e *EthereumClient) GetLatestFinalizedBlockHeader(ctx context.Context) (*ty
 	}
 	latestBlockNumber := header.Number.Uint64()
 	finalizedBlockNumber := latestBlockNumber - e.NetworkConfig.FinalityDepth
+	if finalizedBlockNumber > math.MaxInt64 {
+		return nil, fmt.Errorf("finalized block number %d exceeds int64 range", finalizedBlockNumber)
+	}
 	return e.Client.HeaderByNumber(ctx, big.NewInt(int64(finalizedBlockNumber)))
 }
 
@@ -1121,7 +1127,7 @@ func (e *EthereumClient) EstimatedFinalizationTime(ctx context.Context) (time.Du
 	if e.NetworkConfig.FinalityDepth == 0 {
 		return 0, fmt.Errorf("finality depth is 0 and finality tag is not enabled")
 	}
-	timeBetween := time.Duration(e.NetworkConfig.FinalityDepth) * blckTime
+	timeBetween := time.Duration(e.NetworkConfig.FinalityDepth) * blckTime //nolint
 	e.l.Info().
 		Str("Time", timeBetween.String()).
 		Str("Network", e.GetNetworkName()).
@@ -1159,7 +1165,7 @@ func (e *EthereumClient) TimeBetweenFinalizedBlocks(ctx context.Context, maxTime
 				return 0, err
 			}
 			if nextFinalizedHeader.Number.Cmp(currentFinalizedHeader.Number) > 0 {
-				timeBetween := time.Unix(int64(nextFinalizedHeader.Time), 0).Sub(time.Unix(int64(currentFinalizedHeader.Time), 0))
+				timeBetween := time.Unix(int64(nextFinalizedHeader.Time), 0).Sub(time.Unix(int64(currentFinalizedHeader.Time), 0)) //nolint
 				e.l.Info().
 					Str("Time", timeBetween.String()).
 					Str("Network", e.GetNetworkName()).
@@ -1190,24 +1196,24 @@ func (e *EthereumClient) AvgBlockTime(ctx context.Context) (time.Duration, error
 	}
 	totalTime := time.Duration(0)
 	var previousHeader *types.Header
-	previousHeader, err = e.Client.HeaderByNumber(ctx, big.NewInt(int64(startBlockNumber-1)))
+	previousHeader, err = e.Client.HeaderByNumber(ctx, big.NewInt(int64(startBlockNumber-1))) //nolint
 	if err != nil {
 		return totalTime, err
 	}
 	for i := startBlockNumber; i <= latestBlockNumber; i++ {
-		hdr, err := e.Client.HeaderByNumber(ctx, big.NewInt(int64(i)))
+		hdr, err := e.Client.HeaderByNumber(ctx, big.NewInt(int64(i))) //nolint
 		if err != nil {
 			return totalTime, err
 		}
 
-		blockTime := time.Unix(int64(hdr.Time), 0)
-		previousBlockTime := time.Unix(int64(previousHeader.Time), 0)
+		blockTime := time.Unix(int64(hdr.Time), 0)                    //nolint
+		previousBlockTime := time.Unix(int64(previousHeader.Time), 0) //nolint
 		blockDuration := blockTime.Sub(previousBlockTime)
 		totalTime += blockDuration
 		previousHeader = hdr
 	}
 
-	averageBlockTime := totalTime / time.Duration(numBlocks)
+	averageBlockTime := totalTime / time.Duration(numBlocks) //nolint
 
 	return averageBlockTime, nil
 }
@@ -1730,7 +1736,6 @@ func (e *EthereumMultinodeClient) DeleteHeaderEventSubscription(key string) {
 func (e *EthereumMultinodeClient) WaitForEvents() error {
 	g := errgroup.Group{}
 	for _, c := range e.Clients {
-		c := c
 		g.Go(func() error {
 			return c.WaitForEvents()
 		})

--- a/lib/blockchain/transaction_confirmers.go
+++ b/lib/blockchain/transaction_confirmers.go
@@ -453,7 +453,7 @@ func (e *EthereumClient) backfillMissedBlocks(lastBlockSeen uint64, headerChanne
 		Uint64("Latest Block", latestBlockNumber).
 		Msg("Backfilling missed blocks since RPC connection issues")
 	for i := lastBlockSeen + 1; i <= latestBlockNumber; i++ {
-		header, err := e.HeaderByNumber(context.Background(), big.NewInt(int64(i)))
+		header, err := e.HeaderByNumber(context.Background(), big.NewInt(int64(i))) //nolint
 		if err != nil {
 			e.l.Err(err).Uint64("Number", i).Msg("Error getting header, unable to backfill and process it")
 			return
@@ -492,7 +492,6 @@ func (e *EthereumClient) receiveHeader(header *SafeEVMHeader) error {
 
 	g := errgroup.Group{}
 	for _, sub := range subs {
-		sub := sub
 		g.Go(func() error {
 			return sub.ReceiveHeader(safeHeader)
 		})

--- a/lib/client/rpc_suite_test.go
+++ b/lib/client/rpc_suite_test.go
@@ -1,3 +1,4 @@
+// nolint
 package client
 
 import (

--- a/lib/client/rpc_test.go
+++ b/lib/client/rpc_test.go
@@ -1,3 +1,4 @@
+// nolint
 package client
 
 import (

--- a/lib/config/network.go
+++ b/lib/config/network.go
@@ -90,21 +90,21 @@ func (n *NetworkConfig) OverrideURLsAndKeysFromEVMNetwork() {
 		return
 	}
 	for name, evmNetwork := range n.EVMNetworks {
-		if evmNetwork.URLs != nil && len(evmNetwork.URLs) > 0 {
+		if len(evmNetwork.URLs) > 0 {
 			logging.L.Warn().Str("network", name).Msg("found URLs in EVMNetwork. overriding RPC URLs in RpcWsUrls with EVMNetwork URLs")
 			if n.RpcWsUrls == nil {
 				n.RpcWsUrls = make(map[string][]string)
 			}
 			n.RpcWsUrls[name] = evmNetwork.URLs
 		}
-		if evmNetwork.HTTPURLs != nil && len(evmNetwork.HTTPURLs) > 0 {
+		if len(evmNetwork.HTTPURLs) > 0 {
 			logging.L.Warn().Str("network", name).Msg("found HTTPURLs in EVMNetwork. overriding RPC URLs in RpcHttpUrls with EVMNetwork HTTP URLs")
 			if n.RpcHttpUrls == nil {
 				n.RpcHttpUrls = make(map[string][]string)
 			}
 			n.RpcHttpUrls[name] = evmNetwork.HTTPURLs
 		}
-		if evmNetwork.PrivateKeys != nil && len(evmNetwork.PrivateKeys) > 0 {
+		if len(evmNetwork.PrivateKeys) > 0 {
 			logging.L.Warn().Str("network", name).Msg("found PrivateKeys in EVMNetwork. overriding wallet keys in WalletKeys with EVMNetwork private keys")
 			if n.WalletKeys == nil {
 				n.WalletKeys = make(map[string][]string)

--- a/lib/config/testconfig_test.go
+++ b/lib/config/testconfig_test.go
@@ -218,7 +218,7 @@ func TestValidateNetworkConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // capture range variable
+		tc := tc //nolint capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.networkConfig.Validate()
 			if tc.expectedError != nil {

--- a/lib/docker/test_env/killgrave_test.go
+++ b/lib/docker/test_env/killgrave_test.go
@@ -1,3 +1,4 @@
+// nolint
 package test_env
 
 import (

--- a/lib/gauntlet/gauntlet.go
+++ b/lib/gauntlet/gauntlet.go
@@ -154,7 +154,7 @@ func (g *Gauntlet) ExecCommandWithRetries(args []string, options ExecCommandOpti
 		},
 		retry.Delay(options.RetryDelay),
 		retry.MaxDelay(options.RetryDelay),
-		retry.Attempts(uint(options.RetryCount)),
+		retry.Attempts(uint(options.RetryCount)), //nolint
 	)
 
 	return output, err

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-testing-framework/lib
 
-go 1.22.5
+go 1.23
 
 require (
 	dario.cat/mergo v1.0.1

--- a/lib/k8s/Dockerfile.base
+++ b/lib/k8s/Dockerfile.base
@@ -1,5 +1,5 @@
 # base test for all k8s test runs
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 
 ARG BASE_URL
 ARG HELM_VERSION

--- a/lib/logstream/logstream.go
+++ b/lib/logstream/logstream.go
@@ -259,7 +259,7 @@ func (m *LogStream) ConnectContainer(ctx context.Context, container LogProducing
 						startErr := retry.Do(func() error {
 							return container.StartLogProducer(ctx, tc.WithLogProductionTimeout(timeout))
 						},
-							retry.Attempts(uint(retryLimit)),
+							retry.Attempts(uint(retryLimit)), //nolint
 							retry.Delay(1*time.Second),
 							retry.OnRetry(func(n uint, err error) {
 								m.log.Info().
@@ -298,7 +298,7 @@ func (m *LogStream) ConnectContainer(ctx context.Context, container LogProducing
 				return
 			}
 		}
-	}(cons.logListeningDone, m.loggingConfig.LogStream.LogProducerTimeout.Duration, int(*m.loggingConfig.LogStream.LogProducerRetryLimit))
+	}(cons.logListeningDone, m.loggingConfig.LogStream.LogProducerTimeout.Duration, int(*m.loggingConfig.LogStream.LogProducerRetryLimit)) //nolint
 
 	return err
 }

--- a/lib/logstream/logstream_test.go
+++ b/lib/logstream/logstream_test.go
@@ -1,3 +1,4 @@
+// nolint
 package logstream_test
 
 import (

--- a/lib/networks/known_networks_test.go
+++ b/lib/networks/known_networks_test.go
@@ -1,3 +1,4 @@
+// nolint
 package networks
 
 import (
@@ -82,10 +83,6 @@ func TestVariousNetworkConfig(t *testing.T) {
 	}
 	httpOnlyNetwork := newNetwork
 	httpOnlyNetwork.URLs = nil
-	forkedNetwork := newNetwork
-	forkedNetwork.HTTPURLs = nil
-	forkedNetwork.URLs = nil
-	forkedNetwork.PrivateKeys = nil
 	t.Cleanup(func() {
 		ArbitrumGoerli.URLs = []string{}
 		ArbitrumGoerli.HTTPURLs = []string{}

--- a/lib/utils/seth/seth.go
+++ b/lib/utils/seth/seth.go
@@ -257,10 +257,10 @@ func ValidateSethNetworkConfig(cfg *pkg_seth.Network) error {
 	if cfg == nil {
 		return errors.New("network cannot be nil")
 	}
-	if cfg.URLs == nil || len(cfg.URLs) == 0 {
+	if len(cfg.URLs) == 0 {
 		return errors.New("URLs are required")
 	}
-	if cfg.PrivateKeys == nil || len(cfg.PrivateKeys) == 0 {
+	if len(cfg.PrivateKeys) == 0 {
 		return errors.New("PrivateKeys are required")
 	}
 	if cfg.TransferGasFee == 0 {

--- a/lib/utils/seth/seth_test.go
+++ b/lib/utils/seth/seth_test.go
@@ -196,7 +196,7 @@ func TestMergeSethAndEvmNetworkConfigs(t *testing.T) {
 
 	// Run test cases
 	for _, tc := range testCases {
-		tc := tc // capture range variable
+		tc := tc //nolint capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			mergedConfig, err := seth.MergeSethAndEvmNetworkConfigs(tc.evmNetwork, tc.sethConfig)
 

--- a/seth/.golangci.yml
+++ b/seth/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - unused
     # extra
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - revive
     - goimports
     - gosec

--- a/seth/block_stats.go
+++ b/seth/block_stats.go
@@ -73,7 +73,6 @@ func (cs *BlockStats) Stats(startBlock *big.Int, endBlock *big.Int) error {
 	blockMu := &sync.Mutex{}
 	eg := &errgroup.Group{}
 	for bn := startBlock.Int64(); bn < endBlock.Int64(); bn++ {
-		bn := bn
 		eg.Go(func() error {
 			cs.Limiter.Take()
 			block, err := cs.Client.Client.BlockByNumber(context.Background(), big.NewInt(bn))

--- a/seth/client.go
+++ b/seth/client.go
@@ -370,7 +370,6 @@ func NewClientRaw(
 		eg, egCtx := errgroup.WithContext(ctx)
 		// root key is element 0 in ephemeral
 		for _, addr := range c.Addresses[1:] {
-			addr := addr
 			eg.Go(func() error {
 				return c.TransferETHFromKey(egCtx, 0, addr.Hex(), bd.AddrFunding, gasPrice)
 			})

--- a/seth/client_api_test.go
+++ b/seth/client_api_test.go
@@ -230,7 +230,6 @@ func TestAPIKeys(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			for i := 1; i < 61; i++ {
-				i := i
 				wg.Add(1)
 				go func() {
 					defer wg.Done()

--- a/seth/client_api_test.go
+++ b/seth/client_api_test.go
@@ -231,13 +231,13 @@ func TestAPIKeys(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			for i := 1; i < 61; i++ {
 				wg.Add(1)
-				go func() {
+				go func(i int) {
 					defer wg.Done()
 					_, err := c.Decode(
 						TestEnv.DebugContract.AddCounter(c.NewTXKeyOpts(i), big.NewInt(0), big.NewInt(1)),
 					)
 					require.NoError(t, err)
-				}()
+				}(i)
 			}
 			wg.Wait()
 			for i := 1; i < 61; i++ {

--- a/seth/contract_store.go
+++ b/seth/contract_store.go
@@ -50,8 +50,7 @@ func (c *ContractStore) GetAllABIs() []*abi.ABI {
 
 	var allABIs []*abi.ABI
 	for _, a := range c.ABIs {
-		alias := a
-		allABIs = append(allABIs, &alias)
+		allABIs = append(allABIs, &a)
 	}
 
 	return allABIs

--- a/seth/contract_store.go
+++ b/seth/contract_store.go
@@ -50,7 +50,8 @@ func (c *ContractStore) GetAllABIs() []*abi.ABI {
 
 	var allABIs []*abi.ABI
 	for _, a := range c.ABIs {
-		allABIs = append(allABIs, &a)
+		aCopy := a //nolint
+		allABIs = append(allABIs, &aCopy)
 	}
 
 	return allABIs

--- a/seth/examples_wasp/go.mod
+++ b/seth/examples_wasp/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-testing-framework/examples_wasp
 
-go 1.22.5
+go 1.23.3
 
 require (
 	github.com/ethereum/go-ethereum v1.13.8

--- a/seth/keyfile.go
+++ b/seth/keyfile.go
@@ -55,7 +55,7 @@ func ReturnFunds(c *Client, toAddr string) error {
 	}
 
 	for i := 1; i < len(c.Addresses); i++ {
-		idx := i
+		idx := i //nolint
 		eg.Go(func() error {
 			ctx, balanceCancel := context.WithTimeout(egCtx, c.Cfg.Network.TxnTimeout.Duration())
 			balance, err := c.Client.BalanceAt(ctx, c.Addresses[idx], nil)

--- a/seth/shell.nix
+++ b/seth/shell.nix
@@ -5,7 +5,7 @@ pkgs.mkShell {
     foundry-bin
     go-ethereum
     solc-select
-    go
+    go_1_21
     gopls
     delve
     gotools

--- a/seth/test_utils/client.go
+++ b/seth/test_utils/client.go
@@ -52,7 +52,6 @@ func NewClientWithAddresses(t *testing.T, addressCount int, funding *big.Int) *s
 	eg, egCtx := errgroup.WithContext(ctx)
 	// root key is element 0 in ephemeral
 	for _, addr := range addresses {
-		addr := addr
 		eg.Go(func() error {
 			return c.TransferETHFromKey(egCtx, 0, addr, funding, gasPrice)
 		})

--- a/seth/tracing.go
+++ b/seth/tracing.go
@@ -549,12 +549,11 @@ func (t *Tracer) checkForMissingCalls(trace Trace) []*DecodedCall {
 
 		for _, missingSig := range missingSignatures {
 			byteSignature := common.Hex2Bytes(strings.TrimPrefix(missingSig, "0x"))
-			humanName := missingSig
 
 			abiResult, err := t.ABIFinder.FindABIByMethod(UNKNOWN, byteSignature)
 			if err != nil {
 				L.Info().
-					Str("Signature", humanName).
+					Str("Signature", missingSig).
 					Msg("Method not found in any ABI instance. Unable to provide any more tracing information")
 
 				missedCalls = append(missedCalls, unknownCall)
@@ -569,7 +568,7 @@ func (t *Tracer) checkForMissingCalls(trace Trace) []*DecodedCall {
 
 			missedCalls = append(missedCalls, &DecodedCall{
 				CommonData: CommonData{
-					Signature: humanName,
+					Signature: missingSig,
 					Method:    abiResult.Method.Name,
 					Input:     map[string]interface{}{"warning": NO_DATA},
 					Output:    map[string]interface{}{"warning": NO_DATA},

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs, scriptDir }:
 with pkgs;
 let
-  go = pkgs.go_1_21;
+  go = pkgs.go_1_23;
   postgresql = postgresql_15;
   nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override { inherit nodejs; };

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs, scriptDir }:
 with pkgs;
 let
-  go = pkgs.go_1_23;
+  go = pkgs.go_1_21;
   postgresql = postgresql_15;
   nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override { inherit nodejs; };

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,6 @@
 { pkgs, scriptDir }:
 with pkgs;
 let
-  go = pkgs.go_1_21;
   postgresql = postgresql_15;
   nodejs = nodejs-18_x;
   nodePackages = pkgs.nodePackages.override { inherit nodejs; };

--- a/wasp/flake.lock
+++ b/wasp/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707092692,
-        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the Go language version from 1.22 to 1.23 in both the `go.mod` file and the Docker base image for Kubernetes tests, ensuring compatibility with the latest Go features and improvements.

## What
- **`lib/go.mod`**  
  - Updated the Go version from `1.22.5` to `1.23`. This change will ensure the module uses the latest Go version for compatibility and performance improvements.
- **`lib/k8s/Dockerfile.base`**  
  - Updated the base Docker image from `golang:1.22-bullseye` to `golang:1.23-bullseye`. This ensures the Kubernetes tests run with the updated Go version, aligning the development environment with the module's Go version requirement.
