### PR TITLE
[DPA-1458]: feat(solana): auto deploy programs

### DIFF
--- a/book/src/framework/components/blockchains/solana.md
+++ b/book/src/framework/components/blockchains/solana.md
@@ -17,10 +17,14 @@ arm64 f4hrenh9it/solana:latest - used locally
   # optional, in case you need some custom image
   # image = "solanalabs/solana:v1.18.26"
 
-# optional, in case you need to deploy some programs
-# this example assumes there is a mcm.so in the mounted contracts_dir directory
-# value is the program id to set for the deployed program instead of auto generating
-# useful for deterministic testing
+# optional
+# To deploy a solana program, we can provide a mapping of program name to program id.
+# The program name has to match the name of the .so file in the contracts_dir directory.
+# This example assumes there is a mcm.so in the mounted contracts_dir directory
+# value is the program_id to set for the deployed program, any valid public key can be used here.
+# this allows lookup via program_id during testing.
+# Alternative, we can use `solana deploy` instead of this field to deploy a program, but 
+# program_id will be auto generated.
 [blockchain_a.solana_programs]
   mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"
 

--- a/book/src/framework/components/blockchains/solana.md
+++ b/book/src/framework/components/blockchains/solana.md
@@ -16,6 +16,14 @@ arm64 f4hrenh9it/solana:latest - used locally
   contracts_dir = "."
   # optional, in case you need some custom image
   # image = "solanalabs/solana:v1.18.26"
+
+# optional, in case you need to deploy some programs
+# this example assumes there is a mcm.so in the mounted contracts_dir directory
+# value is the program id to set for the deployed program instead of auto generating
+# useful for deterministic testing
+[blockchain_a.solana_programs]
+  mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"
+
 ```
 
 ## Usage

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -23,6 +23,7 @@ type Input struct {
 	ContractsDir string `toml:"contracts_dir"`
 	// programs to deploy on solana-test-validator start
 	// a map of program name to program id
+	// there needs to be a matching .so file in contracts_dir
 	SolanaPrograms map[string]string `toml:"solana_programs"`
 }
 

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -21,6 +21,9 @@ type Input struct {
 	// publickey to mint when solana-test-validator starts
 	PublicKey    string `toml:"public_key"`
 	ContractsDir string `toml:"contracts_dir"`
+	// programs to deploy on solana-test-validator start
+	// a map of program name to program id
+	SolanaPrograms map[string]string `toml:"solana_programs"`
 }
 
 // Output is a blockchain network output, ChainID and one or more nodes that forms the network

--- a/framework/examples/myproject/smoke_solana.toml
+++ b/framework/examples/myproject/smoke_solana.toml
@@ -4,3 +4,6 @@
   public_key = "9n1pyVGGo6V4mpiSDMVay5As9NurEkY283wwRk1Kto2C"
   contracts_dir = "."
   image = "solanalabs/solana:v1.18.26"
+
+[blockchain_a.solana_programs]
+  mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"


### PR DESCRIPTION
By using `--upgradeable-program` , we can auto deploy programs detected in the mounted path `/programs`, this reduces the need for consumer of this library to have to deploy the programs themselves, especially with go sdk where deploying a program is not straightforward and involves a decent amount of code, the alternative is to ssh into the docker container and run `solana deploy ...` but this involves an extra step.

Inspired from https://github.com/smartcontractkit/chainlink-ccip/blob/609f7b0c9734b3cfc1d1a1aea0fd1ddf4c90bd0c/chains/solana/contracts/tests/testutils/anchor.go#L72-L72

JIRA: https://smartcontract-it.atlassian.net/browse/DPA-1458
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new feature to deploy upgradeable Solana programs at the start of the Solana test validator. This enhancement allows users to specify a map of Solana program names to their corresponding program IDs directly in the blockchain configuration, facilitating a more dynamic and flexible test setup.

## What
- **framework/components/blockchain/blockchain.go**
  - Added `SolanaPrograms map[string]string` to the `Input` struct to allow specifying Solana programs to deploy upon test validator start.
- **framework/components/blockchain/solana.go**
  - Introduced a new logic to construct the `solana-test-validator` command with flags for deploying specified Solana programs. This includes iterating over the `SolanaPrograms` map from the configuration and appending program deployment flags to the validator startup command.
  - Modified the container entrypoint to utilize the newly constructed command with program deployment flags, facilitating the deployment of specified programs when the Solana test validator starts.
