### PR TITLE
control anvil block speed example

### DIFF
--- a/book/src/framework/components/configuration.md
+++ b/book/src/framework/components/configuration.md
@@ -35,11 +35,10 @@ In `TOML`:
 ```
 [blockchain_a]
 chain_id = "31337"
-docker_cmd_params = ["--block-time=1"]
-image = "f4hrenh9it/foundry"
+image = "f4hrenh9it/foundry:latest"
 port = "8500"
-tag = "latest"
 type = "anvil"
+docker_cmd_params = ["-b", "1"]
 ```
 
 ### Best practices for configuration and validation

--- a/book/src/framework/connecting_chainlink_node.md
+++ b/book/src/framework/connecting_chainlink_node.md
@@ -9,6 +9,8 @@ Create your configuration in `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
+
 
 [cl_node]
 

--- a/book/src/framework/first_test.md
+++ b/book/src/framework/first_test.md
@@ -11,6 +11,7 @@ Create your configuration in `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 ```
 
 Create your test in `smoke_test.go`

--- a/book/src/framework/nodeset_capabilities.md
+++ b/book/src/framework/nodeset_capabilities.md
@@ -21,6 +21,7 @@ Create a configuration file `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [nodeset]
   nodes = 5

--- a/book/src/framework/nodeset_compatibility.md
+++ b/book/src/framework/nodeset_compatibility.md
@@ -9,6 +9,7 @@ Create a configuration file `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [nodeset]
   nodes = 5

--- a/book/src/framework/nodeset_docker_rebuild.md
+++ b/book/src/framework/nodeset_docker_rebuild.md
@@ -9,6 +9,7 @@ Create a configuration file `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [nodeset]
   nodes = 5

--- a/book/src/framework/nodeset_environment.md
+++ b/book/src/framework/nodeset_environment.md
@@ -9,6 +9,8 @@ Create a configuration file `smoke.toml`
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
+
 
 [nodeset]
   nodes = 5

--- a/framework/.changeset/v0.2.9.md
+++ b/framework/.changeset/v0.2.9.md
@@ -1,0 +1,2 @@
+- Zero seconds block and anvil mining control example
+- (Bug-fix) Always remove container registry if stopped

--- a/framework/CONFIGURATION.md
+++ b/framework/CONFIGURATION.md
@@ -35,11 +35,10 @@ In `TOML`:
 ```
 [blockchain_a]
 chain_id = "31337"
-docker_cmd_params = ["--block-time=1"]
-image = "f4hrenh9it/foundry"
+image = "f4hrenh9it/foundry:latest"
 port = "8500"
-tag = "latest"
 type = "anvil"
+docker_cmd_params = ["-b", "1"]
 ```
 
 ### Best practices for configuration and validation

