### PR TITLE
Adds changeset for lib

### DIFF
--- a/lib/.changeset/v1.51.0.md
+++ b/lib/.changeset/v1.51.0.md
@@ -1,0 +1,2 @@
+- Allows for EVMClient to Poll for headers when not using WS
+- Adds InitializeHeaderSubscription method


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
These changes improve the EVMClient's flexibility by enabling polling for headers when WebSocket (WS) is not used and introducing a method to initialize header subscriptions.

## What
- **lib/.changeset/v1.51.0.md**
  - Added a new file to document changes for version 1.51.0.
  - Included two new changes: 
    - Allows for EVMClient to poll for headers when not using WS. This change enhances the client's ability to stay updated with blockchain states in environments where WS is unavailable or undesirable.
    - Adds InitializeHeaderSubscription method. This addition provides a structured way to start listening to new headers, making it easier for clients to react to new blockchain events.
