### PR TITLE
Ship 3971 update sentinel

### DIFF
--- a/sentinel/.changeset/v0.1.1.md
+++ b/sentinel/.changeset/v0.1.1.md
@@ -1,0 +1,2 @@
+- Add SentinelCoordinator Struct
+- Minor logging fix

--- a/sentinel/internal/subscription_manager/subscription_manager.go
+++ b/sentinel/internal/subscription_manager/subscription_manager.go
@@ -65,8 +65,8 @@ func (sm *SubscriptionManager) Subscribe(address common.Address, topic common.Ha
 
 	sm.logger.Info().
 		Int64("ChainID", sm.chainID).
-		Hex("Address", []byte(address.Hex())).
-		Hex("Topic", []byte(topic.Hex())).
+		Str("Address", address.Hex()).
+		Str("Topic", topic.Hex()).
 		Int64("SubscriberCount", int64(len(sm.registry[eventKey]))).
 		Msg("New subscription added")
 
@@ -82,8 +82,8 @@ func (sm *SubscriptionManager) Unsubscribe(address common.Address, topic common.
 	if !exists {
 		sm.logger.Warn().
 			Int64("ChainID", sm.chainID).
-			Hex("Address", []byte(address.Hex())).
-			Hex("Topic", []byte(topic.Hex())).
+			Str("Address", address.Hex()).
+			Str("Topic", topic.Hex()).
 			Msg("Attempted to unsubscribe from a non-existent EventKey")
 		return errors.New("event key does not exist")
 	}
@@ -99,8 +99,8 @@ func (sm *SubscriptionManager) Unsubscribe(address common.Address, topic common.
 			sm.mu.Unlock()
 			sm.logger.Info().
 				Int64("ChainID", sm.chainID).
-				Hex("Address", []byte(address.Hex())).
-				Hex("Topic", []byte(topic.Hex())).
+				Str("Address", address.Hex()).
+				Str("Topic", topic.Hex()).
 				Int64("RemainingSubscribers", int64(len(sm.registry[eventKey]))).
 				Msg("Subscription removed")
 			found = true
@@ -124,8 +124,8 @@ func (sm *SubscriptionManager) Unsubscribe(address common.Address, topic common.
 		delete(sm.registry, eventKey)
 		sm.logger.Debug().
 			Int64("ChainID", sm.chainID).
-			Hex("Address", []byte(address.Hex())).
-			Hex("Topic", []byte(topic.Hex())).
+			Str("Address", address.Hex()).
+			Str("Topic", topic.Hex()).
 			Msg("No remaining subscribers, removing EventKey from registry")
 	}
 	sm.mu.Unlock()
@@ -173,8 +173,8 @@ func (sm *SubscriptionManager) BroadcastLog(eventKey internal.EventKey, log api.
 	sm.logger.Debug().
 		Int64("ChainID", sm.chainID).
 		Int("Subscribers", len(subscribers)).
-		Hex("Address", []byte(eventKey.Address.Hex())).
-		Hex("Topic", []byte(eventKey.Topic.Hex())).
+		Str("Address", eventKey.Address.Hex()).
+		Str("Topic", eventKey.Topic.Hex()).
 		Msg("Log broadcasted to all subscribers")
 }
 

--- a/sentinel/sentinel_coordinator.go
+++ b/sentinel/sentinel_coordinator.go
@@ -1,0 +1,31 @@
+// File: sentinel.go
+package sentinel
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+)
+
+type SentinelCoordinator struct {
+	Sentinel *Sentinel
+	wg       *sync.WaitGroup
+	Ctx      context.Context
+	cancel   context.CancelFunc
+	log      zerolog.Logger
+}
+
+func NewSentinelCoordinator(log zerolog.Logger) *SentinelCoordinator {
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	s := NewSentinel(SentinelConfig{})
+
+	return &SentinelCoordinator{
+		Sentinel: s,
+		wg:       wg,
+		Ctx:      ctx,
+		cancel:   cancel,
+		log:      log,
+	}
+}


### PR DESCRIPTION
- Adds Sentinel Coordinator struct
- Minor adjustment to sentinel logging
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes streamline logging for subscription management in the Sentinel application and introduce a new `SentinelCoordinator` struct to manage Sentinel instances. These improvements enhance the application's structure and debuggability.

## What
- **sentinel/.changeset/v0.1.1.md**
  - Adds a new changeset markdown file indicating the addition of `SentinelCoordinator` struct and a minor logging fix.
- **sentinel/internal/subscription_manager/subscription_manager.go**
  - Changes logging from Hex to Str for address and topic in `Subscribe`, `Unsubscribe`, and `BroadcastLog` methods to simplify reading logs.
- **sentinel/sentinel_coordinator.go**
  - Adds a new file defining the `SentinelCoordinator` struct with fields for managing a Sentinel instance, synchronization, context for lifecycle management, and logging. Also includes a constructor function `NewSentinelCoordinator`.
