### PR TITLE
[TT-1608] Swaps Parrot to Chi Backend

### DIFF
--- a/parrot/.changeset/v0.3.0.md
+++ b/parrot/.changeset/v0.3.0.md
@@ -1,0 +1,29 @@
+- Changed underlying parrot router to use chi: https://github.com/go-chi/chi
+- Enables usage of wildcards and more stable routing with less code
+
+### Before Bench
+
+```sh
+goos: darwin
+goarch: arm64
+pkg: github.com/smartcontractkit/chainlink-testing-framework/parrot
+cpu: Apple M3 Max
+BenchmarkRegisterRoute-14        3014044               432.6 ns/op
+BenchmarkRouteResponse-14          16904             66540 ns/op
+BenchmarkSave-14                    6507            177113 ns/op
+BenchmarkLoad-14                    1258            937961 ns/op
+```
+
+### After Bench
+
+```sh
+goos: darwin
+goarch: arm64
+pkg: github.com/smartcontractkit/chainlink-testing-framework/parrot
+cpu: Apple M3 Max
+BenchmarkRegisterRoute-14        2144967               605.9 ns/op
+BenchmarkRouteResponse-14          18518             63014 ns/op
+BenchmarkGetRoutes-14              14031            262574 ns/op
+BenchmarkSave-14                    6404            185332 ns/op
+BenchmarkLoad-14                    1012           1170008 ns/op
+```

--- a/parrot/Makefile
+++ b/parrot/Makefile
@@ -1,8 +1,8 @@
-# Default test log level (can be overridden)
+# Default test log level is none
 PARROT_TEST_LOG_LEVEL ?= ""
-
-# Pass TEST_LOG_LEVEL as a flag to go test
 TEST_ARGS ?= -testLogLevel=$(PARROT_TEST_LOG_LEVEL)
+
+TEST_TIMEOUT ?= 30s
 
 .PHONY: lint
 lint:
@@ -12,17 +12,17 @@ lint:
 test:
 	go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 	set -euo pipefail
-	go test $(TEST_ARGS) -json -cover -coverprofile cover.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+	go test $(TEST_ARGS) -json -timeout $(TEST_TIMEOUT) -cover -coverprofile cover.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 .PHONY: test_race
 test_race:
 	go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 	set -euo pipefail
-	go test $(TEST_ARGS) -json -cover -count=1 -race -coverprofile cover.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+	go test $(TEST_ARGS) -json -timeout $(TEST_TIMEOUT) -cover -count=1 -race -coverprofile cover.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
 
 .PHONY: test_unit
 test_unit:
-	go test $(TEST_ARGS) -coverprofile cover.out ./...
+	go test $(TEST_ARGS) -timeout $(TEST_TIMEOUT) -coverprofile cover.out ./...
 
 .PHONY: bench
 bench:

--- a/parrot/Makefile
+++ b/parrot/Makefile
@@ -20,6 +20,7 @@ test_race:
 	set -euo pipefail
 	go test $(TEST_ARGS) -json -timeout $(TEST_TIMEOUT) -cover -count=1 -race -coverprofile cover.out -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
 
+
 .PHONY: test_unit
 test_unit:
 	go test $(TEST_ARGS) -timeout $(TEST_TIMEOUT) -coverprofile cover.out ./...
@@ -28,10 +29,11 @@ test_unit:
 bench:
 	go test $(TEST_ARGS) -bench=. -run=^$$ ./...
 
+.PHONY: fuzz_tests
+fuzz:
+	go test -list="Fuzz" ./...
+
 .PHONY: build
 build:
-	go build -o ./parrot ./cmd
-
-.PHONY: goreleaser
-goreleaser:
 	cd .. && goreleaser release --snapshot --clean -f ./parrot/.goreleaser.yaml
+	

