### PR TITLE
Update README for ghsecrets tool to clarify AWS profile usage

### DIFF
--- a/tools/ghsecrets/README.md
+++ b/tools/ghsecrets/README.md
@@ -30,9 +30,9 @@ By default, `ghsecrets set` assumes you want to store secrets in AWS Secrets Man
 > **⚠️ Note:** Ensure you authenticate with AWS before using the tool:
 >
 > ```sh
-> aws sso login --profile <your-aws-sdlc-profile>
+> aws sso login --profile <your-aws-sdlc-profile-with-poweruser-role>
 > ```
-> Use the **SDLC** profile in AWS 
+> Use the **SDLC** profile in AWS with **PowerUserAccess** role 
 
 This will read from `~/.testsecrets` (by default) and create/update a secret in AWS Secrets Manager:
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The change updates the README documentation for the `ghsecrets` tool to specify the use of an AWS SDLC profile with the PowerUserAccess role when logging in via AWS SSO. This adjustment ensures users are aware they need enhanced permissions to perform the actions required by the tool.

## What
- **tools/ghsecrets/README.md**
  - Updated the AWS SSO login command to specify the use of a profile with the PowerUserAccess role. This clarifies the permissions needed to use the tool effectively. 
  - Modified the accompanying text to emphasize the requirement of the PowerUserAccess role when using the SDLC profile in AWS. This change highlights the necessity for elevated permissions.
