### PR TITLE
Fix node funding by reading proper primary ETH key based on chain ID

### DIFF
--- a/framework/clclient/client.go
+++ b/framework/clclient/client.go
@@ -557,7 +557,7 @@ func (c *ChainlinkClient) UpdateEthKeyMaxGasPriceGWei(keyId string, gWei int) (*
 }
 
 // ReadPrimaryETHKey reads updated information about the Chainlink's primary ETH key
-func (c *ChainlinkClient) ReadPrimaryETHKey() (*ETHKeyData, error) {
+func (c *ChainlinkClient) ReadPrimaryETHKey(chainId string) (*ETHKeyData, error) {
 	ethKeys, err := c.MustReadETHKeys()
 	if err != nil {
 		return nil, err
@@ -565,7 +565,12 @@ func (c *ChainlinkClient) ReadPrimaryETHKey() (*ETHKeyData, error) {
 	if len(ethKeys.Data) == 0 {
 		return nil, fmt.Errorf("Error retrieving primary eth key on node %s: No ETH keys present", c.URL())
 	}
-	return &ethKeys.Data[0], nil
+	for _, data := range ethKeys.Data {
+		if data.Attributes.ChainID == chainId {
+			return &data, nil
+		}
+	}
+	return nil, fmt.Errorf("error retrieving primary eth key on node %s: No ETH keys present for chain %s", c.URL(), chainId)
 }
 
 // ReadETHKeyAtIndex reads updated information about the Chainlink's ETH key at given index

--- a/framework/components/simple_node_set/fund.go
+++ b/framework/components/simple_node_set/fund.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+	er "github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/clclient"
 	"math/big"
@@ -18,7 +19,7 @@ import (
 func SendETH(client *ethclient.Client, privateKeyHex string, toAddress string, amount *big.Float) error {
 	privateKey, err := crypto.HexToECDSA(privateKeyHex)
 	if err != nil {
-		return fmt.Errorf("failed to parse private key: %v", err)
+		return er.Wrap(err, "failed to parse private key")
 	}
 	wei := new(big.Int)
 	amountWei := new(big.Float).Mul(amount, big.NewFloat(1e18))
@@ -33,12 +34,12 @@ func SendETH(client *ethclient.Client, privateKeyHex string, toAddress string, a
 
 	nonce, err := client.PendingNonceAt(context.Background(), fromAddress)
 	if err != nil {
-		return fmt.Errorf("failed to fetch nonce: %v", err)
+		return er.Wrap(err, "failed to fetch nonce")
 	}
 
 	gasPrice, err := client.SuggestGasPrice(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to fetch gas price: %v", err)
+		return er.Wrap(err, "failed to fetch gas price")
 	}
 	gasLimit := uint64(21000) // Standard gas limit for ETH transfer
 
@@ -46,16 +47,16 @@ func SendETH(client *ethclient.Client, privateKeyHex string, toAddress string, a
 
 	chainID, err := client.NetworkID(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to fetch chain ID: %v", err)
+		return er.Wrap(err, "failed to fetch chain ID")
 	}
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), privateKey)
 	if err != nil {
-		return fmt.Errorf("failed to sign transaction: %v", err)
+		return er.Wrap(err, "failed to sign transaction")
 	}
 
 	err = client.SendTransaction(context.Background(), signedTx)
 	if err != nil {
-		return fmt.Errorf("failed to send transaction: %v", err)
+		return er.Wrap(err, "failed to send transaction")
 	}
 	framework.L.Info().Msgf("Transaction sent: %s", signedTx.Hash().Hex())
 	_, err = bind.WaitMined(context.Background(), client, signedTx)
@@ -67,13 +68,17 @@ func FundNodes(c *ethclient.Client, nodes []*clclient.ChainlinkClient, pkey stri
 	if ethAmount == 0 {
 		return errors.New("funds_eth is 0, set some value in config, ex.: funds_eth = 30.0")
 	}
+	chainID, err := c.ChainID(context.Background())
+	if err != nil {
+		return er.Wrap(err, "failed to fetch chain ID")
+	}
 	for _, cl := range nodes {
-		ek, err := cl.ReadPrimaryETHKey()
+		ek, err := cl.ReadPrimaryETHKey(chainID.String())
 		if err != nil {
 			return err
 		}
 		if err := SendETH(c, pkey, ek.Attributes.Address, big.NewFloat(ethAmount)); err != nil {
-			return fmt.Errorf("failed to fund CL node %s: %w", ek.Attributes.Address, err)
+			return er.Wrapf(err, "failed to fund CL node %s", ek.Attributes.Address)
 		}
 	}
 	return nil


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance error handling across blockchain-related operations by utilizing the `github.com/pkg/errors` package for better error wrapping. Additionally, the update allows for the retrieval of a primary ETH key based on a specific chain ID, improving multi-chain support.

## What
- **framework/clclient/client.go**
  - Modified `ReadPrimaryETHKey` function to accept `chainId` as an argument, enabling fetching of the primary ETH key specific to a given chain ID.
  - Added logic to iterate over ETH keys and return the one matching the provided chain ID, improving support for multi-chain environments.
- **framework/components/simple_node_set/fund.go**
  - Imported `github.com/pkg/errors` package for enhanced error wrapping.
  - Updated error handling in `SendETH` function to use `errors.Wrap` for more descriptive errors.
  - Modified `FundNodes` to fetch and pass chain ID to `ReadPrimaryETHKey`, aligning with changes in `client.go` and supporting multi-chain configurations.
