### PR TITLE
[TT-1934] event hash collision

### DIFF
--- a/seth/.changeset/v1.50.11.md
+++ b/seth/.changeset/v1.50.11.md
@@ -1,0 +1,2 @@
+ - improvement: allow to retry gas estimation by providing `gas_price_estimation_attempt_count` setting on a Network level (defaults to 1 -> no retries)
+ - improvement: better handling of event signature (hash) collisions (although still not 100% bullet-proof due to complexlity)

--- a/seth/client_decode_test.go
+++ b/seth/client_decode_test.go
@@ -75,85 +75,85 @@ func TestSmokeDebugData(t *testing.T) {
 	}
 
 	tests := []test{
-		// {
-		// 	name:   "test named inputs/outputs",
-		// 	method: "emitNamedInputsOutputs",
-		// 	params: []interface{}{big.NewInt(1337), "test"},
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		CommonData: seth.CommonData{
-		// 			Input: map[string]interface{}{
-		// 				"inputVal1": big.NewInt(1337),
-		// 				"inputVal2": "test",
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// // TODO: https://docs.soliditylang.org/en/v0.8.19/control-structures.html read and figure out if
-		// // decoding anynymous + named is heavily used and needed, usually people name params and omit output names
-		// {
-		// 	name:   "test anonymous inputs/outputs",
-		// 	method: "emitInputsOutputs",
-		// 	params: []interface{}{big.NewInt(1337), "test"},
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		CommonData: seth.CommonData{
-		// 			Input: map[string]interface{}{
-		// 				"inputVal1": big.NewInt(1337),
-		// 				"inputVal2": "test",
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	name:   "test one log no index",
-		// 	method: "emitNoIndexEvent",
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		Events: []seth.DecodedTransactionLog{
-		// 			{
-		// 				DecodedCommonLog: seth.DecodedCommonLog{
-		// 					EventData: map[string]interface{}{
-		// 						"sender": c.Addresses[0],
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	name:   "test one log index",
-		// 	method: "emitOneIndexEvent",
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		Events: []seth.DecodedTransactionLog{
-		// 			{
-		// 				DecodedCommonLog: seth.DecodedCommonLog{
-		// 					EventData: map[string]interface{}{
-		// 						"a": big.NewInt(83),
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	name:   "test two log index",
-		// 	method: "emitTwoIndexEvent",
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		Events: []seth.DecodedTransactionLog{
-		// 			{
-		// 				DecodedCommonLog: seth.DecodedCommonLog{
-		// 					EventData: map[string]interface{}{
-		// 						"roundId":   big.NewInt(1),
-		// 						"startedBy": c.Addresses[0],
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		{
+			name:   "test named inputs/outputs",
+			method: "emitNamedInputsOutputs",
+			params: []interface{}{big.NewInt(1337), "test"},
+			write:  true,
+			output: seth.DecodedTransaction{
+				CommonData: seth.CommonData{
+					Input: map[string]interface{}{
+						"inputVal1": big.NewInt(1337),
+						"inputVal2": "test",
+					},
+				},
+			},
+		},
+		// TODO: https://docs.soliditylang.org/en/v0.8.19/control-structures.html read and figure out if
+		// decoding anynymous + named is heavily used and needed, usually people name params and omit output names
+		{
+			name:   "test anonymous inputs/outputs",
+			method: "emitInputsOutputs",
+			params: []interface{}{big.NewInt(1337), "test"},
+			write:  true,
+			output: seth.DecodedTransaction{
+				CommonData: seth.CommonData{
+					Input: map[string]interface{}{
+						"inputVal1": big.NewInt(1337),
+						"inputVal2": "test",
+					},
+				},
+			},
+		},
+		{
+			name:   "test one log no index",
+			method: "emitNoIndexEvent",
+			write:  true,
+			output: seth.DecodedTransaction{
+				Events: []seth.DecodedTransactionLog{
+					{
+						DecodedCommonLog: seth.DecodedCommonLog{
+							EventData: map[string]interface{}{
+								"sender": c.Addresses[0],
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "test one log index",
+			method: "emitOneIndexEvent",
+			write:  true,
+			output: seth.DecodedTransaction{
+				Events: []seth.DecodedTransactionLog{
+					{
+						DecodedCommonLog: seth.DecodedCommonLog{
+							EventData: map[string]interface{}{
+								"a": big.NewInt(83),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "test two log index",
+			method: "emitTwoIndexEvent",
+			write:  true,
+			output: seth.DecodedTransaction{
+				Events: []seth.DecodedTransactionLog{
+					{
+						DecodedCommonLog: seth.DecodedCommonLog{
+							EventData: map[string]interface{}{
+								"roundId":   big.NewInt(1),
+								"startedBy": c.Addresses[0],
+							},
+						},
+					},
+				},
+			},
+		},
 		{
 			name:   "test three log index",
 			method: "emitThreeIndexEvent",
@@ -172,47 +172,47 @@ func TestSmokeDebugData(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	name:   "test log no index string",
-		// 	method: "emitNoIndexEventString",
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		Events: []seth.DecodedTransactionLog{
-		// 			{
-		// 				DecodedCommonLog: seth.DecodedCommonLog{
-		// 					EventData: map[string]interface{}{
-		// 						"str": "myString",
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// // emitNoIndexStructEvent
-		// {
-		// 	name:   "test log struct",
-		// 	method: "emitNoIndexStructEvent",
-		// 	write:  true,
-		// 	output: seth.DecodedTransaction{
-		// 		Events: []seth.DecodedTransactionLog{
-		// 			{
-		// 				DecodedCommonLog: seth.DecodedCommonLog{
-		// 					EventData: map[string]interface{}{
-		// 						"a": struct {
-		// 							Name       string   `json:"name"`
-		// 							Balance    uint64   `json:"balance"`
-		// 							DailyLimit *big.Int `json:"dailyLimit"`
-		// 						}{
-		// 							Name:       "John",
-		// 							Balance:    5,
-		// 							DailyLimit: big.NewInt(10),
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// },
+		{
+			name:   "test log no index string",
+			method: "emitNoIndexEventString",
+			write:  true,
+			output: seth.DecodedTransaction{
+				Events: []seth.DecodedTransactionLog{
+					{
+						DecodedCommonLog: seth.DecodedCommonLog{
+							EventData: map[string]interface{}{
+								"str": "myString",
+							},
+						},
+					},
+				},
+			},
+		},
+		// emitNoIndexStructEvent
+		{
+			name:   "test log struct",
+			method: "emitNoIndexStructEvent",
+			write:  true,
+			output: seth.DecodedTransaction{
+				Events: []seth.DecodedTransactionLog{
+					{
+						DecodedCommonLog: seth.DecodedCommonLog{
+							EventData: map[string]interface{}{
+								"a": struct {
+									Name       string   `json:"name"`
+									Balance    uint64   `json:"balance"`
+									DailyLimit *big.Int `json:"dailyLimit"`
+								}{
+									Name:       "John",
+									Balance:    5,
+									DailyLimit: big.NewInt(10),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 		// TODO: another case - figure out if indexed strings are used by anyone in events
 		// https://ethereum.stackexchange.com/questions/6840/indexed-event-with-string-not-getting-logged
 	}

--- a/seth/client_decode_test.go
+++ b/seth/client_decode_test.go
@@ -75,85 +75,85 @@ func TestSmokeDebugData(t *testing.T) {
 	}
 
 	tests := []test{
-		{
-			name:   "test named inputs/outputs",
-			method: "emitNamedInputsOutputs",
-			params: []interface{}{big.NewInt(1337), "test"},
-			write:  true,
-			output: seth.DecodedTransaction{
-				CommonData: seth.CommonData{
-					Input: map[string]interface{}{
-						"inputVal1": big.NewInt(1337),
-						"inputVal2": "test",
-					},
-				},
-			},
-		},
-		// TODO: https://docs.soliditylang.org/en/v0.8.19/control-structures.html read and figure out if
-		// decoding anynymous + named is heavily used and needed, usually people name params and omit output names
-		{
-			name:   "test anonymous inputs/outputs",
-			method: "emitInputsOutputs",
-			params: []interface{}{big.NewInt(1337), "test"},
-			write:  true,
-			output: seth.DecodedTransaction{
-				CommonData: seth.CommonData{
-					Input: map[string]interface{}{
-						"inputVal1": big.NewInt(1337),
-						"inputVal2": "test",
-					},
-				},
-			},
-		},
-		{
-			name:   "test one log no index",
-			method: "emitNoIndexEvent",
-			write:  true,
-			output: seth.DecodedTransaction{
-				Events: []seth.DecodedTransactionLog{
-					{
-						DecodedCommonLog: seth.DecodedCommonLog{
-							EventData: map[string]interface{}{
-								"sender": c.Addresses[0],
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:   "test one log index",
-			method: "emitOneIndexEvent",
-			write:  true,
-			output: seth.DecodedTransaction{
-				Events: []seth.DecodedTransactionLog{
-					{
-						DecodedCommonLog: seth.DecodedCommonLog{
-							EventData: map[string]interface{}{
-								"a": big.NewInt(83),
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:   "test two log index",
-			method: "emitTwoIndexEvent",
-			write:  true,
-			output: seth.DecodedTransaction{
-				Events: []seth.DecodedTransactionLog{
-					{
-						DecodedCommonLog: seth.DecodedCommonLog{
-							EventData: map[string]interface{}{
-								"roundId":   big.NewInt(1),
-								"startedBy": c.Addresses[0],
-							},
-						},
-					},
-				},
-			},
-		},
+		// {
+		// 	name:   "test named inputs/outputs",
+		// 	method: "emitNamedInputsOutputs",
+		// 	params: []interface{}{big.NewInt(1337), "test"},
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		CommonData: seth.CommonData{
+		// 			Input: map[string]interface{}{
+		// 				"inputVal1": big.NewInt(1337),
+		// 				"inputVal2": "test",
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// // TODO: https://docs.soliditylang.org/en/v0.8.19/control-structures.html read and figure out if
+		// // decoding anynymous + named is heavily used and needed, usually people name params and omit output names
+		// {
+		// 	name:   "test anonymous inputs/outputs",
+		// 	method: "emitInputsOutputs",
+		// 	params: []interface{}{big.NewInt(1337), "test"},
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		CommonData: seth.CommonData{
+		// 			Input: map[string]interface{}{
+		// 				"inputVal1": big.NewInt(1337),
+		// 				"inputVal2": "test",
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	name:   "test one log no index",
+		// 	method: "emitNoIndexEvent",
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		Events: []seth.DecodedTransactionLog{
+		// 			{
+		// 				DecodedCommonLog: seth.DecodedCommonLog{
+		// 					EventData: map[string]interface{}{
+		// 						"sender": c.Addresses[0],
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	name:   "test one log index",
+		// 	method: "emitOneIndexEvent",
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		Events: []seth.DecodedTransactionLog{
+		// 			{
+		// 				DecodedCommonLog: seth.DecodedCommonLog{
+		// 					EventData: map[string]interface{}{
+		// 						"a": big.NewInt(83),
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	name:   "test two log index",
+		// 	method: "emitTwoIndexEvent",
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		Events: []seth.DecodedTransactionLog{
+		// 			{
+		// 				DecodedCommonLog: seth.DecodedCommonLog{
+		// 					EventData: map[string]interface{}{
+		// 						"roundId":   big.NewInt(1),
+		// 						"startedBy": c.Addresses[0],
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 		{
 			name:   "test three log index",
 			method: "emitThreeIndexEvent",
@@ -172,47 +172,47 @@ func TestSmokeDebugData(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:   "test log no index string",
-			method: "emitNoIndexEventString",
-			write:  true,
-			output: seth.DecodedTransaction{
-				Events: []seth.DecodedTransactionLog{
-					{
-						DecodedCommonLog: seth.DecodedCommonLog{
-							EventData: map[string]interface{}{
-								"str": "myString",
-							},
-						},
-					},
-				},
-			},
-		},
-		// emitNoIndexStructEvent
-		{
-			name:   "test log struct",
-			method: "emitNoIndexStructEvent",
-			write:  true,
-			output: seth.DecodedTransaction{
-				Events: []seth.DecodedTransactionLog{
-					{
-						DecodedCommonLog: seth.DecodedCommonLog{
-							EventData: map[string]interface{}{
-								"a": struct {
-									Name       string   `json:"name"`
-									Balance    uint64   `json:"balance"`
-									DailyLimit *big.Int `json:"dailyLimit"`
-								}{
-									Name:       "John",
-									Balance:    5,
-									DailyLimit: big.NewInt(10),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
+		// {
+		// 	name:   "test log no index string",
+		// 	method: "emitNoIndexEventString",
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		Events: []seth.DecodedTransactionLog{
+		// 			{
+		// 				DecodedCommonLog: seth.DecodedCommonLog{
+		// 					EventData: map[string]interface{}{
+		// 						"str": "myString",
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// // emitNoIndexStructEvent
+		// {
+		// 	name:   "test log struct",
+		// 	method: "emitNoIndexStructEvent",
+		// 	write:  true,
+		// 	output: seth.DecodedTransaction{
+		// 		Events: []seth.DecodedTransactionLog{
+		// 			{
+		// 				DecodedCommonLog: seth.DecodedCommonLog{
+		// 					EventData: map[string]interface{}{
+		// 						"a": struct {
+		// 							Name       string   `json:"name"`
+		// 							Balance    uint64   `json:"balance"`
+		// 							DailyLimit *big.Int `json:"dailyLimit"`
+		// 						}{
+		// 							Name:       "John",
+		// 							Balance:    5,
+		// 							DailyLimit: big.NewInt(10),
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
 		// TODO: another case - figure out if indexed strings are used by anyone in events
 		// https://ethereum.stackexchange.com/questions/6840/indexed-event-with-string-not-getting-logged
 	}

--- a/seth/contract_map.go
+++ b/seth/contract_map.go
@@ -45,15 +45,15 @@ func (c ContractMap) GetContractName(addr string) string {
 	return c.addressMap[strings.ToLower(addr)]
 }
 
-func (c ContractMap) GetContractAddress(addr string) string {
-	if addr == UNKNOWN {
+func (c ContractMap) GetContractAddress(name string) string {
+	if name == UNKNOWN {
 		return UNKNOWN
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for k, v := range c.addressMap {
-		if v == addr {
+		if v == name {
 			return k
 		}
 	}

--- a/tools/breakingchanges/cmd/main.go
+++ b/tools/breakingchanges/cmd/main.go
@@ -85,8 +85,8 @@ func getRetractedTags(goModPath string) ([]*semver.Constraints, error) {
 
 func getLatestTag(pathPrefix string, retractedTags []*semver.Constraints) (string, error) {
 	// use regex to find exact matches, as otherwise might include pre-release versions
-	// or versions that partially match the path prefix, e.g. when seraching for 'lib'
-	// we won't make sure we won't include tags like `lib/grafana/v1.0.0`
+	// or versions that partially match the path prefix, e.g. when searching for 'lib'
+	// we want to make sure we won't include tags like `lib/grafana/v1.0.0`
 	grepRegex := fmt.Sprintf("^%s/v[0-9]+\\.[0-9]+\\.[0-9]+$", pathPrefix)
 
 	//nolint


### PR DESCRIPTION
After changing Seth logic to debug event using all ABIs I’ve noticed an intermitently failing Seth smoke test, which turned out to be caused by event signature collision. Two contracts have events with the same name and parameters, but one of them has the last parameter non-indexed. And when that contract’s ABI is selected for decoding, then the test fails.

Comparing signature of the whole event is complicated due to various data types, so I will apply a simpler fix:

if we know what contract is at given address, we know its ABI and we don’t need to iterate overall ABIs

if we don’t then we will iterate over all, but apart from signature also check whether number of indexed parameter matches the log (that’s an easy check)
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve contract log decoding by optimizing the event matching process and fixing minor issues in function parameters and comments. These changes aim to enhance performance, accuracy in event log decoding, and clarity in the codebase.

## What
- **`seth/client.go`**
  - Added `reflect` package import for deep equality checks.
  - Refactored `decodeContractLogs` to use a precomputed map (`sigMap`) of event signatures to their possible events and ABIs, improving efficiency by avoiding redundant ABI iterations.
  - Introduced `buildEventSignatureMap` function to create a signature to event and ABI mapping, facilitating faster event log decoding.
  - Improved logging messages for clarity and debuggability.
  - Added checks for logs with no topics and mismatching indexed parameters, ensuring only logs with matching event signatures and correct indexed parameter counts are processed.
  - Implemented logic to handle known contract ABIs directly, reducing unnecessary ABI comparisons.
- **`seth/contract_map.go`**
  - Fixed parameter name in `GetContractAddress` to accurately reflect its purpose, enhancing code readability and maintainability.
- **`tools/breakingchanges/cmd/main.go`**
  - Corrected a typo and clarified a comment in `getLatestTag` to improve code documentation and readability.
