### PR TITLE
Separate JD database

### DIFF
--- a/framework/.changeset/v0.3.7.md
+++ b/framework/.changeset/v0.3.7.md
@@ -1,0 +1,2 @@
+- Separate JobDistributor database
+- Wait when fund nodes on testnets

--- a/framework/components/jd/jd.go
+++ b/framework/components/jd/jd.go
@@ -54,6 +54,7 @@ func defaultJDDB() *postgres.Input {
 	return &postgres.Input{
 		Image:      "postgres:12",
 		Port:       14000,
+		Name:       "jd-db",
 		VolumeName: "jd",
 		JDDatabase: true,
 	}

--- a/framework/components/jd/jd_test.go
+++ b/framework/components/jd/jd_test.go
@@ -3,7 +3,6 @@ package jd_test
 import (
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
-	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
 	"github.com/stretchr/testify/require"
 	"os"
 	"sync"
@@ -17,14 +16,7 @@ import (
 func TestJD(t *testing.T) {
 	err := framework.DefaultNetwork(&sync.Once{})
 	require.NoError(t, err)
-	pgOut, err := postgres.NewPostgreSQL(&postgres.Input{
-		Image:      "postgres:12.0",
-		Port:       14402,
-		VolumeName: "c",
-	})
-	require.NoError(t, err)
 	_, err = jd.NewJD(&jd.Input{
-		DBURL: pgOut.JDDockerInternalURL,
 		Image: os.Getenv("CTF_JD_IMAGE"),
 	})
 	require.NoError(t, err)

--- a/framework/components/postgres/postgres.go
+++ b/framework/components/postgres/postgres.go
@@ -25,6 +25,7 @@ const (
 type Input struct {
 	Image      string  `toml:"image" validate:"required"`
 	Port       int     `toml:"port"`
+	Name       string  `toml:"name"`
 	VolumeName string  `toml:"volume_name"`
 	Databases  int     `toml:"databases"`
 	JDDatabase bool    `toml:"jd_database"`
@@ -44,7 +45,12 @@ func NewPostgreSQL(in *Input) (*Output, error) {
 	ctx := context.Background()
 
 	bindPort := fmt.Sprintf("%s/tcp", Port)
-	containerName := framework.DefaultTCName("ns-postgresql")
+	var containerName string
+	if in.Name != "" {
+		containerName = framework.DefaultTCName(in.Name)
+	} else {
+		containerName = framework.DefaultTCName("ns-postgresql")
+	}
 
 	var sqlCommands []string
 	for i := 0; i <= in.Databases; i++ {

--- a/framework/components/simple_node_set/fund.go
+++ b/framework/components/simple_node_set/fund.go
@@ -58,7 +58,7 @@ func SendETH(client *ethclient.Client, privateKeyHex string, toAddress string, a
 		return fmt.Errorf("failed to send transaction: %v", err)
 	}
 	framework.L.Info().Msgf("Transaction sent: %s", signedTx.Hash().Hex())
-	_, err = bind.WaitMined(context.Background(), client, tx)
+	_, err = bind.WaitMined(context.Background(), client, signedTx)
 	return err
 }
 

--- a/framework/components/simple_node_set/fund.go
+++ b/framework/components/simple_node_set/fund.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -57,7 +58,8 @@ func SendETH(client *ethclient.Client, privateKeyHex string, toAddress string, a
 		return fmt.Errorf("failed to send transaction: %v", err)
 	}
 	framework.L.Info().Msgf("Transaction sent: %s", signedTx.Hash().Hex())
-	return nil
+	_, err = bind.WaitMined(context.Background(), client, tx)
+	return err
 }
 
 // FundNodes funds Chainlink nodes with N ETH each

--- a/framework/examples/myproject_cll/jd_test.go
+++ b/framework/examples/myproject_cll/jd_test.go
@@ -23,7 +23,6 @@ func TestJDAndNodeSet(t *testing.T) {
 	require.NoError(t, err)
 	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
 	require.NoError(t, err)
-	in.JD.DBURL = out.DBOut.JDDockerInternalURL
 	_, err = jd.NewJD(in.JD)
 	require.NoError(t, err)
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the JobDistributor (JD) component and its integration with the PostgreSQL database, improving the testing framework by allowing more dynamic configuration and interaction. Specifically, separating the JD database setup into its configuration allows for more flexibility and better encapsulation of database specifics. Additionally, ensuring transactions are mined before proceeding enhances reliability during testing on testnets by confirming state changes are complete.

## What
- **`framework/.changeset/v0.3.7.md`**
  - Added a changeset file for version 0.3.7 including separate JobDistributor database setup and modification to wait for fund transactions to be mined on testnets.
- **`framework/components/jd/jd.go`**
  - Imported the `postgres` component for database interactions.
  - Removed `DBURL` from `Input` struct and added `DBInput` for direct postgres configuration.
  - Added a default postgres database configuration specific to JD (`defaultJDDB` function).
  - Integrated the new postgres setup in `NewJD` function, using `DBInput` for database configuration.
- **`framework/components/jd/jd_test.go`**
  - Removed direct PostgreSQL setup, relying on `jd.NewJD` to handle its database integration.
- **`framework/components/postgres/postgres.go`**
  - Added `Name` and `JDDatabase` fields in `Input` struct for customizable container names and enabling a specific database setup for JD.
  - Adjusted container naming and database setup logic to accommodate the new fields.
  - Modified the database URL construction to conditionally include JD database URLs based on the new input.
- **`framework/components/simple_node_set/fund.go`**
  - Added a call to `bind.WaitMined` to wait for the transaction to be mined, improving reliability in testing environments.
- **`framework/examples/myproject_cll/jd_test.go`**
  - Removed setting `DBURL` directly in test setup, relying on the updated JD component configuration.
