### PR TITLE
Fix url and add node container internal ip

### DIFF
--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -71,6 +71,7 @@ type NodeOut struct {
 	HostURL         string `toml:"url"`
 	DockerURL       string `toml:"docker_internal_url"`
 	DockerP2PUrl    string `toml:"p2p_docker_internal_url"`
+	InternalIP      string `toml:"internal_ip"`
 }
 
 // NewNodeWithDB create a new Chainlink node with some image:tag and one or several configs
@@ -301,6 +302,10 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 	if err != nil {
 		return nil, err
 	}
+	ip, err := c.ContainerIP(ctx)
+	if err != nil {
+		return nil, err
+	}
 	host, err := framework.GetHost(c)
 	if err != nil {
 		return nil, err
@@ -315,6 +320,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		HostURL:         fmt.Sprintf("http://%s:%s", host, mp.Port()),
 		DockerURL:       fmt.Sprintf("http://%s:%s", containerName, DefaultHTTPPort),
 		DockerP2PUrl:    fmt.Sprintf("http://%s:%s", containerName, DefaultP2PPort),
+		InternalIP:      ip,
 	}, nil
 }
 

--- a/framework/components/jd/jd.go
+++ b/framework/components/jd/jd.go
@@ -121,10 +121,10 @@ func NewJD(in *Input) (*Output, error) {
 	}
 	out := &Output{
 		UseCache:       true,
-		HostGRPCUrl:    fmt.Sprintf("http://%s:%s", host, in.GRPCPort),
-		DockerGRPCUrl:  fmt.Sprintf("http://%s:%s", containerName, in.GRPCPort),
-		HostWSRPCUrl:   fmt.Sprintf("ws://%s:%s", host, in.WSRPCPort),
-		DockerWSRPCUrl: fmt.Sprintf("ws://%s:%s", containerName, in.WSRPCPort),
+		HostGRPCUrl:    fmt.Sprintf("%s:%s", host, in.GRPCPort),
+		DockerGRPCUrl:  fmt.Sprintf("%s:%s", containerName, in.GRPCPort),
+		HostWSRPCUrl:   fmt.Sprintf("%s:%s", host, in.WSRPCPort),
+		DockerWSRPCUrl: fmt.Sprintf("%s:%s", containerName, in.WSRPCPort),
 	}
 	in.Out = out
 	return out, nil


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes made to `clnode.go` and `jd.go` improve network configuration and address formatting. In `clnode.go`, an `InternalIP` field is added to provide direct access to the container's internal IP, enhancing connectivity options within the network. In `jd.go`, the URL formatting for GRPC and WebSocket RPC URLs is corrected by removing the redundant `http://` scheme, aligning the URLs with typical GRPC and WebSocket addressing conventions.

## What
- **`framework/components/clnode/clnode.go`**
  - Added `InternalIP` field to `NodeOut` struct to include the internal IP address of the Chainlink node container.
  - Added logic to retrieve and set the container's internal IP address in the `newNode` function. This change facilitates direct internal access to the node, useful in networked container environments.
- **`framework/components/jd/jd.go`**
  - Modified URL formatting in `Output` struct. Removed `http://` from GRPC and WebSocket RPC URLs to correct the URL scheme. This change ensures that the URLs are correctly formatted for their respective protocols, with GRPC typically not using `http://` and WebSocket URLs specified as `ws://` or `wss://` for secure connections.
