### PR TITLE
Adds an execution Error Code to Flakeguard

### DIFF
--- a/tools/flakeguard/cmd/check_test_owners.go
+++ b/tools/flakeguard/cmd/check_test_owners.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/rs/zerolog/log"
@@ -18,19 +19,21 @@ var (
 var CheckTestOwnersCmd = &cobra.Command{
 	Use:   "check-test-owners",
 	Short: "Check which tests in the project do not have code owners",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	Run: func(cmd *cobra.Command, args []string) {
 		projectPath, _ := cmd.Flags().GetString("project-path")
 
 		// Scan project for test functions
 		testFileMap, err := reports.ScanTestFiles(projectPath)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Error scanning test files")
+			log.Error().Err(err).Msg("Error scanning test files")
+			os.Exit(ErrorExitCode)
 		}
 
 		// Parse CODEOWNERS file
 		codeOwnerPatterns, err := codeowners.Parse(codeownersPath)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Error parsing CODEOWNERS file")
+			log.Error().Err(err).Msg("Error parsing CODEOWNERS file")
+			os.Exit(ErrorExitCode)
 		}
 
 		// Check for tests without code owners
@@ -73,8 +76,6 @@ var CheckTestOwnersCmd = &cobra.Command{
 				log.Debug().Msg("All Test functions have code owners!")
 			}
 		}
-
-		return nil
 	},
 }
 

--- a/tools/flakeguard/cmd/find.go
+++ b/tools/flakeguard/cmd/find.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/rs/zerolog/log"
 	"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/git"
@@ -32,7 +33,8 @@ var FindTestsCmd = &cobra.Command{
 		if findByTestFilesDiff {
 			changedTestFiles, err := git.FindChangedFiles(projectPath, baseRef, "grep '_test\\.go$'")
 			if err != nil {
-				log.Fatal().Err(err).Msg("Error finding changed test files")
+				log.Error().Err(err).Msg("Error finding changed test files")
+				os.Exit(ErrorExitCode)
 			}
 			if onlyShowChangedTestFiles {
 				outputResults(changedTestFiles, jsonOutput)
@@ -43,7 +45,8 @@ var FindTestsCmd = &cobra.Command{
 			}
 			changedTestPkgs, err = golang.GetFilePackages(changedTestFiles)
 			if err != nil {
-				log.Fatal().Err(err).Msg("Error getting package names for test files")
+				log.Error().Err(err).Msg("Error getting package names for test files")
+				os.Exit(ErrorExitCode)
 			}
 		}
 
@@ -85,27 +88,32 @@ func init() {
 	FindTestsCmd.Flags().Bool("only-show-changed-test-files", false, "Only show the changed test files and exit")
 
 	if err := FindTestsCmd.MarkFlagRequired("base-ref"); err != nil {
-		log.Fatal().Err(err).Msg("Error marking base-ref as required")
+		log.Error().Err(err).Msg("Error marking base-ref as required")
+		os.Exit(ErrorExitCode)
 	}
 }
 
 func findAffectedPackages(baseRef, projectPath string, excludes []string, levels int) []string {
 	goList, err := golang.GoList()
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error getting go list")
+		log.Error().Err(err).Msg("Error getting go list")
+		os.Exit(ErrorExitCode)
 	}
 	gitDiff, err := git.Diff(baseRef)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error getting the git diff")
+		log.Error().Err(err).Msg("Error getting the git diff")
+		os.Exit(ErrorExitCode)
 	}
 	gitModDiff, err := git.ModDiff(baseRef, projectPath)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error getting the git mod diff")
+		log.Error().Err(err).Msg("Error getting the git mod diff")
+		os.Exit(ErrorExitCode)
 	}
 
 	packages, err := golang.ParsePackages(goList.Stdout)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error parsing packages")
+		log.Error().Err(err).Msg("Error parsing packages")
+		os.Exit(ErrorExitCode)
 	}
 
 	fileMap := golang.GetGoFileMap(packages, true)
@@ -113,12 +121,14 @@ func findAffectedPackages(baseRef, projectPath string, excludes []string, levels
 	var changedPackages []string
 	changedPackages, err = git.GetChangedGoPackagesFromDiff(gitDiff.Stdout, projectPath, excludes, fileMap)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error getting changed packages")
+		log.Error().Err(err).Msg("Error getting changed packages")
+		os.Exit(ErrorExitCode)
 	}
 
 	changedModPackages, err := git.GetGoModChangesFromDiff(gitModDiff.Stdout)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error getting go.mod changes")
