### PR TITLE
fix(solana): fix broken smoke test

### DIFF
--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -40,7 +40,7 @@ func defaultSolana(in *Input) {
 		in.Image = "solanalabs/solana:v1.18.26"
 	}
 	if in.Port == "" {
-		in.Port = "8545"
+		in.Port = "8999"
 	}
 }
 

--- a/framework/examples/myproject/smoke_solana.toml
+++ b/framework/examples/myproject/smoke_solana.toml
@@ -3,7 +3,3 @@
   type = "solana"
   public_key = "9n1pyVGGo6V4mpiSDMVay5As9NurEkY283wwRk1Kto2C"
   contracts_dir = "."
-  image = "solanalabs/solana:v1.18.26"
-
-[blockchain_a.solana_programs]
-  mcm = "6UmMZr5MEqiKWD5jqTJd1WCR5kT8oZuFYBLJFi1o6GQX"


### PR DESCRIPTION
The smoke test was expecting the mcm.so file due to the config in `blockchain_a.solana_programs` , since we dont provide any program to deploy in the smoke test, we should not define that config.

I have also updated the default port for solana to be 8999 as that is the default port for solana test validator and it is what users would expect.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update Solana configurations and defaults to improve the framework's compatibility and flexibility with different environments and use cases.

## What
- **framework/components/blockchain/solana.go**
  - Changed default port for Solana from `8545` to `8999`. This modification ensures the port setting aligns better with Solana's default configurations.
- **framework/examples/myproject/smoke_solana.toml**
  - Removed explicit Solana image version, allowing the framework to decide the best version dynamically, which is particularly beneficial for CI environments.
  - Removed `blockchain_a.solana_programs` section, simplifying the configuration by relying on defaults or external settings for Solana programs.
