### PR TITLE
Discard Deprecated CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -82,14 +82,13 @@ jobs:
       - name: Check out Code
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Go
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
+        uses: smartcontractkit/.github/actions/setup-golang@3835daadbcefcae06d12dc42a405a856c980d2cc
         with:
-          test_download_vendor_packages_command: cd ${{ matrix.project.path }} && go mod download
-          go_mod_path: ${{ matrix.project.path }}go.mod
-          cache_key_id: ctf-go-${{ matrix.project.name }}
-          cache_restore_only: 'false'
+          go-version-file: ${{ matrix.project.path }}go.mod
+          use-go-cache: true
+          go-cache-dep-path: ${{ matrix.project.path }}go.sum
       - name: golangci-lint ${{ needs.tools.outputs.golangci-lint-version }}
-        uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc # v5.1.0
+        uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
         with:
           version: v${{ needs.tools.outputs.golangci-lint-version }}
           args: --out-format checkstyle:golangci-lint-report.xml
@@ -113,12 +112,11 @@ jobs:
       - name: Check out Code
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Install Go
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d2f9642bcc24a73400568756f24b72c188ac7a9a # v2.3.31
+        uses: smartcontractkit/.github/actions/setup-golang@3835daadbcefcae06d12dc42a405a856c980d2cc
         with:
-          test_download_vendor_packages_command: cd lib && go mod download
-          go_mod_path: ./lib/go.mod
-          cache_key_id: ctf-go
-          cache_restore_only: 'false'
+          go-version-file: ./lib/go.mod
+          use-go-cache: true
+          go-cache-dep-path: ./lib/go.sum
       - name: Write Go List
         working-directory: lib
         run: go list -json -deps ./... > ../go.list


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the linting and Go environment setup processes, update tool versions for better compatibility and performance, and improve caching mechanisms for Go dependencies. These adjustments ensure more efficient and reliable CI workflows.

## What
- `.github/workflows/lint.yaml`
  - Updated the `actions/checkout` to a fixed version for consistency across jobs.
  - Switched to a newer version of `install-nix-action` and `setup-go` actions for better support and features.
  - Changed the `setup-go` action from `smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go` to `smartcontractkit/.github/actions/setup-golang` in both `golangci` and `vulnerabilities-check` jobs, standardizing the Go setup process across the workflow.
    - Introduced `go-version-file` and `use-go-cache` inputs for better version management and caching.
    - Replaced specific configuration settings with more generalized and efficient ones, like `go-cache-dep-path` for dependency path caching.
  - Updated the `golangci-lint-action` version to `v6.3.2` for the latest features and fixes.
  - Minor tweaks in other jobs like `asdf-install`, `helmlint`, `actionlint`, and `sonarqube` for consistency in checkout action version, ensuring all jobs use the same baseline for operations.
