### PR TITLE
perf tool enhancement

### DIFF
--- a/book/src/libs/wasp/benchspy/real_world.md
+++ b/book/src/libs/wasp/benchspy/real_world.md
@@ -87,14 +87,16 @@ This function fetches the current report (for version passed as environment vari
 Let’s assume you want to ensure that none of the performance metrics degrade by more than **1%** between releases (and that error rate has not changed at all). Here's how you can write assertions using a convenient function for the `Direct` query executor:
 
 ```go
-hasErrors, errors := benchspy.CompareDirectWithThresholds(
+hasFailed, error := benchspy.CompareDirectWithThresholds(
     1.0, // Max 1% worse median latency
     1.0, // Max 1% worse p95 latency
     1.0, // Max 1% worse maximum latency
     0.0, // No increase in error rate
     currentReport, previousReport)
-require.False(t, hasErrors, fmt.Sprintf("errors found: %v", errors))
+require.False(t, hasError, fmt.Sprintf("issues found: %v", error))
 ```
+
+Error returned by this function is a concatenation of all threshold violations found for each standard metric and generator.
 
 ---
 

--- a/wasp/benchspy/report_test.go
+++ b/wasp/benchspy/report_test.go
@@ -1384,13 +1384,10 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 1.0, 1.0, 1.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 1.0, 1.0, 1.0, currentReport, previousReport)
 		assert.True(t, failed)
-		assert.Len(t, errs, 1)
-		assert.Len(t, errs["test-gen"], 1)
-		for _, err := range errs["test-gen"] {
-			assert.Contains(t, err.Error(), "different, which is higher than the threshold")
-		}
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 50.0000%% different, which is higher than the threshold", string(MedianLatency)))
 	})
 
 	t.Run("all metrics exceed thresholds", func(t *testing.T) {
@@ -1442,13 +1439,13 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
 		assert.True(t, failed)
-		assert.Len(t, errs, 1)
-		assert.Len(t, errs["test-gen"], 4)
-		for _, err := range errs["test-gen"] {
-			assert.Contains(t, err.Error(), "different, which is higher than the threshold")
-		}
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 50.0000%% different, which is higher than the threshold", string(MedianLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 50.0000%% different, which is higher than the threshold", string(Percentile95Latency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 50.0000%% different, which is higher than the threshold", string(MaxLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 100.0000%% different, which is higher than the threshold", string(ErrorRate)))
 	})
 
 	t.Run("handle zero values", func(t *testing.T) {
@@ -1500,12 +1497,67 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
 		assert.False(t, failed)
-		assert.Empty(t, errs)
+		assert.Nil(t, err)
 	})
 
