### PR TITLE
use partial gas price percentiles

### DIFF
--- a/seth/client.go
+++ b/seth/client.go
@@ -934,7 +934,7 @@ func (m *Client) CalculateGasEstimations(request GasEstimationRequest) GasEstima
 	defer cancel()
 
 	var disableEstimationsIfNeeded = func(err error) {
-		if strings.Contains(err.Error(), ZeroGasSuggestedErr) {
+		if strings.Contains(err.Error(), ZeroGasSuggestedErr) || strings.Contains(err.Error(), "Partial data received") {
 			L.Warn().Msg("Received incorrect gas estimations. Disabling them and reverting to hardcoded values. Remember to update your config!")
 			m.Cfg.Network.GasPriceEstimationEnabled = false
 		}

--- a/seth/gas.go
+++ b/seth/gas.go
@@ -48,7 +48,8 @@ func (m *GasEstimator) Stats(fromNumber uint64, priorityPerc float64) (GasSugges
 	}
 	gasPercs, err := quantilesFromFloatArray(baseFees)
 	if err != nil {
-		return GasSuggestions{}, err
+		L.Debug().Err(err).Msg("Error calculating gas percentiles. Will use partial data.")
+		// return GasSuggestions{}, err
 	}
 	tips := make([]float64, 0)
 	for _, bf := range hist.Reward {
@@ -64,7 +65,8 @@ func (m *GasEstimator) Stats(fromNumber uint64, priorityPerc float64) (GasSugges
 	}
 	tipPercs, err := quantilesFromFloatArray(tips)
 	if err != nil {
-		return GasSuggestions{}, err
+		// return GasSuggestions{}, err
+		L.Debug().Err(err).Msg("Error calculating tip percentiles. Will use partial data.")
 	}
 	suggestedGasPrice, err := m.Client.Client.SuggestGasPrice(context.Background())
 	if err != nil {
@@ -105,23 +107,28 @@ type GasSuggestions struct {
 func quantilesFromFloatArray(fa []float64) (*GasPercentiles, error) {
 	perMax, err := stats.Max(fa)
 	if err != nil {
-		return nil, err
+		L.Debug().Err(err).Msg("Error calculating max gas price. Continuing")
+		// return nil, err
 	}
 	perc99, err := stats.Percentile(fa, 99)
 	if err != nil {
-		return nil, err
+		L.Debug().Err(err).Msg("Error calculating p99 gas price. Continuing")
+		// return nil, err
 	}
 	perc75, err := stats.Percentile(fa, 75)
 	if err != nil {
-		return nil, err
+		L.Debug().Err(err).Msg("Error calculating p75 gas price. Continuing")
+		// return nil, err
 	}
 	perc50, err := stats.Percentile(fa, 50)
 	if err != nil {
-		return nil, err
+		L.Debug().Err(err).Msg("Error calculating p50 gas price. Continuing")
+		// return nil, err
 	}
 	perc25, err := stats.Percentile(fa, 25)
 	if err != nil {
-		return nil, err
+		L.Debug().Err(err).Msg("Error calculating p25 gas price. Continuing")
+		// return nil, err
 	}
 	return &GasPercentiles{
 		Max:    perMax,


### PR DESCRIPTION
if some percentile calculations fail due to insufficient data we will still try to use what we could calculate instead of erroring
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the robustness and functionality of gas estimation in the blockchain client application by handling partial or incorrect gas estimation data more gracefully and enhancing error handling and logging.

## What
- **seth/client.go**
  - Improved error handling by considering "Partial data received" as a condition to disable gas price estimations and fallback to hardcoded values.
  - Enhanced logging messages when receiving incorrect gas estimations or when EIP1559 fees are not supported by the network, including conditions where the gas price is set to 0.
- **seth/gas.go**
  - Modified error handling in the `Stats` function to log errors and continue instead of returning immediately upon encountering errors calculating gas percentiles.
  - In `quantilesFromFloatArray`, replaced direct error returns with logging the error and continuing, facilitating the use of partial data for gas estimation.
- **seth/gas_adjuster.go**
  - Introduced checks for NaN values in gas price and tip cap calculations to handle partial data scenarios more effectively. It logs an error and skips automation gas estimation in case of NaN values, indicating partial data reception.
