### PR TITLE
retract some more lib tags

### DIFF
--- a/go.md
+++ b/go.md
@@ -8,6 +8,7 @@ flowchart LR
 	chainlink-testing-framework/framework
 	click chainlink-testing-framework/framework href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/framework/examples --> chainlink-testing-framework/framework
+	chainlink-testing-framework/framework/examples --> chainlink-testing-framework/seth
 	chainlink-testing-framework/framework/examples --> chainlink-testing-framework/wasp
 	click chainlink-testing-framework/framework/examples href "https://github.com/smartcontractkit/chainlink-testing-framework"
 	chainlink-testing-framework/grafana

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -329,6 +329,6 @@ require (
 retract (
 	// all of these tags were used, when testing new structure of the repository and by no mean represent latest versions
 	[v1.999.0-test-release, v1.999.999-test-release]
-	[v1.99.1, v1.99.3]
+	[v1.99.1, v1.99.9]
 	v1.50.0
 )

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -327,6 +327,8 @@ require (
 )
 
 retract (
+	// all of these tags were used, when testing new structure of the repository and by no mean represent latest versions
 	[v1.999.0-test-release, v1.999.999-test-release]
+	[v1.99.1, v1.99.3]
 	v1.50.0
 )


### PR DESCRIPTION
why?
I saw some workflows downloading them :/
```
go: downloading github.com/smartcontractkit/chainlink-testing-framework/lib v1.99.4-0.20240903123107-cd7909d3e9fb
```
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates enhance the documentation and dependencies management of the project. By adding new links and dependencies in the documentation, it aids in the navigation and understanding of the project's structure. Retracting specific versions in `go.mod` clarifies the project's versioning strategy, ensuring that test versions are not mistaken for production-ready releases.

## What
- **go.md**
  - Added a new dependency link between `chainlink-testing-framework/framework/examples` and `chainlink-testing-framework/seth`. This change highlights an additional relationship within the project's components, making the framework's structure clearer.
- **lib/go.md**
  - Created a new file, indicating an expansion or restructuring of the project's documentation or modules. The exact purpose of the file is not detailed, but its creation signifies growth or modification.
- **lib/go.mod**
  - Added comments to the `retract` directive for versions `[v1.999.0-test-release, v1.999.999-test-release]` and `[v1.99.1, v1.99.9]`. These comments explain the reasons behind retracting these versions, specifically that they were used for testing the new structure of the repository and do not represent the latest versions. This clarification is crucial for maintaining the integrity and clarity of the versioning system.
