### PR TITLE
update solana validator

### DIFF
--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -31,7 +31,11 @@ var idJSONRaw = `
 `
 
 func defaultSolana(in *Input) {
-	if in.Image == "" {
+	ci := os.Getenv("CI") == "true"
+	if in.Image == "" && !ci {
+		in.Image = "f4hrenh9it/solana"
+	}
+	if in.Image == "" && ci {
 		in.Image = "anzaxyz/agave:v2.1.13"
 	}
 	if in.Port == "" {

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -31,12 +31,8 @@ var idJSONRaw = `
 `
 
 func defaultSolana(in *Input) {
-	ci := os.Getenv("CI") == "true"
-	if in.Image == "" && !ci {
-		in.Image = "f4hrenh9it/solana"
-	}
-	if in.Image == "" && ci {
-		in.Image = "solanalabs/solana:v1.18.26"
+	if in.Image == "" {
+		in.Image = "anza-xyz/agave:v2.1.13"
 	}
 	if in.Port == "" {
 		in.Port = "8999"

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -32,7 +32,7 @@ var idJSONRaw = `
 
 func defaultSolana(in *Input) {
 	if in.Image == "" {
-		in.Image = "anza-xyz/agave:v2.1.13"
+		in.Image = "anzaxyz/agave:v2.1.13"
 	}
 	if in.Port == "" {
 		in.Port = "8999"


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
This change updates the default Docker image used for Solana in a CI environment to use a different version, indicating a shift in the preferred environment setup.

## What
- **framework/components/blockchain/solana.go**
  - Updated the default Docker image for Solana in CI environments from `solanalabs/solana:v1.18.26` to `anzaxyz/agave:v2.1.13`. This change likely reflects a need for updated features or better compatibility provided by the new image version.
