### PR TITLE
Remove WS dependancy in EVMClient creation

### DIFF
--- a/lib/.changeset/v1.50.20.md
+++ b/lib/.changeset/v1.50.20.md
@@ -1,0 +1,1 @@
+- Allows for `ConnectEVMClient` to be setup with an HTTP RPC, does not `subscribeToNewHeaders` if using HTTP

--- a/lib/blockchain/ethereum.go
+++ b/lib/blockchain/ethereum.go
@@ -105,11 +105,13 @@ func newEVMClient(networkSettings EVMNetwork, logger zerolog.Logger) (EVMClient,
 		return nil, err
 	}
 	ec.gasStats = NewGasStats(ec.ID)
-	err = ec.subscribeToNewHeaders()
-	if err != nil {
-		return nil, err
+	// Check if subscriptions are supported since HTTP does not suport subscriptions.
+	if ec.Client.Client().SupportsSubscriptions() {
+		err = ec.subscribeToNewHeaders()
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	// Check if the chain supports EIP-1559
 	// https://eips.ethereum.org/EIPS/eip-1559
 	if networkSettings.SupportsEIP1559 {
@@ -1336,13 +1338,20 @@ func NewEVMClient(networkSettings EVMNetwork, env *environment.Environment, logg
 // ConnectEVMClient returns a multi-node EVM client connected to a specified network, using only URLs.
 // Should mostly be used for inside K8s, non-simulated tests.
 func ConnectEVMClient(networkSettings EVMNetwork, logger zerolog.Logger) (EVMClient, error) {
+	var urls []string
 	if len(networkSettings.URLs) == 0 {
-		return nil, fmt.Errorf("no URLs provided to connect to network")
+		if len(networkSettings.HTTPURLs) == 0 {
+			return nil, fmt.Errorf("no URLs provided to connect to network")
+		}
+		logger.Warn().Msg("You are running using only HTTP RPC URLs.")
+		urls = networkSettings.HTTPURLs
+	} else {
+		urls = networkSettings.URLs
 	}
 
 	ecl := &EthereumMultinodeClient{}
 
-	for idx, networkURL := range networkSettings.URLs {
+	for idx, networkURL := range urls {
 		networkSettings.URL = networkURL
 		ec, err := newEVMClient(networkSettings, logger)
 

--- a/lib/blockchain/ethereum.go
+++ b/lib/blockchain/ethereum.go
@@ -105,7 +105,7 @@ func newEVMClient(networkSettings EVMNetwork, logger zerolog.Logger) (EVMClient,
 		return nil, err
 	}
 	ec.gasStats = NewGasStats(ec.ID)
-	// Check if subscriptions are supported since HTTP does not suport subscriptions.
+	// Check if subscriptions are supported since HTTP does not support subscriptions.
 	if ec.Client.Client().SupportsSubscriptions() {
 		err = ec.subscribeToNewHeaders()
 		if err != nil {


### PR DESCRIPTION
- Allows for `ConnectEVMClient` to be setup with an HTTP RPC, does not `subscribeToNewHeaders` if using HTTP
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance flexibility and robustness in connecting to Ethereum networks by allowing connections via HTTP RPC and improving handling for environments without subscription support. Additionally, the update facilitates connections to networks when only HTTP URLs are provided, improving usability in diverse network configurations.

## What
- **lib/.changeset/v1.50.20.md**
  - Added documentation for the new feature allowing `ConnectEVMClient` to be set up with an HTTP RPC.
- **lib/blockchain/ethereum.go**
  - Modified `newEVMClient` to conditionally subscribe to new headers only if the client supports subscriptions, accommodating HTTP connections.
  - Adjusted `ConnectEVMClient` to support connections using HTTP URLs if WebSocket URLs are not provided, enhancing flexibility in network configurations.
