### PR TITLE
Fixes Flakeguard Reports

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sebawo @smartcontractkit/test-tooling-team
+* @smartcontractkit/test-tooling-team

--- a/tools/flakeguard/Makefile
+++ b/tools/flakeguard/Makefile
@@ -24,88 +24,8 @@ bench:
 
 .PHONY: example
 example:
-	./run_example.sh 3 TestPanic
-	go run . aggregate-results \
-		--results-path ./example_results \
-		--output-path ./example_results \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--branch-name "example-branch" \
-		--base-sha "abc" \
-		--head-sha "xyz" \
-		--github-workflow-name "ExampleWorkflowName" \
-		--github-workflow-run-url "https://github.com/example/repo/actions/runs/1" \
-		--splunk-url "https://splunk.example.com" \
-		--splunk-token "splunk-token" \
-		--splunk-event "example-splunk-event"
-	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
-		--aggregated-results-path ./example_results/all-test-results.json \
-		--output-path ./example_results \
-		--github-repository "smartcontractkit/chainlink-testing-framework" \
-		--github-run-id "1" \
-		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
-		--base-branch "exampleBaseBranch" \
-		--current-branch "exampleCurrentBranch" \
-		--current-commit-sha "abc" \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--action-run-id "1" \
-		--max-pass-ratio "1.0" 
+	./run_example.sh 3 Panic,Timeout
 
 .PHONY: example_flaky_panic
 example_flaky_panic:
 	./run_example.sh 3 TestPanic
-	go run . aggregate-results \
-		--results-path ./example_results \
-		--output-path ./example_results \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--branch-name "example-branch" \
-		--base-sha "abc" \
-		--head-sha "xyz" \
-		--github-workflow-name "ExampleWorkflowName" \
-		--github-workflow-run-url "https://github.com/example/repo/actions/runs/1" \
-		--splunk-url "https://splunk.example.com" \
-		--splunk-token "splunk-token" \
-		--splunk-event "example-splunk-event"
-	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
-		--aggregated-results-path ./example_results/all-test-results.json \
-		--output-path ./example_results \
-		--github-repository "smartcontractkit/chainlink-testing-framework" \
-		--github-run-id "1" \
-		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
-		--base-branch "exampleBaseBranch" \
-		--current-branch "exampleCurrentBranch" \
-		--current-commit-sha "abc" \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--action-run-id "1" \
-		--max-pass-ratio "1.0" 
-
-.PHONY: example_timeout
-example_timeout:
-	rm -rf example_results
-	mkdir -p example_results
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --select-tests=TestTimeout --timeout=1s --max-pass-ratio=1 --race=false --output-json=example_results/example_run_1.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --select-tests=TestTimeout --timeout=1s --max-pass-ratio=1 --race=false --output-json=example_results/example_run_2.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --select-tests=TestTimeout --timeout=1s --max-pass-ratio=1 --race=false --output-json=example_results/example_run_3.json
-	go run . aggregate-results \
-		--results-path ./example_results \
-		--output-path ./example_results \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--branch-name "example-branch" \
-		--base-sha "abc" \
-		--head-sha "xyz" \
-		--github-workflow-name "ExampleWorkflowName" \
-		--github-workflow-run-url "https://github.com/example/repo/actions/runs/1" \
-		--splunk-url "https://splunk.example.com" \
-		--splunk-token "splunk-token" \
-		--splunk-event "example-splunk-event"
-	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
-		--aggregated-results-path ./example_results/all-test-results.json \
-		--output-path ./example_results \
-		--github-repository "smartcontractkit/chainlink-testing-framework" \
-		--github-run-id "1" \
-		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
-		--base-branch "exampleBaseBranch" \
-		--current-branch "exampleCurrentBranch" \
-		--current-commit-sha "abc" \
-		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
-		--action-run-id "1" \
-		--max-pass-ratio "1.0" 

--- a/tools/flakeguard/Makefile
+++ b/tools/flakeguard/Makefile
@@ -41,6 +41,18 @@ example:
 		--splunk-url "https://splunk.example.com" \
 		--splunk-token "splunk-token" \
 		--splunk-event "example-splunk-event"
