### PR TITLE
flakeguard: Fix codeowners 

### DIFF
--- a/tools/flakeguard/cmd/aggregate_results.go
+++ b/tools/flakeguard/cmd/aggregate_results.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/reports"
@@ -26,8 +25,6 @@ var AggregateResultsCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error aggregating results: %v", err)
 		}
-
-		fmt.Printf("PROJECT PATH: %s\n", projectPath)
 
 		// Map test results to paths
 		err = reports.MapTestResultsToPaths(allReport, projectPath)

--- a/tools/flakeguard/cmd/aggregate_results.go
+++ b/tools/flakeguard/cmd/aggregate_results.go
@@ -56,7 +56,7 @@ var AggregateResultsCmd = &cobra.Command{
 
 		// Output results to JSON files
 		if len(resultsToSave) > 0 {
-			return reports.SaveFilteredResultsAndLogs(outputResultsPath, outputLogsPath, allReport)
+			return reports.SaveFilteredResultsAndLogs(outputResultsPath, outputLogsPath, allReport, codeOwnersPath != "")
 		}
 		return nil
 	},

--- a/tools/flakeguard/cmd/aggregate_results.go
+++ b/tools/flakeguard/cmd/aggregate_results.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/reports"
@@ -25,6 +26,8 @@ var AggregateResultsCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error aggregating results: %v", err)
 		}
+
+		fmt.Printf("PROJECT PATH: %s\n", projectPath)
 
 		// Map test results to paths
 		err = reports.MapTestResultsToPaths(allReport, projectPath)
@@ -70,5 +73,4 @@ func init() {
 	AggregateResultsCmd.Flags().BoolVarP(&filterFailed, "filter-failed", "f", false, "If true, filter and output only failed tests based on the max-pass-ratio threshold")
 	AggregateResultsCmd.Flags().StringVarP(&codeOwnersPath, "codeowners-path", "c", "", "Path to the CODEOWNERS file")
 	AggregateResultsCmd.Flags().StringVarP(&projectPath, "project-path", "r", ".", "The path to the Go project. Default is the current directory. Useful for subprojects")
-
 }

--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -71,7 +71,7 @@ var RunTestsCmd = &cobra.Command{
 		// Print all failed tests including flaky tests
 		if printFailedTests {
 			fmt.Printf("PassRatio threshold for flaky tests: %.2f\n", maxPassRatio)
-			reports.PrintTests(os.Stdout, testReport.Results, maxPassRatio)
+			reports.PrintTests(os.Stdout, testReport.Results, maxPassRatio, false)
 		}
 
 		// Save the test results in JSON format

--- a/tools/flakeguard/reports/codebase_scanner.go
+++ b/tools/flakeguard/reports/codebase_scanner.go
@@ -1,6 +1,7 @@
 package reports
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -16,8 +17,14 @@ type TestFileMap map[string]string
 func ScanTestFiles(rootDir string) (TestFileMap, error) {
 	testFileMap := make(TestFileMap)
 
+	// Ensure rootDir is absolute
+	rootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("error normalizing rootDir: %v", err)
+	}
+
 	// Walk through the root directory to find test files
-	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -27,11 +34,18 @@ func ScanTestFiles(rootDir string) (TestFileMap, error) {
 			return nil
 		}
 
+		// Normalize path relative to rootDir
+		relPath, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return fmt.Errorf("error getting relative path for %s: %v", path, err)
+		}
+		relPath = filepath.ToSlash(relPath) // Ensure Unix-style paths
+
 		// Parse the Go file
 		fset := token.NewFileSet()
 		node, err := parser.ParseFile(fset, path, nil, parser.AllErrors)
 		if err != nil {
-			return err
+			return fmt.Errorf("error parsing file %s: %v", path, err)
 		}
 
 		// Traverse the AST to find test or fuzz functions
@@ -43,8 +57,8 @@ func ScanTestFiles(rootDir string) (TestFileMap, error) {
 
 			// Match both "Test" and "Fuzz" prefixes
 			if strings.HasPrefix(funcDecl.Name.Name, "Test") || strings.HasPrefix(funcDecl.Name.Name, "Fuzz") {
-				// Add the function to the map
-				testFileMap[funcDecl.Name.Name] = path
+				// Add the function to the map with relative path
+				testFileMap[funcDecl.Name.Name] = relPath
 			}
 			return true
 		})

