### PR TITLE
[TT-1923] add changeset for Seth v1.50.11

### DIFF
--- a/seth/.changeset/v1.50.11.md
+++ b/seth/.changeset/v1.50.11.md
@@ -1,0 +1,1 @@
+- improvement: allow to retry gas estimation by providing `gas_price_estimation_attempt_count` setting on a Network level (defaults to 1 -> no retries)


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
This change introduces an improvement allowing users to configure the number of attempts for gas price estimation on a network level, enhancing flexibility and reliability in transactions.

## What
- **seth/.changeset/v1.50.11.md**
  - Added documentation for the new feature: allowing retries for gas price estimation by introducing `gas_price_estimation_attempt_count` setting. This defaults to 1, which means no retries unless configured otherwise.