+	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
+		--aggregated-results-path ./example_results/all-test-results.json \
+		--output-path ./example_results \
+		--github-repository "smartcontractkit/chainlink-testing-framework" \
+		--github-run-id "1" \
+		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
+		--base-branch "exampleBaseBranch" \
+		--current-branch "exampleCurrentBranch" \
+		--current-commit-sha "abc" \
+		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
+		--action-run-id "1" \
+		--max-pass-ratio "1.0" 
 
 .PHONY: example_flaky_panic
 example_flaky_panic:
@@ -61,6 +73,18 @@ example_flaky_panic:
 		--splunk-url "https://splunk.example.com" \
 		--splunk-token "splunk-token" \
 		--splunk-event "example-splunk-event"
+	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
+		--aggregated-results-path ./example_results/all-test-results.json \
+		--output-path ./example_results \
+		--github-repository "smartcontractkit/chainlink-testing-framework" \
+		--github-run-id "1" \
+		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
+		--base-branch "exampleBaseBranch" \
+		--current-branch "exampleCurrentBranch" \
+		--current-commit-sha "abc" \
+		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
+		--action-run-id "1" \
+		--max-pass-ratio "1.0" 
 
 .PHONY: example_timeout
 example_timeout:
@@ -81,3 +105,15 @@ example_timeout:
 		--splunk-url "https://splunk.example.com" \
 		--splunk-token "splunk-token" \
 		--splunk-event "example-splunk-event"
+	GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
+		--aggregated-results-path ./example_results/all-test-results.json \
+		--output-path ./example_results \
+		--github-repository "smartcontractkit/chainlink-testing-framework" \
+		--github-run-id "1" \
+		--failed-tests-artifact-name "failed-test-results-with-logs.json" \
+		--base-branch "exampleBaseBranch" \
+		--current-branch "exampleCurrentBranch" \
+		--current-commit-sha "abc" \
+		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
+		--action-run-id "1" \
+		--max-pass-ratio "1.0" 

--- a/tools/flakeguard/Makefile
+++ b/tools/flakeguard/Makefile
@@ -24,11 +24,7 @@ bench:
 
 .PHONY: example
 example:
-	rm -rf example_results
-	mkdir -p example_results
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=Panic,Timeout --max-pass-ratio=1 --race=false --output-json=example_results/example_run_1.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=Panic,Timeout --max-pass-ratio=1 --race=false --output-json=example_results/example_run_2.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=Panic,Timeout --max-pass-ratio=1 --race=false --output-json=example_results/example_run_3.json
+	./run_example.sh 3 TestPanic
 	go run . aggregate-results \
 		--results-path ./example_results \
 		--output-path ./example_results \
@@ -56,11 +52,7 @@ example:
 
 .PHONY: example_flaky_panic
 example_flaky_panic:
-	rm -rf example_results
-	mkdir -p example_results
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=TestPanic --max-pass-ratio=1 --race=false --output-json=example_results/example_run_1.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=TestPanic --max-pass-ratio=1 --race=false --output-json=example_results/example_run_2.json
-	- go run . run --project-path=./runner --test-packages=./example_test_package --run-count=5 --skip-tests=TestPanic --max-pass-ratio=1 --race=false --output-json=example_results/example_run_3.json
+	./run_example.sh 3 TestPanic
 	go run . aggregate-results \
 		--results-path ./example_results \
 		--output-path ./example_results \

--- a/tools/flakeguard/README.md
+++ b/tools/flakeguard/README.md
@@ -36,7 +36,8 @@ Both `find` and `run` commands support JSON output `--json`, making it easy to i
 You can find example usage and see outputs with:
 
 ```sh
-make example       # Run an example flow of running tests and aggregating results
-make example_panic # Run example flow with panicking tests
-ls example_results # See results of each run and aggregation
+make example             # Run an example flow of running tests, aggregating results, and reporting them to GitHub
+make example_flaky_panic # Run example flow with flaky and panicking tests
+make example_timeout     # Run example flow tests the timeout
+ls example_results       # See results of each run and aggregation
 ```

--- a/tools/flakeguard/README.md
+++ b/tools/flakeguard/README.md
@@ -38,6 +38,5 @@ You can find example usage and see outputs with:
 ```sh
 make example             # Run an example flow of running tests, aggregating results, and reporting them to GitHub
 make example_flaky_panic # Run example flow with flaky and panicking tests
-make example_timeout     # Run example flow tests the timeout
 ls example_results       # See results of each run and aggregation
 ```

