### PR TITLE
Fix PortMappings

### DIFF
--- a/framework/components/blockchain/anvil.go
+++ b/framework/components/blockchain/anvil.go
@@ -76,6 +76,7 @@ func newAnvil(in *Input) (*Output, error) {
 		Family:        "evm",
 		ChainID:       in.ChainID,
 		ContainerName: containerName,
+		Container:     c,
 		Nodes: []*Node{
 			{
 				HostWSUrl:             fmt.Sprintf("ws://%s:%s", host, mp.Port()),

--- a/framework/components/blockchain/besu.go
+++ b/framework/components/blockchain/besu.go
@@ -100,6 +100,7 @@ func newBesu(in *Input) (*Output, error) {
 		ChainID:       in.ChainID,
 		Family:        "evm",
 		ContainerName: containerName,
+		Container:     c,
 		Nodes: []*Node{
 			{
 				HostHTTPUrl:           fmt.Sprintf("http://%s:%s", host, mp.Port()),

--- a/framework/components/blockchain/besu.go
+++ b/framework/components/blockchain/besu.go
@@ -67,20 +67,7 @@ func newBesu(in *Input) (*Output, error) {
 		},
 		Labels: framework.DefaultTCLabels(),
 		HostConfigModifier: func(h *container.HostConfig) {
-			h.PortBindings = nat.PortMap{
-				nat.Port(bindPortWs): []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: bindPortWs,
-					},
-				},
-				nat.Port(bindPort): []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: bindPort,
-					},
-				},
-			}
+			h.PortBindings = framework.MapTheSamePort(bindPortWs, bindPort)
 		},
 		WaitingFor: wait.ForListeningPort(nat.Port(in.Port)).WithStartupTimeout(15 * time.Second).WithPollInterval(200 * time.Millisecond),
 		Cmd:        entryPoint,

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"fmt"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 // Input is a blockchain network configuration params
@@ -29,11 +30,12 @@ type Input struct {
 
 // Output is a blockchain network output, ChainID and one or more nodes that forms the network
 type Output struct {
-	UseCache      bool    `toml:"use_cache"`
-	Family        string  `toml:"family"`
-	ContainerName string  `toml:"container_name"`
-	ChainID       string  `toml:"chain_id"`
-	Nodes         []*Node `toml:"nodes"`
+	UseCache      bool                     `toml:"use_cache"`
+	Family        string                   `toml:"family"`
+	ContainerName string                   `toml:"container_name"`
+	Container     testcontainers.Container `toml:"-"`
+	ChainID       string                   `toml:"chain_id"`
+	Nodes         []*Node                  `toml:"nodes"`
 }
 
 // Node represents blockchain node output, URLs required for connection locally and inside docker network

--- a/framework/components/blockchain/geth.go
+++ b/framework/components/blockchain/geth.go
@@ -214,6 +214,7 @@ func newGeth(in *Input) (*Output, error) {
 		Family:        "evm",
 		ChainID:       in.ChainID,
 		ContainerName: containerName,
+		Container:     c,
 		Nodes: []*Node{
 			{
 				HostHTTPUrl:           fmt.Sprintf("http://%s:%s", host, mp.Port()),

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -143,6 +143,7 @@ func newSolana(in *Input) (*Output, error) {
 		UseCache:      true,
 		Family:        "solana",
 		ContainerName: containerName,
+		Container:     c,
 		Nodes: []*Node{
 			{
 				HostWSUrl:             fmt.Sprintf("ws://%s:%s", host, in.WSPort),

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -105,20 +104,7 @@ func newSolana(in *Input) (*Output, error) {
 			WithStartupTimeout(30 * time.Second).
 			WithPollInterval(100 * time.Millisecond),
 		HostConfigModifier: func(h *container.HostConfig) {
-			h.PortBindings = nat.PortMap{
-				nat.Port(bindPort): []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: bindPort,
-					},
-				},
-				nat.Port(wsBindPort): []nat.PortBinding{
-					{
-						HostIP:   "0.0.0.0",
-						HostPort: wsBindPort,
-					},
-				},
-			}
+			h.PortBindings = framework.MapTheSamePort(bindPort, wsBindPort)
 			h.Mounts = append(h.Mounts, mount.Mount{
 				Type:     mount.TypeBind,
 				Source:   contractsDir,

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -135,18 +135,17 @@ func generateEntryPoint() []string {
 func generatePortBindings(in *Input) ([]string, nat.PortMap, error) {
 	httpPort := fmt.Sprintf("%s/tcp", DefaultHTTPPort)
 	innerDebuggerPort := fmt.Sprintf("%d/tcp", DefaultDebuggerPort)
-	debuggerPort := fmt.Sprintf("%d/tcp", in.Node.DebuggerPort)
 	portBindings := nat.PortMap{
 		nat.Port(httpPort): []nat.PortBinding{
 			{
 				HostIP:   "0.0.0.0",
-				HostPort: fmt.Sprintf("%d/tcp", in.Node.HTTPPort),
+				HostPort: strconv.Itoa(in.Node.HTTPPort),
 			},
 		},
 		nat.Port(innerDebuggerPort): []nat.PortBinding{
 			{
 				HostIP:   "0.0.0.0",
-				HostPort: debuggerPort,
+				HostPort: strconv.Itoa(in.Node.DebuggerPort),
 			},
 		},
 	}
@@ -160,7 +159,7 @@ func generatePortBindings(in *Input) ([]string, nat.PortMap, error) {
 			customPorts = append(customPorts, fmt.Sprintf("%s/tcp", pp[1]))
 
 			dockerPort := nat.Port(fmt.Sprintf("%s/tcp", pp[1]))
-			hostPort := fmt.Sprintf("%s/tcp", pp[0])
+			hostPort := pp[0]
 			portBindings[dockerPort] = []nat.PortBinding{
 				{
 					HostIP:   "0.0.0.0",
@@ -171,7 +170,7 @@ func generatePortBindings(in *Input) ([]string, nat.PortMap, error) {
 			customPorts = append(customPorts, fmt.Sprintf("%s/tcp", p))
 
 			dockerPort := nat.Port(fmt.Sprintf("%s/tcp", p))
-			hostPort := fmt.Sprintf("%s/tcp", p)
+			hostPort := p
 			portBindings[dockerPort] = []nat.PortBinding{
 				{
 					HostIP:   "0.0.0.0",

--- a/framework/components/postgres/postgres.go
+++ b/framework/components/postgres/postgres.go
@@ -9,6 +9,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	tcwait "github.com/testcontainers/testcontainers-go/wait"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -121,7 +122,7 @@ func NewPostgreSQL(in *Input) (*Output, error) {
 			nat.Port(bindPort): []nat.PortBinding{
 				{
 					HostIP:   "0.0.0.0",
-					HostPort: fmt.Sprintf("%d/tcp", portToExpose),
+					HostPort: strconv.Itoa(portToExpose),
 				},
 			},
 		}

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -47,15 +47,19 @@ func GetHost(container tc.Container) (string, error) {
 	return host, nil
 }
 
-func MapTheSamePort(port string) nat.PortMap {
-	return nat.PortMap{
-		nat.Port(port): []nat.PortBinding{
+func MapTheSamePort(ports ...string) nat.PortMap {
+	portMap := nat.PortMap{}
+	for _, port := range ports {
+		// need to split off /tcp or /udp
+		onlyPort := strings.SplitN(port, "/", 2)
+		portMap[nat.Port(port)] = []nat.PortBinding{
 			{
 				HostIP:   "0.0.0.0",
-				HostPort: port,
+				HostPort: onlyPort[0],
 			},
-		},
+		}
 	}
+	return portMap
 }
 
 func DefaultTCLabels() map[string]string {


### PR DESCRIPTION
We were mapping `8080/tcp` to `8080/tcp`, which is technically invalid syntax but docker accepted it. We should map `8080/tcp` to `8080` (no protocol specifier). This fixes running CTF with podman.

The second change is exposing the testcontainer object from the solana component. We're programatically using it within a test environment without a TOML config and would like to be able to call `testcontainers.CleanupContainer(c)`