### PR TITLE
Run the chainlink node with dlv

### DIFF
--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -221,7 +221,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		ExposedPorts: exposedPorts,
 		Entrypoint: []string{
 			"/bin/sh", "-c",
-			"chainlink -c /config/config -c /config/overrides -c /config/user-overrides -s /config/secrets -s /config/secrets-overrides -s /config/user-secrets-overrides node start -d -p /config/node_password -a /config/apicredentials",
+            "dlv --listen=0.0.0.0:40000 --headless=true --continue --api-version=2 --accept-multiclient exec /usr/local/bin/chainlink -- -c /config/config -c /config/overrides -c /config/user-overrides -s /config/secrets -s /config/secrets-overrides -s /config/user-secrets-overrides node start -d -p /config/node_password -a /config/apicredentials",
 		},
 		WaitingFor: wait.ForHTTP("/").WithPort(DefaultHTTPPort).WithStartupTimeout(2 * time.Minute),
 	}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The modification enhances the container initialization command for debugging purposes, enabling the use of Delve debugger to attach to the Chainlink node process. This change allows developers to debug the node in a running container, improving the development and troubleshooting experience.

## What
- **framework/components/clnode/clnode.go**
  - Modified the `Entrypoint` command in the container request setup.
    - Changed from running the Chainlink node directly to using `dlv` (Delve debugger) with specific flags to start the Chainlink node. This allows for debugging capabilities within the container by exposing the Delve server on port 40000 and enabling multiclient connections.
