### PR TITLE
Forward SETH_LOG_LEVEL env to remote runner

### DIFF
--- a/lib/k8s/config/overrides.go
+++ b/lib/k8s/config/overrides.go
@@ -109,6 +109,10 @@ const (
 	EnvBase64ConfigOverride             = "BASE64_CONFIG_OVERRIDE"
 	EnvBase64ConfigOverriderDescription = "Base64-encoded TOML config (should contain at least chainlink image and version)"
 	EnvBase64ConfigOverrideExample      = "W0NoYWlubGlua0ltYWdlXQppbWFnZT0icHVibGljLmVjci5hd3MvY2hhaW5saW5rL2NoYWlubGluayIKdmVyc2lvbj0iMi43LjEtYXV0b21hdGlvbi0yMDIzMTEyNyIKCltBdXRvbWF0aW9uXQpbQXV0b21hdGlvbi5HZW5lcmFsXQpkdXJhdGlvbj0yMDAK"
+
+	EnvSethLogLevel            = "SETH_LOG_LEVEL"
+	EnvSethLogLevelDescription = "Specifies the log level used by Seth"
+	EnvSethLogLevelExample     = "info"
 )
 
 var (

--- a/lib/k8s/environment/runner.go
+++ b/lib/k8s/environment/runner.go
@@ -434,6 +434,7 @@ func jobEnvVars(props *Props) *[]*k8s.EnvVar {
 		config.EnvVarInternalDockerRepo,
 		config.EnvVarLocalCharts,
 		config.EnvBase64ConfigOverride,
+		config.EnvSethLogLevel,
 	}
 	for _, k := range lookups {
 		v, success := os.LookupEnv(k)


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
This pull request introduces a new environment variable `SETH_LOG_LEVEL` to specify the log level used by Seth, enhancing configurability for logging within the system. Additionally, it ensures this new variable is propagated to the Kubernetes environment, ensuring consistency across different deployment environments.

## What
- **lib/k8s/config/overrides.go**
  - Added `EnvSethLogLevel`, `EnvSethLogLevelDescription`, and `EnvSethLogLevelExample` to define a new environment variable for Seth's log level, enhancing the configurability for logging.
- **lib/k8s/environment/runner.go**
  - Included `config.EnvSethLogLevel` in the `lookups` slice to ensure the new `SETH_LOG_LEVEL` environment variable is properly propagated to the Kubernetes environment, maintaining consistency and configurability in logging across deployments.