-	t.Run("handle missing metrics", func(t *testing.T) {
+	t.Run("handle missing metrics from current report", func(t *testing.T) {
+		previousReport := &StandardReport{
+			BasicData: BasicData{
+				GeneratorConfigs: map[string]*wasp.Config{
+					"test-gen": {
+						GenName: "test-gen",
+					},
+				},
+			},
+			QueryExecutors: []QueryExecutor{
+				&MockQueryExecutor{
+					KindFn: func() string { return string(StandardQueryExecutor_Direct) },
+					ResultsFn: func() map[string]interface{} {
+						return map[string]interface{}{
+							string(MedianLatency):       100.0,
+							string(Percentile95Latency): 0.0,
+							string(MaxLatency):          0.0,
+							string(ErrorRate):           0.0,
+						}
+					},
+					GeneratorNameFn: func() string { return "test-gen" },
+				},
+			},
+		}
+
+		currentReport := &StandardReport{
+			BasicData: BasicData{
+				GeneratorConfigs: map[string]*wasp.Config{
+					"test-gen": {
+						GenName: "test-gen",
+					},
+				},
+			},
+			QueryExecutors: []QueryExecutor{
+				&MockQueryExecutor{
+					KindFn: func() string { return string(StandardQueryExecutor_Direct) },
+					ResultsFn: func() map[string]interface{} {
+						return map[string]interface{}{
+							string(MedianLatency): 105.0,
+							// missing other metrics
+						}
+					},
+					GeneratorNameFn: func() string { return "test-gen" },
+				},
+			},
+		}
+
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		assert.True(t, failed)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(Percentile95Latency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(MaxLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(ErrorRate)))
+	})
+
+	t.Run("handle missing metrics from previous report", func(t *testing.T) {
 		previousReport := &StandardReport{
 			BasicData: BasicData{
 				GeneratorConfigs: map[string]*wasp.Config{
@@ -1541,6 +1593,63 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 					KindFn: func() string { return string(StandardQueryExecutor_Direct) },
 					ResultsFn: func() map[string]interface{} {
 						return map[string]interface{}{
+							string(MedianLatency):       105.0,
+							string(Percentile95Latency): 0.0,
+							string(MaxLatency):          0.0,
+							string(ErrorRate):           0.0,
+						}
+					},
+					GeneratorNameFn: func() string { return "test-gen" },
+				},
+			},
+		}
+
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		assert.True(t, failed)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from previous report", string(Percentile95Latency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from previous report", string(MaxLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from previous report", string(ErrorRate)))
+	})
+
+	t.Run("handle missing metrics from both reports", func(t *testing.T) {
+		previousReport := &StandardReport{
+			BasicData: BasicData{
+				GeneratorConfigs: map[string]*wasp.Config{
+					"test-gen": {
+						GenName: "test-gen",
+					},
+				},
+			},
+			QueryExecutors: []QueryExecutor{
+				&MockQueryExecutor{
+					KindFn: func() string { return string(StandardQueryExecutor_Direct) },
+					ResultsFn: func() map[string]interface{} {
+						return map[string]interface{}{
+							string(MedianLatency):       100.0,
+							string(Percentile95Latency): 0.0,
+							string(MaxLatency):          0.0,
+							string(ErrorRate):           0.0,
+						}
+					},
+					GeneratorNameFn: func() string { return "test-gen" },
+				},
+			},
+		}
+
+		currentReport := &StandardReport{
+			BasicData: BasicData{
+				GeneratorConfigs: map[string]*wasp.Config{
+					"test-gen": {
+						GenName: "test-gen",
+					},
+				},
+			},
+			QueryExecutors: []QueryExecutor{
+				&MockQueryExecutor{
+					KindFn: func() string { return string(StandardQueryExecutor_Direct) },
+					ResultsFn: func() map[string]interface{} {
+						return map[string]interface{}{
 							string(MedianLatency): 105.0,
 							// missing other metrics
 						}
@@ -1550,13 +1659,12 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
 		assert.True(t, failed)
-		assert.Len(t, errs, 1)
-		assert.Len(t, errs["test-gen"], 3) // Should have errors for missing P95, Max, and Error Rate
-		for _, err := range errs["test-gen"] {
-			assert.Contains(t, err.Error(), "results were missing")
-		}
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(Percentile95Latency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(MaxLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s metric results were missing from current report", string(ErrorRate)))
 	})
 
 	t.Run("handle zero to non-zero transition", func(t *testing.T) {
@@ -1608,13 +1716,13 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
 		assert.True(t, failed)
-		assert.Len(t, errs, 1)
-		assert.Len(t, errs["test-gen"], 4)
-		for _, err := range errs["test-gen"] {
-			assert.Contains(t, err.Error(), "999.0000% different")
-		}
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 999.0000%% different, which is higher than the threshold", string(MedianLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 999.0000%% different, which is higher than the threshold", string(Percentile95Latency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 999.0000%% different, which is higher than the threshold", string(MaxLatency)))
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 999.0000%% different, which is higher than the threshold", string(ErrorRate)))
 	})
 
 	t.Run("handle non-zero to zero transition", func(t *testing.T) {
@@ -1666,9 +1774,9 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, currentReport, previousReport)
 		assert.False(t, failed)
-		assert.Len(t, errs, 0)
+		assert.Nil(t, err)
 	})
 
 	t.Run("handle edge-cases", func(t *testing.T) {
@@ -1720,11 +1828,10 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(0.99, 0.9892, 10.0, 10.0, currentReport, previousReport)
+		failed, err := CompareDirectWithThresholds(0.99, 0.9892, 10.0, 10.0, currentReport, previousReport)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["test-gen"]))
-		assert.Contains(t, errs["test-gen"][0].Error(), "0.9901% different")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("[test-gen] %s is 0.9901%% different, which is higher than the threshold", string(MedianLatency)))
 	})
 
 	t.Run("handle nil reports", func(t *testing.T) {
@@ -1752,23 +1859,20 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, report, nil)
+		failed, err := CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, report, nil)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "one or both reports are nil")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "one or both reports are nil")
 
-		failed, errs = CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, nil, report)
+		failed, err = CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, nil, report)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "one or both reports are nil")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "one or both reports are nil")
 
