### PR TITLE
Public parrot releases to Docker

### DIFF
--- a/.github/workflows/parrot-release.yml
+++ b/.github/workflows/parrot-release.yml
@@ -45,4 +45,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           IMAGE_PREFIX: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
-          IMAGE_TAG: ${{ github.ref_name}}
+          IMAGE_TAG: ${{ github.ref_name }}
+          DOCKER_USERNAME: kalverra
+          DOCKER_PASSWORD: ${{ secrets.KALVERRA_DOCKER_PASSWORD }}

--- a/parrot/.changeset/v0.4.2.md
+++ b/parrot/.changeset/v0.4.2.md
@@ -1,0 +1,1 @@
+Public docker releases for parrot

--- a/parrot/.goreleaser.yaml
+++ b/parrot/.goreleaser.yaml
@@ -16,6 +16,13 @@ env:
 builds:
   - id: parrot
     main: ./cmd/main.go
+    ldflags:
+      - -s
+      - -w
+      - -X github.com/smartcontractkit/chainlink-testing-framework/parrot.version={{.Version}}
+      - -X github.com/smartcontractkit/chainlink-testing-framework/parrot.commit={{.ShortCommit}}
+      - -X github.com/smartcontractkit/chainlink-testing-framework/parrot.date={{.CommitDate}}
+      - -X github.com/smartcontractkit/chainlink-testing-framework/parrot.builtBy=goreleaser
     goos:
       - linux
       - darwin
@@ -34,6 +41,8 @@ dockers:
     image_templates:
       - '{{ .Env.IMG_PRE }}/parrot:{{ .Tag }}-amd64'
       - '{{ .Env.IMG_PRE }}/parrot:latest-amd64'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:{{ .Tag }}-amd64{{ end }}'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:latest-amd64{{ end }}'
     build_flag_templates:
       - --platform=linux/amd64
       - --pull
@@ -47,6 +56,8 @@ dockers:
     image_templates:
       - '{{ .Env.IMG_PRE }}/parrot:{{ .Tag }}-arm64'
       - '{{ .Env.IMG_PRE }}/parrot:latest-arm64'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:{{ .Tag }}-arm64{{ end }}'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:latest-arm64{{ end }}'
     build_flag_templates:
       - --platform=linux/arm64
       - --pull
@@ -64,6 +75,14 @@ docker_manifests:
     image_templates:
       - '{{ .Env.IMG_PRE }}/parrot:latest-amd64'
       - '{{ .Env.IMG_PRE }}/parrot:latest-arm64'
+  - name_template: '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:{{ .Tag }}{{ end }}'
+    image_templates:
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:{{ .Tag }}-amd64{{ end }}'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:{{ .Tag }}-arm64{{ end }}'
+  - name_template: '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:latest{{ end }}'
+    image_templates:
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:latest-amd64{{ end }}'
+      - '{{ if ne .Env.IMG_PRE "local" }}{{ .Env.DOCKER_USER }}/parrot:latest-arm64{{ end }}'
 
 before:
   hooks:

--- a/parrot/Dockerfile
+++ b/parrot/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 
 COPY parrot /parrot
-ENV PARROT_PORT 80
-ENV PARROT_TRACE true
+ENV PARROT_PORT=80
+ENV PARROT_TRACE=true
 EXPOSE 80
 ENTRYPOINT [ "/parrot" ]

--- a/parrot/parrot.go
+++ b/parrot/parrot.go
@@ -33,6 +33,14 @@ const (
 	MethodAny = "ANY"
 )
 
+// These variables are set at build time and describe the Version of the application
+var (
+	version = "dev"
+	commit  = "dev"
+	date    = time.Now().Format(time.RFC3339)
+	builtBy = "local"
+)
+
 // Route holds information about the mock route configuration
 type Route struct {
 	// Method is the HTTP method to match
@@ -195,7 +203,14 @@ func (p *Server) run(listener net.Listener) {
 	}()
 
 	p.log.Info().Str("Address", p.address).Msg("Parrot awake and ready to squawk")
-	p.log.Debug().Str("Save File", p.saveFileName).Str("Log File", p.logFileName).Msg("Configuration")
+	p.log.Debug().
+		Str("Save File", p.saveFileName).
+		Str("Log File", p.logFileName).
+		Str("Version", version).
+		Str("Commit", commit).
+		Str("Build Date", date).
+		Str("Built By", builtBy).
+		Msg("Configuration")
 	if err := p.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		fmt.Println("ERROR: Failed to start server:", err)
 	}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce enhancements to facilitate Docker image releases, improve build information transparency, and standardize environment variable declarations. By adding Docker credentials and refining the build process with detailed flags, the updates ensure better integration with Docker Hub and clarify the build's specifics directly within the binary and Docker images. The adjustments in environment variables formatting in the Dockerfile aim for consistency and clarity.

## What
- **.github/workflows/parrot-release.yml**
  - Added `DOCKER_USERNAME` and `DOCKER_PASSWORD` to the environment variables for Docker login, ensuring Docker Hub can be used for image pushes.
- **parrot/.changeset/v0.4.2.md**
  - Introduced a new changeset for documenting public Docker releases of the parrot application.
- **parrot/.goreleaser.yaml**
  - Added linker flags (`ldflags`) to embed version, commit, date, and build information into the binary.
  - Included Docker user in image templates to support pushing images to user-specific Docker Hub repositories.
  - Modified Docker manifest templates to conditionally include Docker user in image names, facilitating better organization and visibility on Docker Hub.
- **parrot/Dockerfile**
  - Corrected the environment variable declarations for `PARROT_PORT` and `PARROT_TRACE` for consistency and to conform with best practices.
- **parrot/parrot.go**
  - Introduced global variables to hold build time information such as version, commit, build date, and builder identity, enhancing the transparency of the build's origin.
  - Extended logging configuration to include build information, thereby providing immediate insights into the build version and metadata directly from the application logs.
