### PR TITLE
Add workaround for failure on any CRIT log

### DIFF
--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Build and Load Docker Image
         uses: docker/build-push-action@v4
         with:
+          cache-from: type=gha,scope=ctf
+          cache-to: type=gha,scope=ctf,mode=max
           context: /home/runner/work/chainlink-testing-framework/chainlink-testing-framework/chainlink-repo
           file: /home/runner/work/chainlink-testing-framework/chainlink-testing-framework/chainlink-repo/plugins/chainlink.Dockerfile
           load: true

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -11,6 +11,7 @@ jobs:
       LOKI_TENANT_ID: promtail
       LOKI_URL: http://localhost:3030/loki/api/v1/push
       DOCKER_BUILDKIT: 1
+      DOCKER_CLI_EXPERIMENTAL: enabled
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -1,0 +1,61 @@
+name: Framework Docker Cache Test
+on:
+  push:
+
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: framework/examples/myproject
+    env:
+      LOKI_TENANT_ID: promtail
+      LOKI_URL: http://localhost:3030/loki/api/v1/push
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: TestBuild
+            config: build.toml
+            count: 1
+            timeout: 10m
+    name: ${{ matrix.test.name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.8
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-modules-${{ hashFiles('framework/examples/myproject/go.sum') }}-${{ runner.os }}-framework-golden-examples
+          restore-keys: |
+            go-modules-${{ runner.os }}-framework-golden-examples
+            go-modules-${{ runner.os }}
+      - name: Install dependencies
+        run: go mod download
+      - name: Checkout Chainlink repository
+        uses: actions/checkout@v3
+        with:
+          repository: smartcontractkit/chainlink
+          path: chainlink-repo
+      - name: Run System Tests
+        env:
+          CTF_CONFIGS: ${{ matrix.test.config }}
+        run: |
+          go test -timeout ${{ matrix.test.timeout }} -v -count ${{ matrix.test.count }} -run ${{ matrix.test.name }}
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: container-logs-${{ matrix.test.name }}
+          path: framework/examples/myproject/logs
+          retention-days: 1

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -11,7 +11,7 @@ jobs:
       LOKI_TENANT_ID: promtail
       LOKI_URL: http://localhost:3030/loki/api/v1/push
       DOCKER_BUILDKIT: 1
-      DOCKER_CLI_EXPERIMENTAL: enabled
+      CTF_CHAINLINK_IMAGE: chainlink-local-image:latest
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -52,11 +52,13 @@ jobs:
           path: chainlink-repo
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Set up Environment Variables
-        run: |
-          echo "GITHUB_SERVER_URL=${{ github.server_url }}" >> $GITHUB_ENV
-          echo "GITHUB_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
-          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: Build and Load Docker Image
+        uses: docker/build-push-action@v4
+        with:
+          context: /home/runner/work/chainlink-testing-framework/chainlink-testing-framework/chainlink-repo
+          file: /home/runner/work/chainlink-testing-framework/chainlink-testing-framework/chainlink-repo/plugins/chainlink.Dockerfile
+          load: true
+          tags: ${{ env.CTF_CHAINLINK_IMAGE }}
       - name: Run System Tests
         env:
           CTF_CONFIGS: ${{ matrix.test.config }}

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -50,6 +50,11 @@ jobs:
         with:
           repository: smartcontractkit/chainlink
           path: chainlink-repo
+      - name: Set up Environment Variables
+        run: |
+          echo "GITHUB_SERVER_URL=${{ github.server_url }}" >> $GITHUB_ENV
+          echo "GITHUB_REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - name: Run System Tests
         env:
           CTF_CONFIGS: ${{ matrix.test.config }}

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      actions: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -12,7 +12,7 @@ jobs:
       LOKI_URL: http://localhost:3030/loki/api/v1/push
       DOCKER_BUILDKIT: 1
       CTF_CHAINLINK_IMAGE: chainlink-local-image:latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       LOKI_TENANT_ID: promtail
       LOKI_URL: http://localhost:3030/loki/api/v1/push
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/framework-build-cache.yml
+++ b/.github/workflows/framework-build-cache.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           repository: smartcontractkit/chainlink
           path: chainlink-repo
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Set up Environment Variables
         run: |
           echo "GITHUB_SERVER_URL=${{ github.server_url }}" >> $GITHUB_ENV

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -253,10 +253,10 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		})
 	}
 	req.Files = append(req.Files, files...)