--- a/parrot/cmd/main.go
+++ b/parrot/cmd/main.go
@@ -42,6 +42,7 @@ func main() {
 			if json {
 				options = append(options, parrot.WithJSONLogs())
 			}
+			options = append(options, parrot.WithRecorders(recorders...))
 
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
@@ -49,13 +50,6 @@ func main() {
 			p, err := parrot.Wake(options...)
 			if err != nil {
 				return err
-			}
-
-			for _, r := range recorders {
-				err = p.Record(r)
-				if err != nil {
-					return err
-				}
 			}
 
 			c := make(chan os.Signal, 1)

--- a/parrot/errors.go
+++ b/parrot/errors.go
@@ -7,12 +7,13 @@ import (
 
 var (
 	ErrNilRoute        = errors.New("route is nil")
-	ErrNoMethod        = errors.New("no method specified")
 	ErrInvalidPath     = errors.New("invalid path")
+	ErrInvalidMethod   = errors.New("invalid method")
 	ErrNoResponse      = errors.New("route must have a handler or some response")
 	ErrOnlyOneResponse = errors.New("route can only have one response type")
 	ErrResponseMarshal = errors.New("unable to marshal response body to JSON")
 	ErrRouteNotFound   = errors.New("route not found")
+	ErrWildcardPath    = fmt.Errorf("path can only contain one wildcard '*' and it must be the final value")
 
 	ErrNoRecorderURL      = errors.New("no recorder URL specified")
 	ErrInvalidRecorderURL = errors.New("invalid recorder URL")

--- a/parrot/errors.go
+++ b/parrot/errors.go
@@ -18,7 +18,8 @@ var (
 	ErrInvalidRecorderURL = errors.New("invalid recorder URL")
 	ErrRecorderNotFound   = errors.New("recorder not found")
 
-	ErrServerShutdown = errors.New("parrot is already asleep")
+	ErrServerShutdown  = errors.New("parrot is already asleep")
+	ErrServerUnhealthy = errors.New("parrot is unhealthy")
 )
 
 // Custom error type to help add more detail to base errors

--- a/parrot/examples_test.go
+++ b/parrot/examples_test.go
@@ -55,10 +55,7 @@ func ExampleServer_Register_internal() {
 	fmt.Println(len(routes))
 
 	// Delete the route
-	err = p.Delete(route.ID())
-	if err != nil {
-		panic(err)
-	}
+	p.Delete(route)
 
 	// Get all routes from the parrot instance
 	routes = p.Routes()
@@ -98,7 +95,7 @@ func ExampleServer_Register_external() {
 		RawResponseBody:    "Squawk",
 		ResponseStatusCode: http.StatusOK,
 	}
-	resp, err := client.R().SetBody(route).Post("/routes")
+	resp, err := client.R().SetBody(route).Post(parrot.RoutesRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -107,7 +104,7 @@ func ExampleServer_Register_external() {
 
 	// Get all routes from the parrot server
 	routes := make([]*parrot.Route, 0)
-	resp, err = client.R().SetResult(&routes).Get("/routes")
+	resp, err = client.R().SetResult(&routes).Get(parrot.RoutesRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +113,7 @@ func ExampleServer_Register_external() {
 	fmt.Println(len(routes))
 
 	// Delete the route
-	resp, err = client.R().SetBody(route).Delete("/routes")
+	resp, err = client.R().SetBody(route).Delete(parrot.RoutesRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -125,7 +122,7 @@ func ExampleServer_Register_external() {
 
 	// Get all routes from the parrot server
 	routes = make([]*parrot.Route, 0)
-	resp, err = client.R().SetResult(&routes).Get("/routes")
+	resp, err = client.R().SetResult(&routes).Get(parrot.RoutesRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -239,7 +236,7 @@ func ExampleRecorder_external() {
 	}
 
 	// Register the route with the parrot instance
-	resp, err := client.R().SetBody(route).Post("/routes")
+	resp, err := client.R().SetBody(route).Post(parrot.RoutesRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -256,7 +253,7 @@ func ExampleRecorder_external() {
 	}
 
 	// Register the recorder with the parrot instance
-	resp, err = client.R().SetBody(recorder).Post("/record")
+	resp, err = client.R().SetBody(recorder).Post(parrot.RecorderRoute)
 	if err != nil {
 		panic(err)
 	}
@@ -301,7 +298,7 @@ func waitForParrotServer(client *resty.Client, timeoutDur time.Duration) {
 	for { // Wait for the parrot server to start
 		select {
 		case <-ticker.C:
-			resp, err := client.R().Get("/health")
+			resp, err := client.R().Get(parrot.HealthRoute)
 			if err != nil {
 				continue
 			}

--- a/parrot/examples_test.go
+++ b/parrot/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/parrot"
 )
 
-func ExampleServer_Register_internal() {
+func ExampleServer_internal() {
 	// Create a new parrot instance with no logging and a custom save file
 	saveFile := "register_example.json"
 	p, err := parrot.Wake(parrot.WithLogLevel(zerolog.NoLevel), parrot.WithSaveFile(saveFile))
@@ -69,7 +69,7 @@ func ExampleServer_Register_internal() {
 	// 0
 }
 
-func ExampleServer_Register_external() {
+func ExampleServer_external() {
 	var (
 		saveFile = "route_example.json"
 		port     = 9090

--- a/parrot/go.mod
+++ b/parrot/go.mod
@@ -3,18 +3,20 @@ module github.com/smartcontractkit/chainlink-testing-framework/parrot
 go 1.23.4
 
 require (
+	github.com/go-chi/chi v1.5.5
 	github.com/go-resty/resty/v2 v2.16.3
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.10.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/parrot/go.sum
+++ b/parrot/go.sum
@@ -2,6 +2,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
+github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
 github.com/go-resty/resty/v2 v2.16.3 h1:zacNT7lt4b8M/io2Ahj6yPypL7bqx9n1iprfQuodV+E=
 github.com/go-resty/resty/v2 v2.16.3/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -12,8 +14,9 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -30,6 +33,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/parrot/parrot.go
+++ b/parrot/parrot.go
@@ -17,16 +17,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-chi/chi"
 	"github.com/go-resty/resty/v2"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 )
 
 const (
-	healthRoute = "/health"
-	routesRoute = "/routes"
-	recordRoute = "/record"
+	HealthRoute   = "/health"
+	RoutesRoute   = "/routes"
+	RecorderRoute = "/recorder"
 )
 
 // Route holds information about the mock route configuration
@@ -57,11 +57,22 @@ type Server struct {
 	host    string
 	address string
 
-	client             *resty.Client
-	shutDown           bool
-	shutDownChan       chan struct{}
-	shutDownOnce       sync.Once
-	saveFileName       string
+	router *chi.Mux
+	server *http.Server
+	client *resty.Client
+
+	routes        map[string]*Route // Store routes for saving and retrieving
+	routesMu      sync.RWMutex
+	recorderHooks map[string]struct{} // Store recorders based on URL keys to avoid duplicates
+	recordersMu   sync.RWMutex
+
+	// Save and shutdown
+	shutDown     bool
+	shutDownChan chan struct{}
+	shutDownOnce sync.Once
+	saveFileName string
+
+	// Logging
 	useCustomLogger    bool
 	logFileName        string
 	logFile            *os.File
@@ -69,100 +80,12 @@ type Server struct {
 	jsonLogs           bool
 	disableConsoleLogs bool
 	log                zerolog.Logger
-
-	server   *http.Server
-	routes   map[string]*Route // Store routes based on "Method:Path" keys
-	routesMu sync.RWMutex
-
-	recorderHooks map[string]struct{} // Store recorders based on URL keys to avoid duplicates
-	recordersMu   sync.RWMutex
 }
 
 // SaveFile is the structure of the file to save and load parrot data from
 type SaveFile struct {
 	Routes    []*Route `json:"routes"`
 	Recorders []string `json:"recorders"`
-}
-
-// ServerOption defines functional options for configuring the ParrotServer
-type ServerOption func(*Server) error
-
-// WithPort sets the port for the ParrotServer to run on
-func WithPort(port int) ServerOption {
-	return func(s *Server) error {
-		if port < 0 || port > 65535 {
-			return fmt.Errorf("invalid port: %d", port)
-		}
-		s.port = port
-		return nil
-	}
-}
-
-// WithLogLevel sets the visible log level of the default logger
-func WithLogLevel(level zerolog.Level) ServerOption {
-	return func(s *Server) error {
-		s.logLevel = level
-		return nil
-	}
-}
-
-// WithLogger sets the logger for the ParrotServer
-func WithLogger(l zerolog.Logger) ServerOption {
-	return func(s *Server) error {
-		s.log = l
-		s.useCustomLogger = true
-		return nil
-	}
-}
-
-// WithJSONLogs sets the logger to output JSON logs
-func WithJSONLogs() ServerOption {
-	return func(s *Server) error {
-		s.jsonLogs = true
-		return nil
-	}
-}
-
-// DisableConsoleLogs disables logging to the console
-func DisableConsoleLogs() ServerOption {
-	return func(s *Server) error {
-		s.disableConsoleLogs = true
-		return nil
-	}
-}
-
-// WithSaveFile sets the file to save the routes to
-func WithSaveFile(saveFile string) ServerOption {
-	return func(s *Server) error {
-		if saveFile == "" {
-			return fmt.Errorf("invalid save file name: %s", saveFile)
-		}
-		s.saveFileName = saveFile
-		return nil
-	}
-}
-
-// WithLogFile sets the file to save the logs to
-func WithLogFile(logFile string) ServerOption {
-	return func(s *Server) error {
-		if logFile == "" {
-			return fmt.Errorf("invalid log file name: %s", logFile)
-		}
-		s.logFileName = logFile
-		return nil
-	}
-}
-
-// WithRoutes sets the initial routes for the Parrot
-func WithRoutes(routes []*Route) ServerOption {
-	return func(s *Server) error {
-		for _, route := range routes {
-			if err := s.Register(route); err != nil {
-				return fmt.Errorf("failed to register route: %w", err)
-			}
-		}
-		return nil
-	}
 }
 
 // Wake creates a new Parrot server with dynamic route handling
@@ -173,15 +96,16 @@ func Wake(options ...ServerOption) (*Server, error) {
 		logLevel:     zerolog.InfoLevel,
 		logFileName:  "parrot.log",
 
-		client:       resty.New(),
-		shutDownChan: make(chan struct{}),
+		routes: make(map[string]*Route),
+		router: chi.NewRouter(),
+		client: resty.New(),
 
-		routes:   make(map[string]*Route),
-		routesMu: sync.RWMutex{},
+		shutDownChan: make(chan struct{}),
 
 		recorderHooks: make(map[string]struct{}),
 		recordersMu:   sync.RWMutex{},
 	}
+	p.router.Use(p.loggingMiddleware)
 
 	for _, option := range options {
 		if err := option(p); err != nil {
@@ -231,17 +155,19 @@ func Wake(options ...ServerOption) (*Server, error) {
 		return nil, fmt.Errorf("failed to parse port: %w", err)
 	}
 
-	mux := http.NewServeMux()
-	// TODO: Add a route to enable registering recorders
-	mux.HandleFunc(routesRoute, p.routeHandler)
-	mux.HandleFunc(recordRoute, p.recordHandler)
-	mux.HandleFunc(healthRoute, p.healthHandler)
-	mux.HandleFunc("/", p.dynamicHandler)
+	p.router.Get(HealthRoute, p.healthHandlerGET)
+
+	p.router.Get(RoutesRoute, p.routesHandlerGET)
+	p.router.Post(RoutesRoute, p.routesHandlerPOST)
+	p.router.Delete(RoutesRoute, p.routesHandlerDELETE)
+
+	p.router.Get(RecorderRoute, p.recorderHandlerGET)
+	p.router.Post(RecorderRoute, p.recorderHandlerPOST)
 
 	p.server = &http.Server{
 		ReadHeaderTimeout: 5 * time.Second,
 		Addr:              listener.Addr().String(),
-		Handler:           p.loggingMiddleware(mux),
+		Handler:           p.router,
 	}
 
 	if err = p.load(); err != nil {
@@ -273,6 +199,91 @@ func (p *Server) run(listener net.Listener) {
 	if err := p.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		p.log.Fatal().Err(err).Msg("Error while running server")
 	}
+}
+
+// routeCallHandler handles incoming requests to the parrot server routes
+func (p *Server) routeCallHandler(route *Route) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		routeCallLogger := zerolog.Ctx(r.Context())
+		routeCallLogger.UpdateContext(func(c zerolog.Context) zerolog.Context {
+			return c.Str("Route ID", route.ID())
+		})
+
+		if route.Handler != nil {
+			route.Handler(w, r)
+			return
+		}
+
+		if route.RawResponseBody != "" {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(route.ResponseStatusCode)
+			if _, err := w.Write([]byte(route.RawResponseBody)); err != nil {
+				routeCallLogger.Error().Err(err).Msg("Failed to write response")
+				http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			}
+			return
+		}
+
+		if route.ResponseBody != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(route.ResponseStatusCode)
+			if err := json.NewEncoder(w).Encode(route.ResponseBody); err != nil {
+				routeCallLogger.Error().Err(err).Msg("Failed to write response")
+				http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			}
+			return
+		}
+
+		routeCallLogger.Error().Msg("No response provided")
+		http.Error(w, "No response provided", http.StatusInternalServerError)
+	}
+}
+
+// Healthy checks if the parrot server is healthy
+func (p *Server) Healthy() error {
+	if p.shutDown {
+		return ErrServerShutdown
+	}
+
+	healthCheckRoute := &Route{
+		Method:             http.MethodGet,
+		Path:               "/check/health",
+		RawResponseBody:    "Healthy",
+		ResponseStatusCode: http.StatusOK,
+	}
+
+	err := p.Register(healthCheckRoute)
+	if err != nil {
+		return newDynamicError(ErrServerUnhealthy, fmt.Sprintf("%s: unable to register routes", err.Error()))
+	}
+
+	resp, err := p.Call(http.MethodGet, healthCheckRoute.Path)
+	if err != nil {
+		return newDynamicError(ErrServerUnhealthy, fmt.Sprintf("%s: unable to call routes", err.Error()))
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return newDynamicError(ErrServerUnhealthy, fmt.Sprintf("routes not responding with expected code, expected %d, got %d", http.StatusOK, resp.StatusCode()))
+	}
+
+	p.Delete(healthCheckRoute)
+
+	p.log.Debug().Msg("Parrot is healthy")
+	return nil
+}
+
+// healthHandlerGET handles the health check route
+// GET /health
+func (p *Server) healthHandlerGET(w http.ResponseWriter, r *http.Request) {
+	healthLogger := zerolog.Ctx(r.Context())
+
+	err := p.Healthy()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		healthLogger.Error().Err(err).Msg("Parrot is unhealthy")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // Shutdown gracefully shuts down the parrot server
@@ -324,16 +335,39 @@ func (p *Server) Register(route *Route) error {
 		}
 	}
 
+	p.router.MethodFunc(route.Method, route.Path, routeRecordingMiddleware(p, p.routeCallHandler(route)))
+
 	p.routesMu.Lock()
 	defer p.routesMu.Unlock()
 	p.routes[route.ID()] = route
 	p.log.Info().
 		Str("Route ID", route.ID()).
-		Str("Path", route.Path).
-		Str("Method", route.Method).
-		Msg("Route registered")
+		Msg("Registered route")
 
 	return nil
+}
+
+// routesHandlerPOST handles registering a new route
+// POST /routes
+func (p *Server) routesHandlerPOST(w http.ResponseWriter, r *http.Request) {
+	routesLogger := zerolog.Ctx(r.Context())
+
+	var route *Route
+	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		routesLogger.Debug().Err(err).Msg("Failed to decode request body")
+		return
+	}
+	defer r.Body.Close()
+
+	err := p.Register(route)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		routesLogger.Debug().Err(err).Msg("Failed to register route")
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
 }
 
 // Record registers a new recorder with the parrot. All incoming requests to the parrot will be sent to the recorder.
@@ -352,249 +386,19 @@ func (p *Server) Record(recorderURL string) error {
 		return ErrInvalidRecorderURL
 	}
 	p.recorderHooks[recorderURL] = struct{}{}
+	p.log.Info().Str("URL", recorderURL).Msg("Registered Recorder")
 	return nil
 }
 
-// Recorders returns the URLs of all registered recorders
-func (p *Server) Recorders() []string {
-	if p.shutDown {
-		return nil
-	}
-
-	p.recordersMu.RLock()
-	defer p.recordersMu.RUnlock()
-	recorders := make([]string, 0, len(p.recorderHooks))
-	for recorder := range p.recorderHooks {
-		recorders = append(recorders, recorder)
-	}
-	return recorders
-}
-
-// Delete removes a route from the parrot
-func (p *Server) Delete(routeID string) error {
-	if p.shutDown {
-		return ErrServerShutdown
-	}
-
-	p.routesMu.RLock()
-	_, exists := p.routes[routeID]
-	p.routesMu.RUnlock()
-
-	if !exists {
-		return newDynamicError(ErrRouteNotFound, routeID)
-	}
-	p.routesMu.Lock()
-	defer p.routesMu.Unlock()
-	delete(p.routes, routeID)
-	return nil
-}
-
-// Call makes a request to the parrot server
-func (p *Server) Call(method, path string) (*resty.Response, error) {
-	if p.shutDown {
-		return nil, ErrServerShutdown
-	}
-	return p.client.R().Execute(method, "http://"+filepath.Join(p.Address(), path))
-}
-
-func (p *Server) Routes() []*Route {
-	p.routesMu.RLock()
-	defer p.routesMu.RUnlock()
-
-	routes := make([]*Route, 0, len(p.routes))
-	for _, route := range p.routes {
-		routes = append(routes, route)
-	}
-	return routes
-}
-
-// routeHandler handles registering, unregistering, and querying routes
-func (p *Server) routeHandler(w http.ResponseWriter, r *http.Request) {
-	routesLogger := zerolog.Ctx(r.Context())
-	if r.Method == http.MethodDelete {
-		var route *Route
-		if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
-			routesLogger.Debug().Err(err).Msg("Failed to decode request body")
-			return
-		}
-		defer r.Body.Close()
-
-		err := p.Delete(route.ID())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			routesLogger.Debug().Err(err).Msg("Failed to unregister route")
-			return
-		}
-
-		w.WriteHeader(http.StatusNoContent)
-		routesLogger.Info().
-			Str("Route ID", route.ID()).
-			Msg("Route deleted")
-		return
-	}
-
-	if r.Method == http.MethodPost {
-		var route *Route
-		if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
-			http.Error(w, "Invalid request body", http.StatusBadRequest)
-			routesLogger.Debug().Err(err).Msg("Failed to decode request body")
-			return
-		}
-		defer r.Body.Close()
-
-		err := p.Register(route)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			routesLogger.Debug().Err(err).Msg("Failed to register route")
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
-		return
-	}
-
-	if r.Method == http.MethodGet {
-		routes := p.Routes()
-		jsonRoutes, err := json.Marshal(routes)
-		if err != nil {
-			http.Error(w, "Failed to marshal routes", http.StatusInternalServerError)
-			routesLogger.Debug().Err(err).Msg("Failed to marshal routes")
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if _, err = w.Write(jsonRoutes); err != nil {
-			http.Error(w, "Failed to write response", http.StatusInternalServerError)
-			routesLogger.Debug().Err(err).Msg("Failed to write response")
-			return
-		}
-
-		routesLogger.Debug().Int("Count", len(routes)).Msg("Returned routes")
-		return
-	}
-
-	http.Error(w, "Invalid method", http.StatusMethodNotAllowed)
-	routesLogger.Debug().Msg("Invalid method")
-}
-
-// dynamicHandler handles all incoming requests and responds based on the registered routes.
-func (p *Server) dynamicHandler(w http.ResponseWriter, r *http.Request) {
-	p.routesMu.RLock()
-	route, exists := p.routes[r.Method+":"+r.URL.Path]
-	p.routesMu.RUnlock()
-
-	dynamicLogger := zerolog.Ctx(r.Context())
-	if !exists {
-		http.NotFound(w, r)
-		dynamicLogger.Debug().Msg("Route not found")
-		return
-	}
-
-	routeCallID := uuid.New().String()[0:8]
-	dynamicLogger.UpdateContext(func(c zerolog.Context) zerolog.Context {
-		return c.Str("Route Call ID", routeCallID).Str("Route ID", route.ID())
-	})
-
-	requestBody, err := io.ReadAll(r.Body)
-	if err != nil {
-		dynamicLogger.Debug().
-			Err(err).
-			Msg("Failed to read request body")
-		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
-		return
-	}
-
-	routeCall := &RouteCall{
-		RouteCallID: routeCallID,
-		RouteID:     r.Method + ":" + r.URL.Path,
-		Request: &RouteCallRequest{
-			Method:     r.Method,
-			URL:        r.URL,
-			Header:     r.Header,
-			Body:       requestBody,
-			RemoteAddr: r.RemoteAddr,
-		},
-	}
-	recordingWriter := newResponseWriterRecorder(w)
-
-	defer func() {
-		res := recordingWriter.Result()
-		resBody, err := io.ReadAll(res.Body)
-		if err != nil {
-			dynamicLogger.Debug().Err(err).Msg("Failed to read response body")
-			http.Error(w, "Failed to read response body", http.StatusInternalServerError)
-			return
-		}
-
-		routeCall.Response = &RouteCallResponse{
-			StatusCode: res.StatusCode,
-			Header:     res.Header,
-			Body:       resBody,
-		}
-		p.sendToRecorders(routeCall)
-	}()
-
-	// Let the custom handler take over if it exists
-	if route.Handler != nil {
-		dynamicLogger.Debug().Msg("Calling route handler")
-		route.Handler(recordingWriter, r)
-		return
-	}
-
-	recordingWriter.WriteHeader(route.ResponseStatusCode)
-
-	if route.RawResponseBody != "" {
-		if _, err := recordingWriter.Write([]byte(route.RawResponseBody)); err != nil {
-			dynamicLogger.Debug().Err(err).Msg("Failed to write response")
-			http.Error(recordingWriter, "Failed to write response", http.StatusInternalServerError)
-			return
-		}
-		dynamicLogger.Debug().
-			Str("Response", route.RawResponseBody).
-			Msg("Returned raw response")
-		recordingWriter.WriteHeader(route.ResponseStatusCode)
-		return
-	}
-
-	if route.ResponseBody != nil {
-		rawJSON, err := json.Marshal(route.ResponseBody)
-		if err != nil {
-			dynamicLogger.Debug().Err(err).Msg("Failed to marshal JSON response")
-			http.Error(recordingWriter, "Failed to marshal response into json", http.StatusInternalServerError)
-			return
-		}
-		if _, err = recordingWriter.Write(rawJSON); err != nil {
-			dynamicLogger.Debug().Err(err).
-				RawJSON("Response", rawJSON).
-				Msg("Failed to write response")
-			http.Error(recordingWriter, "Failed to write JSON response", http.StatusInternalServerError)
-			return
-		}
-		dynamicLogger.Debug().
-			RawJSON("Response", rawJSON).
-			Msg("Returned JSON response")
-		recordingWriter.WriteHeader(route.ResponseStatusCode)
-		return
-	}
-
-	dynamicLogger.Error().Msg("Route has no response")
-	http.Error(recordingWriter, "Route has no response", http.StatusInternalServerError)
-}
-
-// recordHandler handles registering recorders with the parrot
-func (p *Server) recordHandler(w http.ResponseWriter, r *http.Request) {
+// recorderHandlerPOST handles registering a new recorder
+// POST /recorder
+func (p *Server) recorderHandlerPOST(w http.ResponseWriter, r *http.Request) {
 	recordingLogger := zerolog.Ctx(r.Context())
-	if r.Method != http.MethodPost {
-		http.Error(w, "Invalid method", http.StatusMethodNotAllowed)
-		recordingLogger.Debug().Msg("Invalid method")
-		return
-	}
 
 	var recorder *Recorder
 	if err := json.NewDecoder(r.Body).Decode(&recorder); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
-		recordingLogger.Debug().Err(err).Msg("Failed to decode request body")
+		recordingLogger.Error().Err(err).Msg("Failed to decode request body")
 		return
 	}
 	defer r.Body.Close()
@@ -618,16 +422,117 @@ func (p *Server) recordHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	recordingLogger.Debug().Str("URL", recorder.URL()).Msg("Recorder added")
 }
 
-func (p *Server) healthHandler(w http.ResponseWriter, _ *http.Request) {
+// Recorders returns the URLs of all registered recorders
+func (p *Server) Recorders() []string {
 	if p.shutDown {
-		http.Error(w, "Server is shutting down", http.StatusServiceUnavailable)
+		return nil
+	}
+
+	p.recordersMu.RLock()
+	defer p.recordersMu.RUnlock()
+	recorders := make([]string, 0, len(p.recorderHooks))
+	for recorder := range p.recorderHooks {
+		recorders = append(recorders, recorder)
+	}
+	p.log.Debug().Int("Count", len(recorders)).Msg("Got recorders")
+	return recorders
+}
+
+// recorderHandlerGET handles getting all recorders
+// GET /recorder
+func (p *Server) recorderHandlerGET(w http.ResponseWriter, r *http.Request) {
+	recordersLogger := zerolog.Ctx(r.Context())
+
+	recorders := p.Recorders()
+	jsonRecorders, err := json.Marshal(recorders)
+	if err != nil {
+		http.Error(w, "Failed to marshal recorders", http.StatusInternalServerError)
+		recordersLogger.Error().Err(err).Msg("Failed to marshal recorders")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write(jsonRecorders); err != nil {
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		recordersLogger.Error().Err(err).Msg("Failed to write response")
 		return
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// Delete removes a route from the parrot
+func (p *Server) Delete(route *Route) {
+	p.router.Method(route.Method, route.Path, http.NotFoundHandler())
+	p.routesMu.Lock()
+	defer p.routesMu.Unlock()
+	delete(p.routes, route.ID())
+	p.log.Info().
+		Str("Route ID", route.ID()).
+		Msg("Route deleted")
+}
+
+// routesHandlerDELETE handles deleting a route
+// DELETE /routes
+func (p *Server) routesHandlerDELETE(w http.ResponseWriter, r *http.Request) {
+	routesLogger := zerolog.Ctx(r.Context())
+
+	var route *Route
+	if err := json.NewDecoder(r.Body).Decode(&route); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		routesLogger.Debug().Err(err).Msg("Failed to decode request body")
+		return
+	}
+	defer r.Body.Close()
+
+	p.Delete(route)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Call makes a request to the parrot server
+func (p *Server) Call(method, path string) (*resty.Response, error) {
+	if p.shutDown {
+		return nil, ErrServerShutdown
+	}
+	return p.client.R().Execute(method, "http://"+filepath.Join(p.Address(), path))
+}
+
+func (p *Server) Routes() []*Route {
+	if p.shutDown {
+		return nil
+	}
+
+	p.routesMu.RLock()
+	defer p.routesMu.RUnlock()
+	routes := make([]*Route, 0, len(p.routes))
+	for _, route := range p.routes {
+		routes = append(routes, route)
+	}
+	p.log.Debug().Int("Count", len(routes)).Msg("Returned routes")
+	return routes
+}
+
+// routesHandlerGET handles getting all routes
+// GET /routes
+func (p *Server) routesHandlerGET(w http.ResponseWriter, r *http.Request) {
+	routesLogger := zerolog.Ctx(r.Context())
+
+	routes := p.Routes()
+	jsonRoutes, err := json.Marshal(routes)
+	if err != nil {
+		http.Error(w, "Failed to marshal routes", http.StatusInternalServerError)
+		routesLogger.Error().Err(err).Msg("Failed to marshal routes")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err = w.Write(jsonRoutes); err != nil {
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		routesLogger.Error().Err(err).Msg("Failed to write response")
+		return
+	}
 }
 
 // load loads all registered routes from a file.
@@ -703,7 +608,11 @@ func (p *Server) sendToRecorders(routeCall *RouteCall) {
 	}
 
 	client := resty.New()
-	p.log.Trace().Int("Recorder Count", len(p.recorderHooks)).Str("Route ID", routeCall.RouteID).Msg("Sending route call to recorders")
+	p.log.Trace().
+		Int("Recorder Count", len(p.recorderHooks)).
+		Str("Route Call ID", routeCall.ID).
+		Str("Route ID", routeCall.RouteID).
+		Msg("Sending route call to recorders")
 
 	for hook := range p.recorderHooks {
 		go func(hook string) {
@@ -712,7 +621,6 @@ func (p *Server) sendToRecorders(routeCall *RouteCall) {
 				p.log.Error().Err(err).Str("Recorder Hook", hook).Msg("Failed to send route call to recorder")
 				return
 			}
-			defer resp.RawResponse.Body.Close()
 			if resp.IsError() {
 				p.log.Error().
 					Str("Recorder Hook", hook).
@@ -721,11 +629,16 @@ func (p *Server) sendToRecorders(routeCall *RouteCall) {
 					Msg("Failed to send route call to recorder")
 				return
 			}
-			p.log.Trace().Str("Route ID", routeCall.RouteID).Str("Recorder Hook", hook).Msg("Route call sent to recorder")
+			p.log.Trace().
+				Str("Route Call ID", routeCall.ID).
+				Str("Route ID", routeCall.RouteID).
+				Str("Recorder Hook", hook).
+				Msg("Route call sent to recorder")
 		}(hook)
 	}
 }
 
+// loggingMiddleware logs all incoming requests
 func (p *Server) loggingMiddleware(next http.Handler) http.Handler {
 	h := hlog.NewHandler(p.log)
 
@@ -748,20 +661,22 @@ func (p *Server) loggingMiddleware(next http.Handler) http.Handler {
 var pathRegex = regexp.MustCompile(`^\/[a-zA-Z0-9\-._~%!$&'()*+,;=:@\/]*$`)
 
 func isValidPath(path string) bool {
-	switch path {
-	case "", "/", "//", healthRoute, recordRoute, routesRoute, "/.", "/..":
+	if path == "" || path == "/" {
+		return false
+	}
+	if strings.Contains(path, "//") {
 		return false
 	}
 	if !strings.HasPrefix(path, "/") {
 		return false
 	}
-	if strings.HasPrefix(path, recordRoute) {
+	if strings.HasPrefix(path, RecorderRoute) {
 		return false
 	}
-	if strings.HasPrefix(path, healthRoute) {
+	if strings.HasPrefix(path, HealthRoute) {
 		return false
 	}
-	if strings.HasPrefix(path, routesRoute) {
+	if strings.HasPrefix(path, RoutesRoute) {
 		return false
 	}
 	return pathRegex.MatchString(path)

--- a/parrot/parrot.go
+++ b/parrot/parrot.go
@@ -699,6 +699,8 @@ func isValidMethod(method string) bool {
 		http.MethodPatch,
 		http.MethodDelete,
 		http.MethodOptions,
+		http.MethodConnect,
+		http.MethodTrace,
 		MethodAny:
 		return true
 	}

--- a/parrot/parrot_fuzz_test.go
+++ b/parrot/parrot_fuzz_test.go
@@ -48,10 +48,12 @@ func FuzzMethodAny(f *testing.F) {
 	f.Add(http.MethodPatch)
 	f.Add(http.MethodDelete)
 	f.Add(http.MethodOptions)
+	f.Add(http.MethodConnect)
+	f.Add(http.MethodTrace)
 
 	f.Fuzz(func(t *testing.T, method string) {
 		if !isValidMethod(method) {
-			t.Skip("invalid method")
+			t.Skipf("invalid method '%s'", method)
 		}
 		resp, err := p.Call(method, route.Path)
 		require.NoError(t, err)

--- a/parrot/parrot_fuzz_test.go
+++ b/parrot/parrot_fuzz_test.go
@@ -1,0 +1,62 @@
+package parrot
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzRegisterPath(f *testing.F) {
+	p := newParrot(f)
+
+	baseRoute := Route{
+		Method:             http.MethodGet,
+		ResponseStatusCode: http.StatusOK,
+		RawResponseBody:    "Squawk",
+	}
+	f.Add("/foo")
+	f.Add("/foo/bar")
+	f.Add("/*")
+	f.Add("/foo/*")
+
+	f.Fuzz(func(t *testing.T, path string) {
+		route := baseRoute
+		route.Path = path
+
+		_ = p.Register(&route) // We just don't want panics
+	})
+}
+
+func FuzzMethodAny(f *testing.F) {
+	p := newParrot(f)
+
+	route := &Route{
+		Method:             MethodAny,
+		Path:               "/any",
+		ResponseStatusCode: http.StatusOK,
+		RawResponseBody:    "Squawk",
+	}
+
+	err := p.Register(route)
+	require.NoError(f, err)
+
+	f.Add(http.MethodGet)
+	f.Add(http.MethodPost)
+	f.Add(http.MethodPut)
+	f.Add(http.MethodPatch)
+	f.Add(http.MethodDelete)
+	f.Add(http.MethodOptions)
+
+	f.Fuzz(func(t *testing.T, method string) {
+		if !isValidMethod(method) {
+			t.Skip("invalid method")
+		}
+		resp, err := p.Call(method, route.Path)
+		require.NoError(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode(), fmt.Sprintf("bad response code with method: '%s'", method))
+		require.Equal(t, "Squawk", string(resp.Body()), fmt.Sprintf("bad response body with method: '%s'", method))
+	})
+}

--- a/parrot/parrot_options.go
+++ b/parrot/parrot_options.go
@@ -1,0 +1,100 @@
+package parrot
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+)
+
+// ServerOption defines functional options for configuring the ParrotServer
+type ServerOption func(*Server) error
+
+// WithPort sets the port for the ParrotServer to run on
+func WithPort(port int) ServerOption {
+	return func(s *Server) error {
+		if port < 0 || port > 65535 {
+			return fmt.Errorf("invalid port: %d", port)
+		}
+		s.port = port
+		return nil
+	}
+}
+
+// WithLogLevel sets the visible log level of the default logger
+func WithLogLevel(level zerolog.Level) ServerOption {
+	return func(s *Server) error {
+		s.logLevel = level
+		return nil
+	}
+}
+
+// WithLogger sets the logger for the ParrotServer
+func WithLogger(l zerolog.Logger) ServerOption {
+	return func(s *Server) error {
+		s.log = l
+		s.useCustomLogger = true
+		return nil
+	}
+}
+
+// WithJSONLogs sets the logger to output JSON logs
+func WithJSONLogs() ServerOption {
+	return func(s *Server) error {
+		s.jsonLogs = true
+		return nil
+	}
+}
+
+// DisableConsoleLogs disables logging to the console
+func DisableConsoleLogs() ServerOption {
+	return func(s *Server) error {
+		s.disableConsoleLogs = true
+		return nil
+	}
+}
+
+// WithSaveFile sets the file to save the routes to
+func WithSaveFile(saveFile string) ServerOption {
+	return func(s *Server) error {
+		if saveFile == "" {
+			return fmt.Errorf("invalid save file name: %s", saveFile)
+		}
+		s.saveFileName = saveFile
+		return nil
+	}
+}
+
+// WithLogFile sets the file to save the logs to
+func WithLogFile(logFile string) ServerOption {
+	return func(s *Server) error {
+		if logFile == "" {
+			return fmt.Errorf("invalid log file name: %s", logFile)
+		}
+		s.logFileName = logFile
+		return nil
+	}
+}
+
+// WithRoutes sets the initial routes for the Parrot
+func WithRoutes(routes []*Route) ServerOption {
+	return func(s *Server) error {
+		for _, route := range routes {
+			if err := s.Register(route); err != nil {
+				return fmt.Errorf("failed to register route: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
+// WithRecorders sets the initial recorders for the Parrot
+func WithRecorders(recorders ...string) ServerOption {
+	return func(s *Server) error {
+		for _, recorder := range recorders {
+			if err := s.Record(recorder); err != nil {
+				return fmt.Errorf("failed to register recorder: %w", err)
+			}
+		}
+		return nil
+	}
+}

--- a/parrot/parrot_options.go
+++ b/parrot/parrot_options.go
@@ -28,15 +28,6 @@ func WithLogLevel(level zerolog.Level) ServerOption {
 	}
 }
 
-// WithLogger sets the logger for the ParrotServer
-func WithLogger(l zerolog.Logger) ServerOption {
-	return func(s *Server) error {
-		s.log = l
-		s.useCustomLogger = true
-		return nil
-	}
-}
-
 // WithJSONLogs sets the logger to output JSON logs
 func WithJSONLogs() ServerOption {
 	return func(s *Server) error {

--- a/parrot/parrot_test.go
+++ b/parrot/parrot_test.go
@@ -306,7 +306,7 @@ func TestBadRegisterRoute(t *testing.T) {
 		},
 		{
 			name: "no method",
-			err:  ErrNoMethod,
+			err:  ErrInvalidMethod,
 			route: &Route{
 				Path:               "/hello",
 				RawResponseBody:    "Squawk",
@@ -369,20 +369,6 @@ func TestBadRegisterRoute(t *testing.T) {
 				Path:               "/hello",
 				RawResponseBody:    "Squawk",
 				ResponseBody:       map[string]any{"message": "Squawk"},
-				ResponseStatusCode: http.StatusOK,
-			},
-		},
-		{
-			name: "too many responses",
-			err:  ErrOnlyOneResponse,
-			route: &Route{
-				Method:       http.MethodGet,
-				Path:         "/hello",
-				ResponseBody: map[string]any{"message": "Squawk"},
-				Handler: func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte("Squawk"))
-				},
 				ResponseStatusCode: http.StatusOK,
 			},
 		},
@@ -586,16 +572,16 @@ func TestJSONLogger(t *testing.T) {
 	require.Contains(t, string(logs), fmt.Sprintf(`"Route ID":"%s"`, route.ID()), "expected log file to contain route call in JSON format")
 }
 
-func newParrot(t *testing.T) *Server {
-	t.Helper()
+func newParrot(tb testing.TB) *Server {
+	tb.Helper()
 
-	logFileName := t.Name() + ".log"
-	saveFileName := t.Name() + ".json"
+	logFileName := tb.Name() + ".log"
+	saveFileName := tb.Name() + ".json"
 	p, err := Wake(WithSaveFile(saveFileName), WithLogFile(logFileName), WithLogLevel(testLogLevel))
-	require.NoError(t, err, "error waking parrot")
-	t.Cleanup(func() {
+	require.NoError(tb, err, "error waking parrot")
+	tb.Cleanup(func() {
 		err := p.Shutdown(context.Background())
-		assert.NoError(t, err, "error shutting down parrot")
+		assert.NoError(tb, err, "error shutting down parrot")
 		p.WaitShutdown() // Wait for shutdown to complete and file to be written
 		os.Remove(saveFileName)
 		os.Remove(logFileName)

--- a/parrot/recorder_test.go
+++ b/parrot/recorder_test.go
@@ -73,7 +73,6 @@ func TestResponseWriterRecorder(t *testing.T) {
 			recordedBody, err := io.ReadAll(recordedResp.Body)
 			require.NoError(t, err, "error reading recorded response body")
 
-			// TODO: Make sure body is actually getting checked
 			assert.Equal(t, tc.expectedRespCode, actualResp.StatusCode, "actual response has unexpected status code")
 			assert.Equal(t, tc.expectedRespCode, recordedResp.StatusCode, "recorded response has unexpected status code")
 			assert.Equal(t, tc.expectedRespBody, string(actualBody), "actual response has unexpected body")

--- a/parrot/testdata/fuzz/FuzzMethodAny/771e938e4458e983
+++ b/parrot/testdata/fuzz/FuzzMethodAny/771e938e4458e983
@@ -1,2 +1,0 @@
-go test fuzz v1
-string("0")

--- a/parrot/testdata/fuzz/FuzzMethodAny/771e938e4458e983
+++ b/parrot/testdata/fuzz/FuzzMethodAny/771e938e4458e983
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0")


### PR DESCRIPTION
Uses Chi as the parrot backend for wildcard support
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the performance and functionality of the parrot package by integrating a more robust router, adding new benchmarks, refining tests, and separating options into a dedicated file. These modifications facilitate better routing, testing, and configuration management.

## What
- **parrot/.changeset/v0.3.0.md**
  - Added details about changing to chi router and benchmark results before and after the change.
- **parrot/Makefile**
  - Modified the default test log level and introduced a test timeout variable.
- **parrot/cmd/main.go**
  - Updated to append recorders directly in the options setup.
- **parrot/errors.go**
  - Added a new error for unhealthy server status.
- **parrot/examples_test.go**
  - Simplified the deletion of routes in examples.
- **parrot/go.mod** and **parrot/go.sum**
  - Added `github.com/go-chi/chi` and updated dependencies.
- **parrot/parrot.go**
  - Integrated chi router, added new methods for route handling, and implemented health checking.
- **parrot/parrot_benchmark_test.go**
  - Added a benchmark for getting routes.
- **parrot/parrot_options.go**
  - Separated server options into a new file for better organization.
- **parrot/parrot_test.go**
  - Updated tests to reflect changes in routing and error handling.
- **parrot/recorder.go** and **parrot/recorder_test.go**
  - Improved recorder functionality and tests, including middleware for route recording.
