### PR TITLE
[TT-1929] make sure go.mods are tidy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,26 @@ jobs:
       - name: Run pre-commit checks
         run: |
           nix develop -c sh -c "pre-commit run --hook-stage pre-commit --show-diff-on-failure --color=always"
+
+  clean-go-mods:
+    name: Clean go mods
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.23.3
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.3'
+      - name: Install gomods
+        run: go install github.com/jmank88/gomods@v0.1.4
+      - name: Check out code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Run gomods tidy
+        run: gomods tidy
+      - name: Ensure clean after tidy
+        run: |
+          git add --all
+          git diff --minimal --cached --exit-code
+
   tools:
     name: Get tool-versions
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes implement new jobs and steps in the GitHub Actions workflow to enhance code quality and dependency management. Specifically, they add a job for cleaning Go modules, ensuring all dependencies are correctly managed and tidy. This is crucial for maintaining a clean and efficient codebase.

## What
- **.github/workflows/lint.yaml**
  - Added a new job `clean-go-mods` to run Go modules cleanup. This includes setting up Go 1.23.3, installing gomods, checking out code, running `gomods tidy`, and ensuring the codebase is clean after the tidy operation. This ensures that the project's dependencies are properly managed and free from unnecessary modules.
  - Other existing jobs like `pre-commit`, `tools`, `golangci`, `vulnerabilities-check`, `asdf-install`, `helmlint`, `actionlint`, and `sonarqube` remain unchanged, focusing on their specific tasks like linting, vulnerabilities check, installing dependencies, linting Helm charts, validating GitHub Action workflows, and running SonarQube analysis respectively.