-	if req.Image != "" && (in.Node.DockerFilePath != "" || in.Node.DockerContext != "") {
-		return nil, errors.New("you provided both 'image' and one of 'docker_file', 'docker_ctx' fields. Please provide either 'image' or params to build a local one")
-	}
 	if req.Image == "" {
+		if in.Node.DockerFilePath != "" || in.Node.DockerContext != "" {
+			return nil, errors.New("image field is empty but there are no 'docker_ctx' or 'docker_file' set in TOML config")
+		}
 		req.Image = TmpImageName
 		if err := framework.BuildImageOnce(once, in.Node.DockerContext, in.Node.DockerFilePath, req.Image); err != nil {
 			return nil, err

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -283,6 +283,7 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 			"docker",
 			"buildx",
 			"build",
+			"--load",
 			"--cache-from",
 			fmt.Sprintf("type=gha,url=%s,token=%s,scope=ctfdocker", cacheURL, githubToken),
 			"--cache-to",

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -71,6 +71,7 @@ func DefaultTCName(name string) string {
 
 // runCommand executes a command and prints the output.
 func runCommand(name string, args ...string) error {
+	L.Info().Str("Command", name).Strs("Args", args).Msg("Executing os command")
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -79,6 +80,7 @@ func runCommand(name string, args ...string) error {
 
 // RunCommandDir executes a command in some directory and prints the output
 func RunCommandDir(dir, name string, args ...string) error {
+	L.Info().Str("Command", name).Strs("Args", args).Msg("Executing os command")
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -268,8 +270,8 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 		err = runCommand(
 			"docker",
 			"build",
-			"--cache-from=type=gha,scope=tmp-cache-ctf",
-			"--cache-to=type=gha,scope=tmp-cache-ctf,mode=max",
+			"--cache-from=type=gha,scope=ctfdocker",
+			"--cache-to=type=gha,scope=ctfdocker,mode=max",
 			"-t",
 			nameAndTag,
 			"-f",

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -281,6 +281,7 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 		cacheURL := fmt.Sprintf("%s/%s", githubServerURL, githubRepository)
 		err = runCommand(
 			"docker",
+			"buildx",
 			"build",
 			"--cache-from",
 			fmt.Sprintf("type=gha,url=%s,token=%s,scope=ctfdocker", cacheURL, githubToken),

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -269,6 +269,7 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 		dfilePath := filepath.Join(dctx, dfile)
 		err = runCommand(
 			"docker",
+			"buildx",
 			"build",
 			"--cache-from=type=gha,scope=ctfdocker",
 			"--cache-to=type=gha,scope=ctfdocker,mode=max",

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -267,33 +267,7 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 	var err error
 	once.Do(func() {
 		dfilePath := filepath.Join(dctx, dfile)
-
-		githubServerURL := os.Getenv("GITHUB_SERVER_URL")
-		githubRepository := os.Getenv("GITHUB_REPOSITORY")
-		githubToken := os.Getenv("GITHUB_TOKEN")
-
-		if githubServerURL == "" || githubRepository == "" || githubToken == "" {
-			L.Fatal().Err(err).Msg("Required environment variables are missing: GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_TOKEN")
-			return
-		}
-
-		// Construct the cache URL
-		cacheURL := fmt.Sprintf("%s/%s", githubServerURL, githubRepository)
-		err = runCommand(
-			"docker",
-			"buildx",
-			"build",
-			"--load",
-			"--cache-from",
-			fmt.Sprintf("type=gha,url=%s,token=%s,scope=ctfdocker", cacheURL, githubToken),
-			"--cache-to",
-			fmt.Sprintf("type=gha,url=%s,token=%s,scope=ctfdocker,mode=max", cacheURL, githubToken),
-			"-t",
-			nameAndTag,
-			"-f",
-			dfilePath,
-			dctx,
-		)
+		err = runCommand("docker", "build", "-t", nameAndTag, "-f", dfilePath, dctx)
 		if err != nil {
 			err = fmt.Errorf("failed to build Docker image: %w", err)
 		}

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -269,10 +269,11 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 		dfilePath := filepath.Join(dctx, dfile)
 		err = runCommand(
 			"docker",
-			"buildx",
 			"build",
-			"--cache-from=type=gha,scope=ctfdocker",
-			"--cache-to=type=gha,scope=ctfdocker,mode=max",
+			"--cache-from",
+			"type=gha,scope=ctfdocker",
+			"--cache-to",
+			"type=gha,scope=ctfdocker,mode=max",
 			"-t",
 			nameAndTag,
 			"-f",

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -265,7 +265,17 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 	var err error
 	once.Do(func() {
 		dfilePath := filepath.Join(dctx, dfile)
-		err = runCommand("docker", "build", "-t", nameAndTag, "-f", dfilePath, dctx)
+		err = runCommand(
+			"docker",
+			"build",
+			"--cache-from=type=gha,scope=tmp-cache-ctf",
+			"--cache-to=type=gha,scope=tmp-cache-ctf,mode=max",
+			"-t",
+			nameAndTag,
+			"-f",
+			dfilePath,
+			dctx,
+		)
 		if err != nil {
 			err = fmt.Errorf("failed to build Docker image: %w", err)
 		}

--- a/framework/examples/myproject/build.toml
+++ b/framework/examples/myproject/build.toml
@@ -16,5 +16,5 @@
   [[nodeset.node_specs]]
 
     [nodeset.node_specs.node]
-      docker_ctx = "/home/runner/work/chainlink-testing-framework/chainlink-repo"
+      docker_ctx = "/home/runner/work/chainlink-testing-framework/chainlink-testing-framework/chainlink-repo"
       docker_file = "plugins/chainlink.Dockerfile"

--- a/framework/examples/myproject/build.toml
+++ b/framework/examples/myproject/build.toml
@@ -1,0 +1,20 @@
+
+[blockchain_a]
+  type = "anvil"
+  docker_cmd_params = ["-b", "1"]
+
+[data_provider]
+  port = 9111
+
+[nodeset]
+  nodes = 5
+  override_mode = "all"
+
+  [nodeset.db]
+    image = "postgres:12.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      docker_ctx = "/home/runner/work/chainlink-testing-framework/chainlink-repo"
+      docker_file = "plugins/chainlink.Dockerfile"

--- a/framework/examples/myproject/build_test.go
+++ b/framework/examples/myproject/build_test.go
@@ -1,0 +1,26 @@
+package examples
+
+import (
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake"
+	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type CfgBuild struct {
+	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
+	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
+	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+}
+
+func TestBuild(t *testing.T) {
+	in, err := framework.Load[CfgBuild](t)
+	require.NoError(t, err)
+
+	bc, err := blockchain.NewBlockchainNetwork(in.BlockchainA)
+	require.NoError(t, err)
+	_, err = ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	require.NoError(t, err)
+}

--- a/framework/logs_test.go
+++ b/framework/logs_test.go
@@ -11,11 +11,18 @@ func TestCheckLogFilesForLevels(t *testing.T) {
 		name        string
 		dir         string
 		content     string
+		ignoreFlag  bool
 		expectError bool
 	}{
 		{
 			name:        "Clean",
 			dir:         "clean",
+			expectError: false,
+		},
+		{
+			name:        "Ignore all",
+			dir:         "crit",
+			ignoreFlag:  true,
 			expectError: false,
 		},
 		{
@@ -37,6 +44,9 @@ func TestCheckLogFilesForLevels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.ignoreFlag {
+				t.Setenv("CTF_IGNORE_CRITICAL_LOGS", "true")
+			}
 			err := checkNodeLogErrors(filepath.Join("testdata", tt.dir))
 			if tt.expectError && err == nil {
 				t.Errorf("expected error but got none")


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new GitHub Actions workflow for Docker cache testing, alongside adding configuration and test files for a sample project in the framework. This setup aims to streamline development and testing processes by leveraging Docker caching mechanisms and setting up a structured example project with blockchain and node configurations.

## What
- **.github/workflows/framework-build-cache.yml**
  - Added a new GitHub Actions workflow for testing Docker cache in the framework examples project. This includes setup steps for Go, caching Go modules, checking out the Chainlink repository, and running system tests with specific configurations.
- **framework/examples/myproject/build.toml**
  - Introduced a new TOML configuration file specifying blockchain settings (using Anvil), data provider configurations, and node set details including a PostgreSQL database image and Docker context for Chainlink nodes. This config is pivotal for setting up the project's blockchain environment.
- **framework/examples/myproject/build_test.go**
  - Added a new Go test file that leverages the Chainlink testing framework to load the project configuration from `build.toml` and initialize a blockchain network and node set based on the provided configurations. This test validates the project setup and configurations.