--- a/tools/flakeguard/cmd/generate_report.go
+++ b/tools/flakeguard/cmd/generate_report.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const exampleGitHubToken = "EXAMPLE_GITHUB_TOKEN" //nolint:gosec
+
 var GenerateReportCmd = &cobra.Command{
 	Use:   "generate-report",
 	Short: "Generate test reports from aggregated results that can be posted to GitHub",
@@ -191,6 +193,9 @@ func init() {
 }
 
 func fetchArtifactLink(githubToken, githubRepo string, githubRunID int64, artifactName string) (string, error) {
+	if githubToken == exampleGitHubToken {
+		return "https://example-artifact-link.com", nil
+	}
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: githubToken},

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -121,7 +121,7 @@ type SummaryData struct {
 	RacedTests int `json:"raced_tests"`
 	// FlakyTests tracks how many tests are considered flaky
 	FlakyTests int `json:"flaky_tests"`
-	// FlakyTestPercent is the percentage of tests that are considered flaky
+	// FlakyTestPercent is the human-readable percentage of tests that are considered flaky
 	FlakyTestPercent string `json:"flaky_test_percent"`
 
 	// Individual test run counts
@@ -134,7 +134,7 @@ type SummaryData struct {
 	FailedRuns int `json:"failed_runs"`
 	// SkippedRuns tracks how many test runs were skipped
 	SkippedRuns int `json:"skipped_runs"`
-	// PassPercent is the percentage of test runs that passed
+	// PassPercent is the human-readable percentage of test runs that passed
 	PassPercent string `json:"pass_percent"`
 }
 

--- a/tools/flakeguard/reports/data.go
+++ b/tools/flakeguard/reports/data.go
@@ -28,12 +28,12 @@ type TestReport struct {
 
 // GenerateSummaryData generates a summary of a report's test results
 func (testReport *TestReport) GenerateSummaryData() {
-	var runs, mostRuns, passes, fails, skips, panickedTests, racedTests, flakyTests, skippedTests int
+	var runs, testRunCount, passes, fails, skips, panickedTests, racedTests, flakyTests, skippedTests int
 
 	for _, result := range testReport.Results {
 		runs += result.Runs
-		if result.Runs > mostRuns {
-			mostRuns = result.Runs
+		if result.Runs > testRunCount {
+			testRunCount = result.Runs
 		}
 		passes += result.Successes
 		fails += result.Failures
@@ -67,7 +67,7 @@ func (testReport *TestReport) GenerateSummaryData() {
 
 	testReport.SummaryData = &SummaryData{
 		UniqueTestsRun:   totalTests,
-		TestRunCount:     mostRuns,
+		TestRunCount:     testRunCount,
 		PanickedTests:    panickedTests,
 		RacedTests:       racedTests,
 		FlakyTests:       flakyTests,

--- a/tools/flakeguard/reports/data_test.go
+++ b/tools/flakeguard/reports/data_test.go
@@ -205,7 +205,7 @@ func TestGenerateSummaryData(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			GenerateSummaryData(tc.testReport)
+			tc.testReport.GenerateSummaryData()
 			assert.Equal(t, tc.expected, tc.testReport.SummaryData, "Summary data does not match expected")
 		})
 	}

--- a/tools/flakeguard/reports/io.go
+++ b/tools/flakeguard/reports/io.go
@@ -491,10 +491,13 @@ func aggregate(reportChan <-chan *TestReport, errChan <-chan error, opts *aggreg
 
 	sortTestResults(aggregatedResults)
 	fullReport.Results = aggregatedResults
-	GenerateSummaryData(fullReport)
+	fullReport.GenerateSummaryData()
 
 	if sendToSplunk {
 		err = sendDataToSplunk(opts, *fullReport)
+		if err != nil {
+			return fullReport, fmt.Errorf("error sending data to Splunk: %w", err)
+		}
 	}
 	return fullReport, err
 }
@@ -630,6 +633,7 @@ func sendDataToSplunk(opts *aggregateOptions, report TestReport) error {
 			Int("successfully sent", successfulResultsSent).
 			Int("total results", len(results)).
 			Errs("errors", splunkErrs).
+			Str("report id", report.ID).
 			Str("duration", time.Since(start).String()).
 			Msg("Errors occurred while sending test results to Splunk")
 	} else {
@@ -637,6 +641,7 @@ func sendDataToSplunk(opts *aggregateOptions, report TestReport) error {
 			Int("successfully sent", successfulResultsSent).
 			Int("total results", len(results)).
 			Str("duration", time.Since(start).String()).
+			Str("report id", report.ID).
 			Msg("All results sent successfully to Splunk")
 	}
 

--- a/tools/flakeguard/reports/io.go
+++ b/tools/flakeguard/reports/io.go
@@ -127,7 +127,9 @@ func LoadAndAggregate(resultsPath string, options ...AggregateOption) (*TestRepo
 	}
 
 	// Apply options
-	opts := aggregateOptions{}
+	opts := aggregateOptions{
+		maxPassRatio: 1.0,
+	}
 	for _, opt := range options {
 		opt(&opts)
 	}

--- a/tools/flakeguard/reports/presentation.go
+++ b/tools/flakeguard/reports/presentation.go
@@ -90,10 +90,10 @@ func GenerateGitHubSummaryMarkdown(w io.Writer, testReport *TestReport, maxPassR
 
 	if testReport.SummaryData.FlakyTests > 0 {
 		fmt.Fprintln(w, "## Found Flaky Tests :x:")
-		fmt.Fprintln(w)
 	} else {
 		fmt.Fprintln(w, "## No Flakes Found :white_check_mark:")
 	}
+	fmt.Fprintln(w)
 
 	RenderResults(w, testReport, true, false)
 

--- a/tools/flakeguard/reports/presentation.go
+++ b/tools/flakeguard/reports/presentation.go
@@ -199,12 +199,12 @@ func renderSummaryTable(w io.Writer, summary *SummaryData, markdown bool, collap
 		{"Panicked Tests", fmt.Sprintf("%d", summary.PanickedTests)},
 		{"Raced Tests", fmt.Sprintf("%d", summary.RacedTests)},
 		{"Flaky Tests", fmt.Sprintf("%d", summary.FlakyTests)},
-		{"Flaky Test Ratio", summary.FlakyTestPercent},
+		{"Flaky Test Percent", summary.FlakyTestPercent},
 		{"Total Test Runs", fmt.Sprintf("%d", summary.TotalRuns)},
 		{"Passes", fmt.Sprintf("%d", summary.PassedRuns)},
 		{"Failures", fmt.Sprintf("%d", summary.FailedRuns)},
 		{"Skips", fmt.Sprintf("%d", summary.SkippedRuns)},
-		{"Pass Ratio", summary.PassPercent},
+		{"Pass Percent", summary.PassPercent},
 	}
 	if markdown {
 		for i, row := range summaryData {

--- a/tools/flakeguard/reports/presentation_test.go
+++ b/tools/flakeguard/reports/presentation_test.go
@@ -241,7 +241,7 @@ func TestRenderResults(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Generate the summary data
-			GenerateSummaryData(tc.testReport)
+			tc.testReport.GenerateSummaryData()
 
 			var buf bytes.Buffer
 			RenderResults(&buf, tc.testReport, false, false)

--- a/tools/flakeguard/run_example.sh
+++ b/tools/flakeguard/run_example.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-run_flakeguard() {
+run_flakeguard_example() {
   local run_count=$1
   local skip_tests=$2
 
@@ -22,10 +22,46 @@ run_flakeguard() {
       exit $EXIT_CODE
     fi
   done
+
+  go run . aggregate-results \
+		--results-path ./example_results \
+		--output-path ./example_results \
+		--repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
+		--branch-name "example-branch" \
+		--base-sha "abc" \
+		--head-sha "xyz" \
+		--github-workflow-name "ExampleWorkflowName" \
+		--github-workflow-run-url "https://github.com/example/repo/actions/runs/1" \
+		--splunk-url "https://splunk.example.com" \
+		--splunk-token "splunk-token" \
+		--splunk-event "example-splunk-event"
+  local EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 2 ]; then
+    echo "ERROR: Flakeguard encountered an error while aggregating results"
+    exit $EXIT_CODE
+  fi
+
+  GITHUB_TOKEN="EXAMPLE_GITHUB_TOKEN" go run . generate-report \
+    --aggregated-results-path ./example_results/all-test-results.json \
+    --output-path ./example_results \
+    --github-repository "smartcontractkit/chainlink-testing-framework" \
+    --github-run-id "1" \
+    --failed-tests-artifact-name "failed-test-results-with-logs.json" \
+    --base-branch "exampleBaseBranch" \
+    --current-branch "exampleCurrentBranch" \
+    --current-commit-sha "abc" \
+    --repo-url "https://github.com/smartcontractkit/chainlink-testing-framework" \
+    --action-run-id "1" \
+    --max-pass-ratio "1.0"
+  local EXIT_CODE=$?
+  if [ $EXIT_CODE -eq 2 ]; then
+    echo "ERROR: Flakeguard encountered an error while generating report for the aggregated results"
+    exit $EXIT_CODE
+  fi
 }
 
 # Run the commands
 rm -rf example_results
 mkdir -p example_results
 
-run_flakeguard "$1" "$2"
+run_flakeguard_example "$1" "$2"

--- a/tools/flakeguard/run_example.sh
+++ b/tools/flakeguard/run_example.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+run_flakeguard() {
+  local run_count=$1
+  local skip_tests=$2
+
+  echo "Running Flakeguard $run_count times"
+
+  for ((i=1; i<=$run_count; i++)); do
+    output_file="example_results/example_run_$i.json"
+    go run . run \
+      --project-path=./runner \
+      --test-packages=./example_test_package \
+      --run-count=5 \
+      --skip-tests=$skip_tests \
+      --max-pass-ratio=1 \
+      --race=false \
+      --output-json=$output_file
+    local EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 2 ]; then
+      echo "ERROR: Flakeguard encountered an error while running tests"
+      exit $EXIT_CODE
+    fi
+  done
+}
+
+# Run the commands
+rm -rf example_results
+mkdir -p example_results
+
+run_flakeguard "$1" "$2"

--- a/tools/flakeguard/run_example.sh
+++ b/tools/flakeguard/run_example.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Used to run flakeguard on the example test package
 
 run_flakeguard_example() {
   local run_count=$1

--- a/tools/flakeguard/runner/runner.go
+++ b/tools/flakeguard/runner/runner.go
@@ -84,7 +84,7 @@ func (r *Runner) RunTests() (*reports.TestReport, error) {
 		Results:       results,
 		MaxPassRatio:  r.MaxPassRatio,
 	}
-	reports.GenerateSummaryData(report)
+	report.GenerateSummaryData()
 	return report, nil
 }
 


### PR DESCRIPTION
Fixes issues with flakeguard aggregations not showing proper flaky test amounts.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes streamline the flakeguard tool's example commands and improve GitHub integration. They remove repetitive code, refine the presentation of test report summaries, and enhance artifact handling for test reports, making it easier to identify and address flaky tests.

## What
- **CODEOWNERS**
  - Removed `@sebawo` from the CODEOWNERS file, leaving only `@smartcontractkit/test-tooling-team` as the code owner.
- **tools/flakeguard/Makefile**
  - Simplified the `example`, `example_flaky_panic`, and `example_timeout` commands to use a new script `run_example.sh` with parameters, reducing redundancy.
- **tools/flakeguard/README.md**
  - Updated the README to reflect changes in how to run examples and view results, aligning with the new `run_example.sh` script usage.
- **tools/flakeguard/cmd/generate_report.go**
  - Introduced a constant for an example GitHub token and added a condition to use a mock URL for artifact links when using this example token, facilitating easier testing and examples.
- **tools/flakeguard/reports/data.go**
  - Moved and refined the `GenerateSummaryData` function to be a method of `TestReport`, improving encapsulation. Adjusted summary data generation logic for clarity and efficiency.
- **tools/flakeguard/reports/data_test.go**, **tools/flakeguard/reports/presentation_test.go**
  - Updated tests to use the newly moved `GenerateSummaryData` method.
- **tools/flakeguard/reports/io.go**
  - Adjusted loading and aggregation of test reports to default the `maxPassRatio` to 1.0 if not specified, and added error handling for data sending to Splunk.
- **tools/flakeguard/reports/presentation.go**
  - Altered markdown generation for GitHub, making the summary table and test results more readable and user-friendly. Changed "Flaky Test Ratio" to "Flaky Test Percent" and "Pass Ratio" to "Pass Percent" for clarity.
- **tools/flakeguard/run_example.sh**
  - Added a new script to run flakeguard examples, encapsulating the previously inlined Makefile commands for cleaner and more maintainable execution steps.
- **tools/flakeguard/runner/runner.go**
  - Made minor adjustments in line with the refactored `GenerateSummaryData` usage.