--- a/tools/flakeguard/reports/codebase_scanner.go
+++ b/tools/flakeguard/reports/codebase_scanner.go
@@ -16,33 +16,39 @@ type TestFileMap map[string]string
 func ScanTestFiles(rootDir string) (TestFileMap, error) {
 	testFileMap := make(TestFileMap)
 
+	// Walk through the root directory to find test files
 	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
+
+		// Skip files that are not Go test files
 		if !strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 
-		// Parse the file
+		// Parse the Go file
 		fset := token.NewFileSet()
 		node, err := parser.ParseFile(fset, path, nil, parser.AllErrors)
 		if err != nil {
 			return err
 		}
 
-		// Traverse the AST to find test functions
+		// Traverse the AST to find test or fuzz functions
 		ast.Inspect(node, func(n ast.Node) bool {
 			funcDecl, ok := n.(*ast.FuncDecl)
 			if !ok {
 				return true
 			}
-			if strings.HasPrefix(funcDecl.Name.Name, "Test") {
-				// Add both the package and test function to the map
+
+			// Match both "Test" and "Fuzz" prefixes
+			if strings.HasPrefix(funcDecl.Name.Name, "Test") || strings.HasPrefix(funcDecl.Name.Name, "Fuzz") {
+				// Add the function to the map
 				testFileMap[funcDecl.Name.Name] = path
 			}
 			return true
 		})
+
 		return nil
 	})
 

--- a/tools/flakeguard/reports/owner_mapper.go
+++ b/tools/flakeguard/reports/owner_mapper.go
@@ -1,6 +1,10 @@
 package reports
 
