### PR TITLE
flakeguard: Add tests for codeowners and cmd to find tests in go project without owners

### DIFF
--- a/tools/flakeguard/cmd/check_test_owners.go
+++ b/tools/flakeguard/cmd/check_test_owners.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/codeowners"
+	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/reports"
+	"github.com/spf13/cobra"
+)
+
+var (
+	codeownersPath     string
+	printTestFunctions bool
+)
+
+// CheckTestOwnersCmd checks which tests lack code owners
+var CheckTestOwnersCmd = &cobra.Command{
+	Use:   "check-test-owners",
+	Short: "Check which tests in the project do not have code owners",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Scan project for test functions
+		testFileMap, err := reports.ScanTestFiles(projectPath)
+		if err != nil {
+			log.Fatalf("Error scanning test files: %v", err)
+		}
+
+		// Parse CODEOWNERS file
+		codeOwnerPatterns, err := codeowners.Parse(codeownersPath)
+		if err != nil {
+			log.Fatalf("Error parsing CODEOWNERS file: %v", err)
+		}
+
+		// Check for tests without code owners
+		testsWithoutOwners := make(map[string]string) // Map of test names to their relative paths
+		for testName, filePath := range testFileMap {
+			relFilePath, err := filepath.Rel(projectPath, filePath)
+			if err != nil {
+				fmt.Printf("Error getting relative path for test %s: %v\n", testName, err)
+				continue
+			}
+			// Convert to Unix-style path for matching
+			relFilePath = filepath.ToSlash(relFilePath)
+
+			owners := codeowners.FindOwners(relFilePath, codeOwnerPatterns)
+			if len(owners) == 0 {
+				testsWithoutOwners[testName] = relFilePath
+			}
+		}
+
+		// Calculate percentages
+		totalTests := len(testFileMap)
+		totalWithoutOwners := len(testsWithoutOwners)
+		totalWithOwners := totalTests - totalWithoutOwners
+
+		percentageWithOwners := float64(totalWithOwners) / float64(totalTests) * 100
+		percentageWithoutOwners := float64(totalWithoutOwners) / float64(totalTests) * 100
+
+		// Report results
+		fmt.Printf("Total Test functions found: %d\n", totalTests)
+		fmt.Printf("Test functions with owners: %d (%.2f%%)\n", totalWithOwners, percentageWithOwners)
+		fmt.Printf("Test functions without owners: %d (%.2f%%)\n", totalWithoutOwners, percentageWithoutOwners)
+
+		if printTestFunctions {
+
+			if totalWithoutOwners > 0 {
+				fmt.Println("\nTest functions without owners:")
+				for testName, relPath := range testsWithoutOwners {
+					fmt.Printf("- %s (%s)\n", testName, relPath)
+				}
+			} else {
+				fmt.Println("All Test functions have code owners!")
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	CheckTestOwnersCmd.Flags().StringVarP(&projectPath, "project-path", "p", ".", "Path to the root of the project")
+	CheckTestOwnersCmd.Flags().StringVarP(&codeownersPath, "codeowners-path", "c", ".github/CODEOWNERS", "Path to the CODEOWNERS file")
+	CheckTestOwnersCmd.Flags().BoolVarP(&printTestFunctions, "print-test-functions", "t", false, "Print all test functions without owners")
+}

--- a/tools/flakeguard/codeowners/parser_test.go
+++ b/tools/flakeguard/codeowners/parser_test.go
@@ -1,0 +1,77 @@
+package codeowners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindOwners(t *testing.T) {
+	tests := []struct {
+		name           string
+		filePath       string
+		patterns       []PatternOwner
+		expectedOwners []string
+	}{
+		{
+			name:     "Exact match",
+			filePath: "core/services/job/job_test.go",
+			patterns: []PatternOwner{
+				{Pattern: "/core/services/job", Owners: []string{"@team1", "@team2"}}, // Leading /
+			},
+			expectedOwners: []string{"@team1", "@team2"},
+		},
+		{
+			name:     "Wildcard match",
+			filePath: "core/services/ocr_test.go",
+			patterns: []PatternOwner{
+				{Pattern: "/core/services/ocr*", Owners: []string{"@ocr-team"}}, // Leading /
+			},
+			expectedOwners: []string{"@ocr-team"},
+		},
+		{
+			name:     "No match",
+			filePath: "core/services/unknown/unknown_test.go",
+			patterns: []PatternOwner{
+				{Pattern: "/core/services/job", Owners: []string{"@team1"}},     // Leading /
+				{Pattern: "/core/services/ocr*", Owners: []string{"@ocr-team"}}, // Leading /
+			},
+			expectedOwners: nil,
+		},
+		{
+			name:     "Multiple matches, last wins",
+			filePath: "core/services/ocr_test.go",
+			patterns: []PatternOwner{
+				{Pattern: "/core/services/*", Owners: []string{"@general-team"}}, // Leading /
+				{Pattern: "/core/services/ocr*", Owners: []string{"@ocr-team"}},  // Leading /
+			},
+			expectedOwners: []string{"@ocr-team"},
+		},
+		{
+			name:     "Directory match",
+			filePath: "core/services/job/subdir/job_test.go",
+			patterns: []PatternOwner{
+				{Pattern: "/core/services/job", Owners: []string{"@team1"}}, // Leading /
+			},
+			expectedOwners: []string{"@team1"},
+		},
+		{
+			name:     "Leading slash directory match",
+			filePath: "core/capabilities/compute/compute_test.go",
+			patterns: []PatternOwner{
+				{
+					Pattern: "/core/capabilities/",
+					Owners:  []string{"@smartcontractkit/keystone", "@smartcontractkit/capabilities-team"},
+				},
+			},
+			expectedOwners: []string{"@smartcontractkit/keystone", "@smartcontractkit/capabilities-team"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			owners := FindOwners(test.filePath, test.patterns)
+			assert.Equal(t, test.expectedOwners, owners)
+		})
+	}
+}

--- a/tools/flakeguard/main.go
+++ b/tools/flakeguard/main.go
@@ -29,6 +29,7 @@ func init() {
 	rootCmd.AddCommand(cmd.FindTestsCmd)
 	rootCmd.AddCommand(cmd.RunTestsCmd)
 	rootCmd.AddCommand(cmd.AggregateResultsCmd)
+	rootCmd.AddCommand(cmd.CheckTestOwnersCmd)
 }
 
 func main() {


### PR DESCRIPTION
…wners
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new command `CheckTestOwnersCmd` to identify tests without specified code owners, enhance the codeowners parser to support wildcard patterns, and normalize file paths for consistent matching. These updates improve the maintainability and traceability of test cases by ensuring that all parts of the codebase have clear ownership, facilitating better code reviews and accountability.

## What
- **tools/flakeguard/cmd/check_test_owners.go**: Added a new file implementing `CheckTestOwnersCmd`, which scans the project's tests and reports those without code owners.
  - New command to check test owners and report statistics about code ownership coverage.
- **tools/flakeguard/codeowners/parser.go**: Enhanced the CODEOWNERS file parser to support wildcard patterns and normalize file paths.
  - Normalized file patterns to Unix-style paths for consistent matching across platforms.
  - Added `IsWildcardPattern` function to detect wildcard characters in patterns.
  - Improved `FindOwners` function to accurately match file paths against wildcard patterns and report errors in pattern matching.
- **tools/flakeguard/codeowners/parser_test.go**: Introduced unit tests for the `FindOwners` function to validate its logic against various matching scenarios.
  - New tests to ensure accurate owner finding for exact, wildcard, and directory matches, including handling of leading slashes and multiple pattern matches.
- **tools/flakeguard/main.go**: Integrated the new `CheckTestOwnersCmd` into the main application.
  - Added `CheckTestOwnersCmd` to the list of commands available in the flakeguard tool.