-		failed, errs = CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, nil, nil)
+		failed, err = CompareDirectWithThresholds(10.0, 10.0, 10.0, 10.0, nil, nil)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "one or both reports are nil")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "one or both reports are nil")
 	})
 
 	t.Run("handle incorrect thresholds", func(t *testing.T) {
@@ -1796,26 +1900,23 @@ func TestBenchSpy_CompareDirectWithThresholds(t *testing.T) {
 			},
 		}
 
-		failed, errs := CompareDirectWithThresholds(-0.1, 100.0, 0.0, 100.0, report, report)
+		failed, err := CompareDirectWithThresholds(-0.1, 100.0, 0.0, 100.0, report, report)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "median threshold -0.1000 is not in the range [0, 100]")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "median threshold -0.1000 is not in the range [0, 100]")
 
-		failed, errs = CompareDirectWithThresholds(1.0, 101.0, 0.0, 100.0, report, report)
+		failed, err = CompareDirectWithThresholds(1.0, 101.0, 0.0, 100.0, report, report)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 1, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "p95 threshold 101.0000 is not in the range [0, 100]")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "p95 threshold 101.0000 is not in the range [0, 100]")
 
-		failed, errs = CompareDirectWithThresholds(-1, -1, -1, -1, report, report)
+		failed, err = CompareDirectWithThresholds(-1, -1, -1, -1, report, report)
 		assert.True(t, failed)
-		assert.Equal(t, 1, len(errs))
-		assert.Equal(t, 4, len(errs["initialization"]))
-		assert.Contains(t, errs["initialization"][0].Error(), "median threshold -1.0000 is not in the range [0, 100]")
-		assert.Contains(t, errs["initialization"][1].Error(), "p95 threshold -1.0000 is not in the range [0, 100]")
-		assert.Contains(t, errs["initialization"][2].Error(), "max threshold -1.0000 is not in the range [0, 100]")
-		assert.Contains(t, errs["initialization"][3].Error(), "error rate threshold -1.0000 is not in the range [0, 100]")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "median threshold -1.0000 is not in the range [0, 100]")
+		assert.Contains(t, err.Error(), "p95 threshold -1.0000 is not in the range [0, 100]")
+		assert.Contains(t, err.Error(), "max threshold -1.0000 is not in the range [0, 100]")
+		assert.Contains(t, err.Error(), "error rate threshold -1.0000 is not in the range [0, 100]")
 	})
 }
 


### PR DESCRIPTION
Direct query comparison:
* add threshold validation, 
* nil report validation, 
* better readability for infinite metric change (`999%` instead of `100%` since in reality the change is infinite)
* couple more unit tests for edge cases
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes refine the calculation of percentage differences, especially for edge cases where previous values are zero, and enhance the validation and comparison logic in the benchmark spy reporting functionality. This includes handling cases with nil reports, incorrect thresholds, and transitions from zero to non-zero values more gracefully, which improves the accuracy and reliability of performance comparison over time.

## What
- **wasp/benchspy/report.go**
  - Modified `calculateDiffPercentage` function to handle edge cases, especially when the previous value is 0, by introducing conventions for infinite changes and complete improvements.
  - Added checks in `CompareDirectWithThresholds` to immediately return errors if one or both reports are nil, ensuring the function handles uninitialized reports.
  - Introduced `validateThresholds` function to ensure that the thresholds for median, P95, max latency, and error rate are within the acceptable range of 0 to 100.
- **wasp/benchspy/report_test.go**
  - Enhanced test cases to cover new scenarios, including handling of nil reports, incorrect threshold values, zero to non-zero transitions, and non-zero to zero transitions. This ensures the new logic behaves as expected under a wide range of conditions.
