### PR TITLE
Flakeguard: improve report aggregation performance and omit output for passed tests

### DIFF
--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -4,6 +4,8 @@ on:
     types: [submitted]
   pull_request:
     types: [labeled]
+    paths-ignore:
+      - 'tools/**'    
 
 jobs:
   eth_env:

--- a/tools/flakeguard/cmd/aggregate_results.go
+++ b/tools/flakeguard/cmd/aggregate_results.go
@@ -36,25 +36,17 @@ var AggregateResultsCmd = &cobra.Command{
 
 		// Start spinner for loading test reports
 		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-		s.Suffix = " Loading test reports..."
+		s.Suffix = " Aggregating test reports..."
 		s.Start()
 
-		// Load test reports from JSON files
-		testReports, err := reports.LoadReports(resultsPath)
+		// Load test reports from JSON files and aggregate them
+		aggregatedReport, err := reports.LoadAndAggregate(resultsPath)
 		if err != nil {
 			s.Stop()
 			return fmt.Errorf("error loading test reports: %w", err)
 		}
 		s.Stop()
-		fmt.Println("Test reports loaded successfully.")
-
-		// Start spinner for aggregating reports
-		s = spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-		s.Suffix = " Aggregating test reports..."
-		s.Start()
-
-		// Aggregate the reports
-		aggregatedReport, err := reports.Aggregate(testReports...)
+		fmt.Println("Test reports aggregated successfully.")
 
 		// Add metadata to the aggregated report
 		aggregatedReport.HeadSHA = headSHA

--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -31,6 +31,7 @@ var RunTestsCmd = &cobra.Command{
 		selectTests, _ := cmd.Flags().GetStringSlice("select-tests")
 		useShuffle, _ := cmd.Flags().GetBool("shuffle")
 		shuffleSeed, _ := cmd.Flags().GetString("shuffle-seed")
+		omitOutputsOnSuccess, _ := cmd.Flags().GetBool("omit-test-outputs-on-success")
 
 		// Check if project dependencies are correctly set up
 		if err := checkDependencies(projectPath); err != nil {
@@ -62,6 +63,7 @@ var RunTestsCmd = &cobra.Command{
 			SelectedTestPackages: testPackages,
 			UseShuffle:           useShuffle,
 			ShuffleSeed:          shuffleSeed,
+			OmitOutputsOnSuccess: omitOutputsOnSuccess,
 		}
 
 		// Run the tests
@@ -119,6 +121,7 @@ func init() {
 	RunTestsCmd.Flags().StringSlice("skip-tests", nil, "Comma-separated list of test names to skip from running")
 	RunTestsCmd.Flags().StringSlice("select-tests", nil, "Comma-separated list of test names to specifically run")
 	RunTestsCmd.Flags().Float64("max-pass-ratio", 1.0, "The maximum pass ratio threshold for a test to be considered flaky. Any tests below this pass rate will be considered flaky.")
+	RunTestsCmd.Flags().Bool("omit-test-outputs-on-success", true, "Omit test outputs and package outputs for tests that pass")
 }
 
 func checkDependencies(projectPath string) error {

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -128,13 +128,13 @@ func FilterTests(results []TestResult, predicate func(TestResult) bool) []TestRe
 	return filtered
 }
 
-func Aggregate(reports ...*TestReport) (*TestReport, error) {
+func aggregate(reportChan <-chan *TestReport) (*TestReport, error) {
 	testMap := make(map[string]TestResult)
 	fullReport := &TestReport{}
 	excludedTests := map[string]struct{}{}
 	selectedTests := map[string]struct{}{}
 
-	for _, report := range reports {
+	for report := range reportChan {
 		if fullReport.GoProject == "" {
 			fullReport.GoProject = report.GoProject
 		} else if fullReport.GoProject != report.GoProject {
@@ -159,6 +159,7 @@ func Aggregate(reports ...*TestReport) (*TestReport, error) {
 		}
 	}
 
+	// Finalize excluded and selected tests
 	for test := range excludedTests {
 		fullReport.ExcludedTests = append(fullReport.ExcludedTests, test)
 	}
@@ -166,6 +167,7 @@ func Aggregate(reports ...*TestReport) (*TestReport, error) {
 		fullReport.SelectedTests = append(fullReport.SelectedTests, test)
 	}
 
+	// Prepare final results
 	var aggregatedResults []TestResult
 	for _, result := range testMap {
 		aggregatedResults = append(aggregatedResults, result)

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -179,6 +179,15 @@ func aggregate(reportChan <-chan *TestReport) (*TestReport, error) {
 	return fullReport, nil
 }
 
+func aggregateFromReports(reports ...*TestReport) (*TestReport, error) {
+	reportChan := make(chan *TestReport, len(reports))
+	for _, report := range reports {
+		reportChan <- report
+	}
+	close(reportChan)
+	return aggregate(reportChan)
+}
+
 func mergeTestResults(a, b TestResult) TestResult {
 	a.Runs += b.Runs
 	a.Durations = append(a.Durations, b.Durations...)

--- a/tools/flakeguard/reports/data_test.go
+++ b/tools/flakeguard/reports/data_test.go
@@ -287,7 +287,7 @@ func TestAggregate(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := aggregate(report1, report2)
+	aggregatedReport, err := aggregateFromReports(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestAggregateOutputs(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := aggregate(report1, report2)
+	aggregatedReport, err := aggregateFromReports(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestAggregateIdenticalOutputs(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := aggregate(report1, report2)
+	aggregatedReport, err := aggregateFromReports(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -569,7 +569,7 @@ func TestAggregate_AllSkippedTests(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := aggregate(report1, report2)
+	aggregatedReport, err := aggregateFromReports(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}

--- a/tools/flakeguard/reports/data_test.go
+++ b/tools/flakeguard/reports/data_test.go
@@ -287,7 +287,7 @@ func TestAggregate(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := Aggregate(report1, report2)
+	aggregatedReport, err := aggregate(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestAggregateOutputs(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := Aggregate(report1, report2)
+	aggregatedReport, err := aggregate(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestAggregateIdenticalOutputs(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := Aggregate(report1, report2)
+	aggregatedReport, err := aggregate(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}
@@ -569,7 +569,7 @@ func TestAggregate_AllSkippedTests(t *testing.T) {
 		},
 	}
 
-	aggregatedReport, err := Aggregate(report1, report2)
+	aggregatedReport, err := aggregate(report1, report2)
 	if err != nil {
 		t.Fatalf("Error aggregating reports: %v", err)
 	}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the efficiency and readability of the code, streamline the test results aggregation process, remove redundant code, and enhance the handling of test outputs. They also introduce better error handling during the aggregation of test reports and the loading of large JSON files.

## What
- **tools/flakeguard/cmd/aggregate_results.go**
  - Modified spinner suffix to "Aggregating test reports..." to better reflect the current operation.
  - Streamlined aggregation and loading of test reports by combining them into a single operation, improving code efficiency.
  - Removed redundant spinner instantiation for loading and aggregating reports, reducing code duplication.
  - Added comments to clarify the purpose of certain blocks of code, improving code readability.
- **tools/flakeguard/cmd/run.go**
  - Added a flag `omitOutputsOnSuccess` to omit test and package outputs for successful tests, reducing noise in the output.
- **tools/flakeguard/reports/data.go**
  - Refactored `Aggregate` function into `aggregate` to use a channel for processing test reports, enhancing efficiency in handling concurrent report processing.
  - Implemented finalization of excluded and selected tests after aggregation, ensuring accurate test result reporting.
  - Prepared final results after aggregation, ensuring a comprehensive test report.
- **tools/flakeguard/reports/data_test.go**
  - Adjusted tests to use the new `aggregate` function, ensuring the test suite remains relevant and passes with the refactored code.
- **tools/flakeguard/reports/io.go**
  - Introduced `LoadAndAggregate` function that loads test reports and aggregates them concurrently using channels, improving performance and error handling.
  - Implemented `processLargeFile` function to support efficient loading and parsing of large JSON files, improving the system's scalability.
- **tools/flakeguard/runner/runner.go**
  - Added `OmitOutputsOnSuccess` field to the `Runner` struct to support the new flag for omitting outputs on successful tests.
  - Modified `parseTestResults` to be a method of `Runner` and utilize the `OmitOutputsOnSuccess` field, ensuring consistent behavior according to user configuration.