-import "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/codeowners"
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/codeowners"
+)
 
 // MapTestResultsToOwners maps test results to their code owners based on the TestPath and CODEOWNERS file.
 func MapTestResultsToOwners(report *TestReport, codeOwnersPath string) error {
@@ -12,6 +16,8 @@ func MapTestResultsToOwners(report *TestReport, codeOwnersPath string) error {
 
 	// Assign owners to each test result
 	for i, result := range report.Results {
+		fmt.Printf("Loaded Patterns: %+v\n", codeOwnerPatterns)
+		fmt.Printf("TestPath: %s\n", result.TestPath)
 		if result.TestPath != "NOT FOUND" {
 			report.Results[i].CodeOwners = codeowners.FindOwners(result.TestPath, codeOwnerPatterns)
 		} else {

--- a/tools/flakeguard/reports/owner_mapper.go
+++ b/tools/flakeguard/reports/owner_mapper.go
@@ -1,10 +1,6 @@
 package reports
 
-import (
-	"fmt"
-
-	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/codeowners"
-)
+import "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/codeowners"
 
 // MapTestResultsToOwners maps test results to their code owners based on the TestPath and CODEOWNERS file.
 func MapTestResultsToOwners(report *TestReport, codeOwnersPath string) error {
@@ -16,8 +12,6 @@ func MapTestResultsToOwners(report *TestReport, codeOwnersPath string) error {
 
 	// Assign owners to each test result
 	for i, result := range report.Results {
-		fmt.Printf("Loaded Patterns: %+v\n", codeOwnerPatterns)
-		fmt.Printf("TestPath: %s\n", result.TestPath)
 		if result.TestPath != "NOT FOUND" {
 			report.Results[i].CodeOwners = codeowners.FindOwners(result.TestPath, codeOwnerPatterns)
 		} else {

--- a/tools/flakeguard/reports/path_mapper.go
+++ b/tools/flakeguard/reports/path_mapper.go
@@ -1,49 +1,37 @@
 package reports
 
 import (
-	"fmt"
-	"path/filepath"
 	"strings"
 )
 
 // MapTestResultsToPaths maps test results to their corresponding file paths.
 func MapTestResultsToPaths(report *TestReport, rootDir string) error {
 	// Scan the codebase for test functions
-	rootDir, err := filepath.Abs(rootDir)
-	if err != nil {
-		return fmt.Errorf("error normalizing rootDir: %v", err)
-	}
-
 	testFileMap, err := ScanTestFiles(rootDir)
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("Root Directory: %s\n", rootDir)
-	fmt.Printf("Test File Map: %+v\n", testFileMap)
 
 	// Assign file paths to each test result
 	for i, result := range report.Results {
 		testName := result.TestName
 		var filePath string
 
+		// Handle subtests
 		if strings.Contains(testName, "/") {
-			parentTestName := strings.SplitN(testName, "/", 2)[0]
+			parentTestName := strings.SplitN(testName, "/", 2)[0] // Extract parent test
 			if path, exists := testFileMap[parentTestName]; exists {
 				filePath = path
 			}
 		} else if path, exists := testFileMap[testName]; exists {
+			// Handle normal tests
 			filePath = path
 		}
 
 		if filePath != "" {
-			relFilePath, err := filepath.Rel(rootDir, filePath)
-			if err != nil {
-				return fmt.Errorf("error getting relative path: %v", err)
-			}
-			report.Results[i].TestPath = filepath.ToSlash(relFilePath)
+			report.Results[i].TestPath = filePath
 		} else {
-			fmt.Printf("TestName not mapped: %s\n", testName)
+			// Log or mark tests not found in the codebase
 			report.Results[i].TestPath = "NOT FOUND"
 		}
 	}

--- a/tools/flakeguard/reports/path_mapper.go
+++ b/tools/flakeguard/reports/path_mapper.go
@@ -9,36 +9,41 @@ import (
 // MapTestResultsToPaths maps test results to their corresponding file paths.
 func MapTestResultsToPaths(report *TestReport, rootDir string) error {
 	// Scan the codebase for test functions
+	rootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return fmt.Errorf("error normalizing rootDir: %v", err)
+	}
+
 	testFileMap, err := ScanTestFiles(rootDir)
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Root Directory: %s\n", rootDir)
+	fmt.Printf("Test File Map: %+v\n", testFileMap)
 
 	// Assign file paths to each test result
 	for i, result := range report.Results {
 		testName := result.TestName
 		var filePath string
 
-		// Handle subtests
 		if strings.Contains(testName, "/") {
-			parentTestName := strings.SplitN(testName, "/", 2)[0] // Extract parent test
+			parentTestName := strings.SplitN(testName, "/", 2)[0]
 			if path, exists := testFileMap[parentTestName]; exists {
 				filePath = path
 			}
 		} else if path, exists := testFileMap[testName]; exists {
-			// Handle normal tests
 			filePath = path
 		}
 
-		// Normalize filePath to be relative to the project root
 		if filePath != "" {
 			relFilePath, err := filepath.Rel(rootDir, filePath)
 			if err != nil {
 				return fmt.Errorf("error getting relative path: %v", err)
 			}
-			report.Results[i].TestPath = relFilePath
+			report.Results[i].TestPath = filepath.ToSlash(relFilePath)
 		} else {
-			// Log or mark tests not found in the codebase
+			fmt.Printf("TestName not mapped: %s\n", testName)
 			report.Results[i].TestPath = "NOT FOUND"
 		}
 	}


### PR DESCRIPTION
Fix relative test paths and codeowners in flakeguard test results.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the functionality and usability of the FlakeGuard tool by improving how test results and related data are handled and presented. Specifically, these changes aim to refine the process of aggregating test results, mapping test results to their respective file paths or code owners, running tests with additional output options, and generating more informative and customizable reports. By including an option to consider code owners in the output and refining file path handling, the updates make it easier to identify responsibility for test failures and improve the clarity of test result reporting.

## What
- **tools/flakeguard/cmd/aggregate_results.go**
  - Added a parameter to include code owners in the `SaveFilteredResultsAndLogs` function call, allowing for more detailed output depending on whether the code owners' path is provided.
- **tools/flakeguard/cmd/run.go**
  - Modified the `PrintTests` function call to include a new parameter controlling the inclusion of code owners in the output, enhancing the detail of printed test reports.
- **tools/flakeguard/reports/codebase_scanner.go**
  - Improved error handling and path normalization in `ScanTestFiles` function to ensure reliable file path processing and added support for identifying "Fuzz" test functions along with "Test" functions.
- **tools/flakeguard/reports/path_mapper.go**
  - Simplified file path handling in `MapTestResultsToPaths` by directly assigning scanned file paths to test results without further normalization, ensuring clarity in reporting where tests are located within the project.
- **tools/flakeguard/reports/reports.go**
  - Adjusted various reporting functions (`PrintTests`, `MarkdownSummary`, `SaveFilteredResultsAndLogs`) to support the optional inclusion of code owners in the output, and streamlined the presentation logic to improve the readability and informativeness of reports.
