### PR TITLE
Keep test outputs for Flakeguard in separate fields

### DIFF
--- a/tools/flakeguard/cmd/aggregate_results.go
+++ b/tools/flakeguard/cmd/aggregate_results.go
@@ -121,7 +121,8 @@ var AggregateResultsCmd = &cobra.Command{
 
 			// Remove logs from test results for the report without logs
 			for i := range failedReportWithLogs.Results {
-				failedReportWithLogs.Results[i].Outputs = nil
+				failedReportWithLogs.Results[i].PassedOutputs = nil
+				failedReportWithLogs.Results[i].FailedOutputs = nil
 				failedReportWithLogs.Results[i].PackageOutputs = nil
 			}
 
@@ -137,7 +138,8 @@ var AggregateResultsCmd = &cobra.Command{
 
 		// Remove logs from test results for the aggregated report
 		for i := range aggregatedReport.Results {
-			aggregatedReport.Results[i].Outputs = nil
+			aggregatedReport.Results[i].PassedOutputs = nil
+			aggregatedReport.Results[i].FailedOutputs = nil
 			aggregatedReport.Results[i].PackageOutputs = nil
 		}
 

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -36,7 +36,7 @@ type TestResult struct {
 	Failures       int
 	Successes      int
 	Skips          int
-	Outputs        map[string][]string // Temporary storage for outputs during test run
+	Outputs        map[string][]string `json:"-"` // Temporary storage for outputs during test run
 	PassedOutputs  map[string][]string // Outputs for passed runs
 	FailedOutputs  map[string][]string // Outputs for failed runs
 	Durations      []time.Duration

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -36,7 +36,9 @@ type TestResult struct {
 	Failures       int
 	Successes      int
 	Skips          int
-	Outputs        []string
+	Outputs        map[string][]string // Temporary storage for outputs during test run
+	PassedOutputs  map[string][]string // Outputs for passed runs
+	FailedOutputs  map[string][]string // Outputs for failed runs
 	Durations      []time.Duration
 	PackageOutputs []string
 	TestPath       string
@@ -191,7 +193,18 @@ func aggregateFromReports(reports ...*TestReport) (*TestReport, error) {
 func mergeTestResults(a, b TestResult) TestResult {
 	a.Runs += b.Runs
 	a.Durations = append(a.Durations, b.Durations...)
-	a.Outputs = append(a.Outputs, b.Outputs...)
+	if a.PassedOutputs == nil {
+		a.PassedOutputs = make(map[string][]string)
+	}
+	if a.FailedOutputs == nil {
+		a.FailedOutputs = make(map[string][]string)
+	}
+	for runID, outputs := range b.PassedOutputs {
+		a.PassedOutputs[runID] = append(a.PassedOutputs[runID], outputs...)
+	}
+	for runID, outputs := range b.FailedOutputs {
+		a.FailedOutputs[runID] = append(a.FailedOutputs[runID], outputs...)
+	}
 	a.PackageOutputs = append(a.PackageOutputs, b.PackageOutputs...)
 	a.Successes += b.Successes
 	a.Failures += b.Failures

--- a/tools/flakeguard/reports/data_test.go
+++ b/tools/flakeguard/reports/data_test.go
@@ -386,8 +386,6 @@ func TestAggregateOutputs(t *testing.T) {
 
 	result := aggregatedReport.Results[0]
 
-	// Expected outputs after aggregation:
-	// The aggregator should have merged both test runs' outputs under the same run key ("run1").
 	expectedOutputs := map[string][]string{
 		"run1": {
 			"Output from report1 test run",

--- a/tools/flakeguard/reports/io.go
+++ b/tools/flakeguard/reports/io.go
@@ -216,7 +216,8 @@ func SaveSummaryAsJSON(fs FileSystem, path string, summary SummaryData) error {
 func SaveReportNoLogs(fs FileSystem, filePath string, report TestReport) error {
 	var filteredResults []TestResult
 	for _, r := range report.Results {
-		r.Outputs = nil
+		r.FailedOutputs = nil
+		r.PassedOutputs = nil
 		r.PackageOutputs = nil
 		filteredResults = append(filteredResults, r)
 	}

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -409,7 +409,6 @@ func (r *Runner) parseTestResults(filePaths []string) ([]reports.TestResult, err
 				}
 			case "output":
 				// Handled above when entryLine.Test is not empty
-				// ...existing code for other actions...
 			}
 			if entryLine.Test != "" {
 				result.Runs = result.Successes + result.Failures

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -407,6 +407,11 @@ func (r *Runner) parseTestResults(filePaths []string) ([]reports.TestResult, err
 					// Clear temporary outputs
 					delete(result.Outputs, runID)
 				}
+			case "skip":
+				if entryLine.Test != "" {
+					result.Skipped = true
+					result.Skips++
+				}
 			case "output":
 				// Handled above when entryLine.Test is not empty
 			}

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -481,6 +481,14 @@ func (r *Runner) parseTestResults(filePaths []string) ([]reports.TestResult, err
 		results = append(results, *result)
 	}
 
+	// Omit success outputs if requested
+	if r.OmitOutputsOnSuccess {
+		for i := range results {
+			results[i].PassedOutputs = make(map[string][]string)
+			results[i].Outputs = make(map[string][]string)
+		}
+	}
+
 	return results, nil
 }
 

--- a/tools/flakeguard/runner/runner_test.go
+++ b/tools/flakeguard/runner/runner_test.go
@@ -590,9 +590,6 @@ func TestOmitOutputsOnSuccess(t *testing.T) {
 		}
 	}
 	require.NotNil(t, testPassResult, "expected 'TestPass' result not found in report")
-
-	// Since TestPass always succeeds and OmitOutputsOnSuccess is true,
-	// we expect no PassedOutputs or general outputs.
 	require.Empty(t, testPassResult.PassedOutputs, "expected no passed outputs due to OmitOutputsOnSuccess")
 	require.Empty(t, testPassResult.Outputs, "expected no captured outputs due to OmitOutputsOnSuccess and a successful test")
 }

--- a/tools/flakeguard/runner/runner_test.go
+++ b/tools/flakeguard/runner/runner_test.go
@@ -496,6 +496,74 @@ func TestAttributeRaceToTest(t *testing.T) {
 	}
 }
 
+func TestFailedOutputs(t *testing.T) {
+	t.Parallel()
+
+	runner := Runner{
+		ProjectPath:          "./",
+		Verbose:              true,
+		RunCount:             1,
+		SelectedTestPackages: []string{flakyTestPackagePath},
+		SelectTests:          []string{"TestFail"}, // This test is known to fail consistently
+		CollectRawOutput:     true,
+	}
+
+	testReport, err := runner.RunTests()
+	require.NoError(t, err, "running tests should not produce an unexpected error")
+
+	require.Equal(t, 1, testReport.TestRunCount, "unexpected number of test runs")
+
+	var testFailResult *reports.TestResult
+	for i := range testReport.Results {
+		if testReport.Results[i].TestName == "TestFail" {
+			testFailResult = &testReport.Results[i]
+			break
+		}
+	}
+	require.NotNil(t, testFailResult, "expected TestFail result not found in report")
+
+	require.NotEmpty(t, testFailResult.FailedOutputs, "expected failed outputs for TestFail")
+
+	// Verify that each run (in this case, only one) has some non-empty output
+	for runID, outputs := range testFailResult.FailedOutputs {
+		t.Logf("Failed outputs for run %s: %v", runID, outputs)
+		require.NotEmpty(t, outputs, "Failed outputs should not be empty for TestFail")
+	}
+}
+
+func TestOmitOutputsOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	runner := Runner{
+		ProjectPath:          "./",
+		Verbose:              true,
+		RunCount:             1,
+		SelectedTestPackages: []string{flakyTestPackagePath},
+		SelectTests:          []string{"TestPass"}, // Known passing test
+		CollectRawOutput:     true,
+		OmitOutputsOnSuccess: true,
+	}
+
+	testReport, err := runner.RunTests()
+	require.NoError(t, err, "running tests should not produce an unexpected error")
+
+	require.Equal(t, 1, testReport.TestRunCount, "unexpected number of test runs")
+
+	var testPassResult *reports.TestResult
+	for i := range testReport.Results {
+		if testReport.Results[i].TestName == "TestPass" {
+			testPassResult = &testReport.Results[i]
+			break
+		}
+	}
+	require.NotNil(t, testPassResult, "expected 'TestPass' result not found in report")
+
+	// Since TestPass always succeeds and OmitOutputsOnSuccess is true,
+	// we expect no PassedOutputs or general outputs.
+	require.Empty(t, testPassResult.PassedOutputs, "expected no passed outputs due to OmitOutputsOnSuccess")
+	require.Empty(t, testPassResult.Outputs, "expected no captured outputs due to OmitOutputsOnSuccess and a successful test")
+}
+
 var (
 	improperlyAttributedPanicEntries = []entry{
 		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "panic: This test intentionally panics [recovered]\n"},

--- a/tools/flakeguard/runner/runner_test.go
+++ b/tools/flakeguard/runner/runner_test.go
@@ -531,6 +531,39 @@ func TestFailedOutputs(t *testing.T) {
 	}
 }
 
+func TestSkippedTests(t *testing.T) {
+	t.Parallel()
+
+	runner := Runner{
+		ProjectPath:          "./",
+		Verbose:              true,
+		RunCount:             1,
+		SelectedTestPackages: []string{flakyTestPackagePath},
+		SelectTests:          []string{"TestSkipped"}, // Known skipping test
+		CollectRawOutput:     true,
+	}
+
+	testReport, err := runner.RunTests()
+	require.NoError(t, err, "running tests should not produce an unexpected error")
+
+	require.Equal(t, 1, testReport.TestRunCount, "unexpected number of test runs")
+
+	var testSkipResult *reports.TestResult
+	for i := range testReport.Results {
+		if testReport.Results[i].TestName == "TestSkipped" {
+			testSkipResult = &testReport.Results[i]
+			break
+		}
+	}
+	require.NotNil(t, testSkipResult, "expected 'TestSkipped' result not found in report")
+
+	// Check that the test was properly marked as skipped
+	require.True(t, testSkipResult.Skipped, "test 'TestSkipped' should be marked as skipped")
+	require.Equal(t, 0, testSkipResult.Failures, "test 'TestSkipped' should have no failures")
+	require.Equal(t, 0, testSkipResult.Successes, "test 'TestSkipped' should have no successes")
+	require.Equal(t, 1, testSkipResult.Skips, "test 'TestSkipped' should have exactly one skip recorded")
+}
+
 func TestOmitOutputsOnSuccess(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the granularity and structure of test outputs in the FlakeGuard tool. By distinguishing between passed and failed outputs, and organizing them by run ID, the updates facilitate more detailed analysis and debugging of test results. Additionally, adjustments to output handling based on test outcomes (e.g., omitting outputs for passing tests when specified) enhance the tool's flexibility and user control over the report content. 

## What
- **tools/flakeguard/cmd/aggregate_results.go**
  - Separated test outputs into `PassedOutputs` and `FailedOutputs` for failed tests reporting, enhancing result analysis.
- **tools/flakeguard/reports/data.go**
  - Introduced `PassedOutputs` and `FailedOutputs` maps to the `TestResult` struct, replacing the generic `Outputs` slice. This change allows for a more structured approach to storing test outputs.
- **tools/flakeguard/reports/io.go**
  - Adjusted `SaveReportNoLogs` to clear `FailedOutputs` and `PassedOutputs` instead of the `Outputs` slice, aligning with the new output structure.
- **tools/flakeguard/runner/runner.go**
  - Modified output handling in `parseTestResults` to categorize outputs into `PassedOutputs` and `FailedOutputs`, keyed by run ID. This nuanced categorization aids in a more detailed analysis of test behaviors across multiple runs.
  - Introduced a mechanism to omit outputs for successful test runs when specified, supporting concise reporting.
- **tools/flakeguard/runner/runner_test.go**
  - Added tests for verifying the proper segregation and handling of failed outputs, skipped tests, and the functionality to omit outputs on successful tests, ensuring the new features work as intended.