--- a/framework/components/blockchain/anvil.go
+++ b/framework/components/blockchain/anvil.go
@@ -20,7 +20,7 @@ const (
 func deployAnvil(in *Input) (*Output, error) {
 	ctx := context.Background()
 	entryPoint := []string{"anvil"}
-	defaultCmd := []string{"--host", "0.0.0.0", "--port", in.Port, "--chain-id", in.ChainID, "-b", "1"}
+	defaultCmd := []string{"--host", "0.0.0.0", "--port", in.Port, "--chain-id", in.ChainID}
 	entryPoint = append(entryPoint, defaultCmd...)
 	entryPoint = append(entryPoint, in.DockerCmdParamsOverrides...)
 	framework.L.Info().Any("Cmd", strings.Join(entryPoint, " ")).Msg("Creating anvil with command")

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -76,6 +76,9 @@ func BuildAndPublishLocalDockerImage(once *sync.Once, dockerfile string, buildCo
 		if registryRunning {
 			fmt.Println("Local registry container is already running.")
 		} else {
+			L.Info().Msg("Removing local registry")
+			_ = runCommand("docker", "stop", "local-registry")
+			_ = runCommand("docker", "rm", "local-registry")
 			L.Info().Msg("Starting local registry container...")
 			err := runCommand("docker", "run", "-d", "-p", "5050:5000", "--name", "local-registry", "registry:2")
 			if err != nil {

--- a/framework/examples/myproject/chaos.toml
+++ b/framework/examples/myproject/chaos.toml
@@ -4,6 +4,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [data_provider]
   port = 9111

--- a/framework/examples/myproject/example_components/onchain/deployment.go
+++ b/framework/examples/myproject/example_components/onchain/deployment.go
@@ -1,12 +1,9 @@
 package onchain
 
 import (
-	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/ethereum/go-ethereum/common"
 	testToken "github.com/smartcontractkit/chainlink-testing-framework/framework/examples/example_components/gethwrappers"
 	"math/big"
-	"time"
-
-	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/seth"
 )
@@ -21,25 +18,12 @@ type Output struct {
 	Addresses []common.Address `toml:"addresses"`
 }
 
-func NewProductOnChainDeployment(in *Input) (*Output, error) {
+func NewProductOnChainDeployment(c *seth.Client, in *Input) (*Output, error) {
 	if in.Out != nil && in.Out.UseCache {
 		return in.Out, nil
 	}
 
 	// deploy your contracts here, example
-
-	t := seth.Duration{D: 2 * time.Minute}
-
-	c, err := seth.NewClientBuilder().
-		WithRpcUrl(in.URL).
-		WithProtections(true, false, &t).
-		WithGasPriceEstimations(true, 0, seth.Priority_Fast).
-		WithTracing(seth.TracingLevel_All, []string{seth.TraceOutput_Console}).
-		WithPrivateKeys([]string{blockchain.DefaultAnvilPrivateKey}).
-		Build()
-	if err != nil {
-		return nil, err
-	}
 
 	contractABI, err := testToken.BurnMintERC677MetaData.GetAbi()
 	if err != nil {
@@ -64,6 +48,6 @@ func NewProductOnChainDeployment(in *Input) (*Output, error) {
 		// save all the addresses to output, so it can be cached
 		Addresses: []common.Address{dd.Address},
 	}
-	in.Out = out
+	//in.Out = out
 	return out, nil
 }

--- a/framework/examples/myproject/fork.toml
+++ b/framework/examples/myproject/fork.toml
@@ -7,6 +7,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [blockchain_src]
   chain_id = "3337"
@@ -14,3 +15,4 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8555"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]

--- a/framework/examples/myproject/fork_plus_offchain.toml
+++ b/framework/examples/myproject/fork_plus_offchain.toml
@@ -7,6 +7,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+ docker_cmd_params = ["-b", "1"]
 
 [blockchain_src]
   chain_id = "3337"
@@ -14,7 +15,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8555"
   type = "anvil"
-
+  docker_cmd_params = ["-b", "1"]
 
 [nodeset]
   nodes = 5

--- a/framework/examples/myproject/fork_plus_offchain_test.go
+++ b/framework/examples/myproject/fork_plus_offchain_test.go
@@ -81,10 +81,10 @@ func TestOffChainAndFork(t *testing.T) {
 	// deploy 2 example product contracts
 	// you should replace it with chainlink-deployments
 	in.ContractsSrc.URL = bcSrc.Nodes[0].HostWSUrl
-	contractsSrc, err := onchain.NewProductOnChainDeployment(in.ContractsSrc)
+	contractsSrc, err := onchain.NewProductOnChainDeployment(scSrc, in.ContractsSrc)
 	require.NoError(t, err)
 	in.ContractsDst.URL = bcDst.Nodes[0].HostWSUrl
-	contractsDst, err := onchain.NewProductOnChainDeployment(in.ContractsDst)
+	contractsDst, err := onchain.NewProductOnChainDeployment(scDst, in.ContractsDst)
 	require.NoError(t, err)
 
 	t.Run("test some contracts with fork", func(t *testing.T) {

--- a/framework/examples/myproject/fork_test.go
+++ b/framework/examples/myproject/fork_test.go
@@ -47,10 +47,10 @@ func TestFork(t *testing.T) {
 	// deploy 2 example product contracts
 	// you can replace it with chainlink-deployments
 	in.ContractsSrc.URL = bcSrc.Nodes[0].HostWSUrl
-	contractsSrc, err := onchain.NewProductOnChainDeployment(in.ContractsSrc)
+	contractsSrc, err := onchain.NewProductOnChainDeployment(scSrc, in.ContractsSrc)
 	require.NoError(t, err)
 	in.ContractsDst.URL = bcDst.Nodes[0].HostWSUrl
-	contractsDst, err := onchain.NewProductOnChainDeployment(in.ContractsDst)
+	contractsDst, err := onchain.NewProductOnChainDeployment(scDst, in.ContractsDst)
 	require.NoError(t, err)
 
 	t.Run("test some contracts with fork", func(t *testing.T) {

--- a/framework/examples/myproject/quick-deploy.toml
+++ b/framework/examples/myproject/quick-deploy.toml
@@ -1,0 +1,7 @@
+[contracts_src]
+
+[blockchain_src]
+  chain_id = "3337"
+  image = "f4hrenh9it/foundry:latest"
+  port = "8545"
+  type = "anvil"

--- a/framework/examples/myproject/quick_deploy_test.go
+++ b/framework/examples/myproject/quick_deploy_test.go
@@ -1,0 +1,59 @@
+package examples
+
+import (
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/examples/example_components/onchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/rpc"
+	"github.com/stretchr/testify/require"
+	"math/big"
+	"testing"
+	"time"
+)
+
+type CfgQuickDeploy struct {
+	ContractsSrc  *onchain.Input    `toml:"contracts_src" validate:"required"`
+	BlockchainSrc *blockchain.Input `toml:"blockchain_src" validate:"required"`
+}
+
+func randAddr() (string, error) {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		return "", err
+	}
+	publicKey := privateKey.PublicKey
+	address := crypto.PubkeyToAddress(publicKey).Hex()
+	return address, nil
+}
+
+func TestQuickDeploy(t *testing.T) {
+	in, err := framework.Load[CfgQuickDeploy](t)
+	require.NoError(t, err)
+
+	// spin up 2 anvils
+	bcSrc, err := blockchain.NewBlockchainNetwork(in.BlockchainSrc)
+	require.NoError(t, err)
+
+	// deploy 2 example product contracts
+	// you can replace it with chainlink-deployments
+	in.ContractsSrc.URL = bcSrc.Nodes[0].HostWSUrl
+	c, err := ethclient.Dial(bcSrc.Nodes[0].HostWSUrl)
+	require.NoError(t, err)
+
+	t.Run("test some contracts with fork", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			ra, err := randAddr()
+			require.NoError(t, err)
+			err = simple_node_set.SendETH(c, blockchain.DefaultAnvilPrivateKey, ra, big.NewFloat(0.1))
+			require.NoError(t, err)
+		}
+		t.Log("now mining")
+
+		miner := rpc.NewRemoteAnvilMiner(bcSrc.Nodes[0].HostHTTPUrl, nil)
+		miner.MinePeriodically(200 * time.Millisecond)
+		time.Sleep(10 * time.Second)
+	})
+}

--- a/framework/examples/myproject/quick_deploy_test.go
+++ b/framework/examples/myproject/quick_deploy_test.go
@@ -43,7 +43,7 @@ func TestQuickDeploy(t *testing.T) {
 	c, err := ethclient.Dial(bcSrc.Nodes[0].HostWSUrl)
 	require.NoError(t, err)
 
-	t.Run("test some contracts with fork", func(t *testing.T) {
+	t.Run("make 100 transactions with 0s blocks then control the speed", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			ra, err := randAddr()
 			require.NoError(t, err)

--- a/framework/examples/myproject/scalability.toml
+++ b/framework/examples/myproject/scalability.toml
@@ -4,6 +4,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [data_provider]
   port = 9111

--- a/framework/examples/myproject/smoke.toml
+++ b/framework/examples/myproject/smoke.toml
@@ -4,6 +4,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [data_provider]
   port = 9111

--- a/framework/examples/myproject/upgrade.toml
+++ b/framework/examples/myproject/upgrade.toml
@@ -4,6 +4,7 @@
   image = "f4hrenh9it/foundry:latest"
   port = "8545"
   type = "anvil"
+  docker_cmd_params = ["-b", "1"]
 
 [data_provider]
   port = 9111

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -2,6 +2,8 @@ module github.com/smartcontractkit/chainlink-testing-framework/framework
 
 go 1.22
 
+replace github.com/smartcontractkit/chainlink-testing-framework/seth => ../seth
+
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.39
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.33.3


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes made improve the blockchain simulation environment by refining the anvil deployment process, enhancing the Docker image handling, and updating the contract deployment logic for testing purposes. These modifications streamline the setup and teardown processes for test environments, making it easier for developers to create and manage blockchain simulations.

## What
- **framework/.changeset/v0.2.9.md**
  - Added notes about zero seconds block and anvil mining control example, and a bug-fix related to always removing container registry if stopped.
- **framework/components/blockchain/anvil.go**
  - Removed block time `-b "1"` parameter from anvil deployment to allow for zero-second block times.
- **framework/docker.go**
  - Added commands to remove the local registry container before starting a new one to ensure a clean environment.
- **framework/examples/myproject/example_components/onchain/deployment.go**
  - Refactored `NewProductOnChainDeployment` to accept `*seth.Client` directly and removed unused time and blockchain imports.
- **framework/examples/myproject/fork_plus_offchain_test.go & fork_test.go**
  - Updated `NewProductOnChainDeployment` calls to pass `*seth.Client` according to the new function signature.
- **framework/examples/myproject/quick-deploy.toml**
  - New configuration file added for quick deployment settings.
- **framework/examples/myproject/quick_deploy_test.go**
  - New test file added demonstrating how to make transactions with 0s blocks and control mining speed.
- **framework/go.mod**
  - Added a replace directive for `github.com/smartcontractkit/chainlink-testing-framework/seth` to point to a local path, facilitating local development and testing.
