### PR TITLE
[BenchSpy] add tiny test start/end time validation

### DIFF
--- a/wasp/benchspy/basic.go
+++ b/wasp/benchspy/basic.go
@@ -121,6 +121,13 @@ func (b *BasicData) Validate() error {
 		return errors.New("test end time is missing. We cannot query Loki without a time range. Please set it and try again")
 	}
 
+	if b.TestEnd.Before(b.TestStart) {
+		return errors.New("test end time is before test start time. Please set valid times and try again")
+	}
+	if b.TestEnd.Sub(b.TestStart) < time.Second {
+		return errors.New("test duration is less than a second. Please set a valid time range and try again")
+	}
+
 	if len(b.GeneratorConfigs) == 0 {
 		return errors.New("generator configs are missing. At least one is required. Please set them and try again")
 	}

--- a/wasp/benchspy/basic_test.go
+++ b/wasp/benchspy/basic_test.go
@@ -277,6 +277,33 @@ func TestBenchSpy_TestBasicData_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "generator configs are missing",
 		},
+		{
+			name: "test start and end time are the same",
+			bd: &BasicData{
+				TestStart: time.Now(),
+				TestEnd:   time.Now(),
+			},
+			wantErr: true,
+			errMsg:  "test duration is less than a second",
+		},
+		{
+			name: "test end time before start time",
+			bd: &BasicData{
+				TestStart: time.Now().Add(time.Hour),
+				TestEnd:   time.Now(),
+			},
+			wantErr: true,
+			errMsg:  "test end time is before test start time",
+		},
+		{
+			name: "test end time are start time < 1s apart",
+			bd: &BasicData{
+				TestStart: time.Now(),
+				TestEnd:   time.Now().Add(time.Second - time.Millisecond),
+			},
+			wantErr: true,
+			errMsg:  "test duration is less than a second",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduced in both `basic.go` and `basic_test.go` are designed to enhance validation logic for test data configurations in the benchmarking spy utility. By ensuring start and end times are logical and minimum test duration criteria are met, these amendments aim to prevent erroneous data collection and analysis.

## What
- **wasp/benchspy/basic.go**
  - Added validation to check if test end time is before test start time. This ensures the logical sequence of test timings.
  - Added validation to ensure the test duration is at least one second. This prevents creating tests with durations too short to be meaningful.
- **wasp/benchspy/basic_test.go**
  - Introduced test cases for new validation rules:
    - Checking when test start and end times are the same, expecting an error regarding test duration.
    - Verifying behavior when test end time is set before start time, expecting an error about invalid time sequence.
    - Testing with test end time less than a second apart from start time, expecting a validation error about insufficient test duration.