+		log.Error().Err(err).Msg("Error getting go.mod changes")
+		os.Exit(ErrorExitCode)
 	}
 
 	depMap := golang.GetGoDepMap(packages)
@@ -156,7 +166,8 @@ func outputResults(packages []string, jsonOutput bool) {
 	if jsonOutput {
 		data, err := json.Marshal(packages)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Error marshaling test packages to JSON")
+			log.Error().Err(err).Msg("Error marshaling test packages to JSON")
+			os.Exit(ErrorExitCode)
 		}
 		log.Debug().Str("output", string(data)).Msg("JSON")
 	} else {

--- a/tools/flakeguard/reports/presentation.go
+++ b/tools/flakeguard/reports/presentation.go
@@ -176,6 +176,13 @@ func buildSettingsTable(testReport *TestReport, maxPassRatio float64) [][]string
 	return rows
 }
 
+func RenderError(
+	w io.Writer,
+	err error,
+) {
+	fmt.Fprintln(w, ":x: Error Running Flakeguard :x:")
+}
+
 // RenderResults renders the test results into a console or markdown format.
 // If in markdown mode, the table results can also be made collapsible.
 func RenderResults(

--- a/tools/flakeguard/runner/runner_test.go
+++ b/tools/flakeguard/runner/runner_test.go
@@ -497,7 +497,7 @@ func TestAttributeRaceToTest(t *testing.T) {
 }
 
 // TODO: Running the failing test here fools tools like gotestfmt into thinking we actually ran a failing test
-// as the output gets piped out to the console. This is a minor annoyance we should fix.
+// as the output gets piped out to the console. This a confusing annoyance that I'd like to fix, but it's not crucial.p\\\\\\\\\\-
 func TestFailedOutputs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
New error code for Flakeguard to help us identify when we find flakes, or when we hit errors finding flakes.

Exit Code 1: Flakeguard ran successfully and found some flakes
Exit Code 2: Flakeguard hit some issues and was not able to complete
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce enhancements and bug fixes to various commands in the Flakeguard tool suite, focusing on error handling, logging improvements, and exit code standardization. These modifications aim to make the tool more robust and user-friendly by providing clearer error messages, ensuring consistent exit behavior across commands, and improving the overall reliability and maintainability of the codebase.

## What
- **`tools/flakeguard/cmd/aggregate_results.go`**:
  - Import `"os"` for exit code management and error handling.
  - Replace `RunE` with `Run` to manage errors and exit codes manually.
  - Use `log.Error()` and `os.Exit()` for error handling, improving clarity and control over exit behavior.
  - Remove redundant error checks and stop spinners more reliably.
- **`tools/flakeguard/cmd/check_test_owners.go`**:
  - Import `"os"` for handling exit codes.
  - Replace `RunE` with `Run` for manual error and exit code management.
  - Use `log.Error()` and `os.Exit()` for error handling.
- **`tools/flakeguard/cmd/find.go`**:
  - Import `"os"` for improved error and exit code handling.
  - Transition to `Run` from `RunE` and manage errors and exit codes manually.
  - Use `log.Error()` and `os.Exit()` for error handling.
  - Adjust logging and error handling for consistency and clarity.
- **`tools/flakeguard/cmd/generate_report.go`**:
  - Import `"os"` for enhanced error handling and exit code management.
  - Shift from `RunE` to `Run` to manually handle errors and exit codes.
  - Apply `log.Error()` and `os.Exit()` for error handling, enhancing clarity.
  - Improve error messaging and exit strategy for a user-friendly interface.
- **`tools/flakeguard/cmd/run.go`**:
  - Define constants `FlakyTestsExitCode` and `ErrorExitCode` for standardized exit codes.
  - Utilize `Run` instead of `RunE` for explicit error and exit code control.
  - Implement `log.Error()` and `os.Exit()` for uniform error handling.
  - Clarify and standardize error and exit code handling for reliability.
- **`tools/flakeguard/reports/presentation.go`**:
  - Introduce `RenderError` function for consistent error reporting.
- **`tools/flakeguard/runner/runner_test.go`**:
  - Minor text adjustment in a comment for clarity.
