### PR TITLE
multi-dashboard annotations, add RMN dummy

### DIFF
--- a/framework/.changeset/v0.5.2.md
+++ b/framework/.changeset/v0.5.2.md
@@ -1,0 +1,2 @@
+- Update chaos playground for RMN
+- Allow multiple dashboard UIDs

--- a/framework/grafana/grafana.go
+++ b/framework/grafana/grafana.go
@@ -1,8 +1,6 @@
 package framework
 
 import (
-	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -13,47 +11,19 @@ type Client struct {
 }
 
 // NewGrafanaClient initializes a new Grafana client with the specified URL and API key.
-func NewGrafanaClient(url, apiKey string) *Client {
+func NewGrafanaClient(url, bearerToken string) *Client {
 	return &Client{
 		resty: resty.New().
 			SetBaseURL(url).
-			SetHeader("Authorization", "Bearer "+apiKey),
+			SetHeader("Authorization", "Bearer "+bearerToken),
 	}
 }
 
 type Annotation struct {
-	ID           int64         `json:"id"`
-	AlertID      int64         `json:"alertId"`
-	DashboardID  int64         `json:"dashboardId"`
-	DashboardUID string        `json:"dashboardUID"`
-	PanelID      int64         `json:"panelId"`
-	PrevState    string        `json:"prevState"`
-	NewState     string        `json:"newState"`
-	Text         string        `json:"text"`
-	Time         time.Time     `json:"time"`
-	TimeEnd      time.Time     `json:"timeEnd"`
-	Created      time.Time     `json:"created"`
-	Updated      time.Time     `json:"updated"`
-	Tags         []interface{} `json:"tags"`
-	Data         interface{}   `json:"data"`
-}
-
-type AnnotationsQueryParams struct {
-	Limit        *int
-	AlertID      *int
-	DashboardID  *int
-	DashboardUID *string
-	Type         *string
-	From         *time.Time
-	To           *time.Time
-}
-
-type PostAnnotation struct {
-	DashboardID  *int
 	PanelID      *int
-	DashboardUID string
-	Time         *time.Time
-	TimeEnd      *time.Time
+	DashboardUID []string
+	StartTime    *time.Time
+	EndTime      *time.Time
 	Tags         []string
 	Text         string
 }
@@ -63,67 +33,39 @@ type PostAnnotationResponse struct {
 	ID      int64  `json:"id"`
 }
 
-// GetAnnotations retrieves a list of annotations based on specified query parameters.
-func (c *Client) GetAnnotations(params AnnotationsQueryParams) ([]Annotation, *resty.Response, error) {
-	query := make(url.Values)
-	if params.Limit != nil {
-		query.Set("limit", fmt.Sprintf("%d", *params.Limit))
-	}
-	if params.AlertID != nil {
-		query.Set("alertId", fmt.Sprintf("%d", *params.AlertID))
-	}
-	if params.DashboardID != nil {
-		query.Set("dashboardId", fmt.Sprintf("%d", *params.DashboardID))
-	}
-	if params.DashboardUID != nil {
-		query.Set("dashboardUID", *params.DashboardUID)
-	}
-	if params.Type != nil {
-		query.Set("type", *params.Type)
+// Annotate adds annotation to all the dashboards, works for both single point annotation with just StartTime and for ranges with StartTime/EndTime
+func (c *Client) Annotate(annotation Annotation) ([]PostAnnotationResponse, []*resty.Response, error) {
+	var results []PostAnnotationResponse
+	var responses []*resty.Response
+
+	for _, uid := range annotation.DashboardUID {
+		a := map[string]interface{}{
+			"dashboardUID": uid,
+			"tags":         annotation.Tags,
+			"text":         annotation.Text,
+		}
+		if annotation.PanelID != nil {
+			a["panelId"] = *annotation.PanelID
+		}
+		if annotation.StartTime != nil {
+			a["time"] = annotation.StartTime.UnixMilli()
+		}
+		if annotation.EndTime != nil {
+			a["timeEnd"] = annotation.EndTime.UnixMilli()
+		}
+
+		var result PostAnnotationResponse
+		r, err := c.resty.R().
+			SetBody(a).
+			SetResult(&result).
+			Post("/api/annotations")
+		if err != nil {
+			return nil, nil, err // Return early if any request fails
+		}
+
+		results = append(results, result)
+		responses = append(responses, r)
 	}
 
-	if (params.From != nil && params.To == nil) || (params.To != nil && params.From == nil) {
-		return nil, nil, fmt.Errorf("both From and To must be set")
-	}
-
-	if params.From != nil {
-		query.Set("from", fmt.Sprintf("%d", params.From.UnixMilli()))
-	}
-	if params.To != nil {
-		query.Set("to", fmt.Sprintf("%d", params.To.UnixMilli()))
-	}
-
-	var result []Annotation
-	r, err := c.resty.R().
-		SetResult(&result).
-		SetQueryString(query.Encode()).
-		Get("/api/annotations")
-	return result, r, err
-}
-
-// PostAnnotation sends a new annotation to a specified dashboard.
-func (c *Client) PostAnnotation(annotation PostAnnotation) (PostAnnotationResponse, *resty.Response, error) {
-	a := map[string]interface{}{
-		"dashboardUID": annotation.DashboardUID,
-		"tags":         annotation.Tags,
-		"text":         annotation.Text,
-	}
-	if annotation.DashboardID != nil {
-		a["dashboardId"] = *annotation.DashboardID
-	}
-	if annotation.PanelID != nil {
-		a["panelId"] = *annotation.PanelID
-	}
-	if annotation.Time != nil {
-		a["time"] = annotation.Time.UnixMilli()
-	}
-	if annotation.TimeEnd != nil {
-		a["timeEnd"] = annotation.TimeEnd.UnixMilli()
-	}
-	var result PostAnnotationResponse
-	r, err := c.resty.R().
-		SetBody(a).
-		SetResult(&result).
-		Post("/api/annotations")
-	return result, r, err
+	return results, responses, nil
 }

--- a/framework/grafana/grafana_test.go
+++ b/framework/grafana/grafana_test.go
@@ -1,14 +1,13 @@
 package framework
 
 import (
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
-// TestPostAnnotationIntegration tests the PostAnnotation method against a real Grafana instance.
+// TestPostAnnotationIntegration tests the Annotation method against a real Grafana instance.
 func TestPostAnnotationIntegration(t *testing.T) {
 	t.Skip("manual grafana integration test")
 	grafanaURL := os.Getenv("GRAFANA_URL")
@@ -18,18 +17,21 @@ func TestPostAnnotationIntegration(t *testing.T) {
 	}
 	client := NewGrafanaClient(grafanaURL, apiKey)
 
-	annotation := PostAnnotation{
-		DashboardUID: "WaspDebug",
-		Text:         "CTFv2 test annotation",
-		Tags:         []string{"tag-1", "tag-2"},
-		Time:         Ptr(time.Now().Add(-1 * time.Minute)),
-		TimeEnd:      Ptr(time.Now()),
+	annotation := Annotation{
+		Text:      "CTFv2 test annotation",
+		StartTime: Ptr(time.Now().Add(-11 * time.Minute)),
+		//EndTime:      Ptr(time.Now()),
+		DashboardUID: []string{"WaspDebug", "e98b5451-12dc-4a8b-9576-2c0b67ddbd0c"},
+		Tags:         []string{"tag-3", "tag-4"},
 	}
-	response, resp, err := client.PostAnnotation(annotation)
-	assert.NoError(t, err, "PostAnnotation should not return an error")
-	assert.Equal(t, 200, resp.StatusCode(), "Expected HTTP status code 200")
-	assert.NotEmpty(t, response.ID, "Annotation ID should not be empty")
-	assert.NotEmpty(t, response.Message, "Annotation message should not be empty")
+	response, resp, err := client.Annotate(annotation)
+	assert.NoError(t, err, "Annotate should not return an error")
+	assert.Equal(t, 200, resp[0].StatusCode(), "Expected HTTP status code 200")
+	assert.NotEmpty(t, response[0].ID, "Annotation ID should not be empty")
+	assert.NotEmpty(t, response[0].Message, "Annotation message should not be empty")
+	assert.Equal(t, 200, resp[1].StatusCode(), "Expected HTTP status code 200")
+	assert.NotEmpty(t, response[1].ID, "Annotation ID should not be empty")
+	assert.NotEmpty(t, response[1].Message, "Annotation message should not be empty")
 }
 
 func Ptr[T any](value T) *T {

--- a/infra/chaosmesh-playground/dummy-cluster.yaml
+++ b/infra/chaosmesh-playground/dummy-cluster.yaml
@@ -79,7 +79,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-0
+  name: node-0
   labels:
     app.kubernetes.io/instance: ccip-0
 spec:
@@ -118,7 +118,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-1
+  name: node-1
   labels:
     app.kubernetes.io/instance: ccip-1
 spec:
@@ -157,7 +157,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-2
+  name: node-2
   labels:
     app.kubernetes.io/instance: ccip-2
 spec:
@@ -196,7 +196,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-3
+  name: node-3
   labels:
     app.kubernetes.io/instance: ccip-3
 spec:
@@ -235,7 +235,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-db-0
+  name: db-0
   labels:
     app.kubernetes.io/instance: chainlink-don-db-0
 spec:
@@ -274,7 +274,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-db-1
+  name: db-1
   labels:
     app.kubernetes.io/instance: chainlink-don-db-1
 spec:
@@ -313,7 +313,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-db-2
+  name: db-2
   labels:
     app.kubernetes.io/instance: chainlink-don-db-2
 spec:
@@ -352,7 +352,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-db-3
+  name: db-3
   labels:
     app.kubernetes.io/instance: chainlink-don-db-3
 spec:
@@ -391,7 +391,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: http-ping-deployment-db-4
+  name: db-4
   labels:
     app.kubernetes.io/instance: chainlink-don-db-4
 spec:
@@ -404,6 +404,162 @@ spec:
       labels:
         app: http-ping-app
         app.kubernetes.io/instance: chainlink-don-db-4
+    spec:
+      containers:
+        - name: http-ping-container
+          image: python:3.9
+          command:
+            - sh
+            - -c
+            - |
+              apt-get update && apt-get install -y dnsutils iputils-ping
+              python -m http.server 8080 &
+              while true; do
+                POD_IPS=$(nslookup http-ping-service | awk '/Address/ {print $2}' | tail -n +2)
+                for IP in $POD_IPS; do
+                  if [ "$IP" != "$(hostname -i)" ]; then
+                    LATENCY=$(ping -c 1 $IP | grep 'time=' | awk -F'time=' '{print $2}' | awk '{print $1}')
+                    echo "$IP ->> $LATENCY ms"
+                  fi
+                done
+                sleep 1
+              done
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rmn-0
+  labels:
+    app.kubernetes.io/instance: rmn-0
+spec:
+  selector:
+    matchLabels:
+      app: http-ping-app
+      app.kubernetes.io/instance: rmn-0
+  template:
+    metadata:
+      labels:
+        app: http-ping-app
+        app.kubernetes.io/instance: rmn-0
+    spec:
+      containers:
+        - name: http-ping-container
+          image: python:3.9
+          command:
+            - sh
+            - -c
+            - |
+              apt-get update && apt-get install -y dnsutils iputils-ping
+              python -m http.server 8080 &
+              while true; do
+                POD_IPS=$(nslookup http-ping-service | awk '/Address/ {print $2}' | tail -n +2)
+                for IP in $POD_IPS; do
+                  if [ "$IP" != "$(hostname -i)" ]; then
+                    LATENCY=$(ping -c 1 $IP | grep 'time=' | awk -F'time=' '{print $2}' | awk '{print $1}')
+                    echo "$IP ->> $LATENCY ms"
+                  fi
+                done
+                sleep 1
+              done
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rmn-1
+  labels:
+    instance: rmn-1
+spec:
+  selector:
+    matchLabels:
+      app: http-ping-app
+      app.kubernetes.io/instance: rmn-1
+  template:
+    metadata:
+      labels:
+        app: http-ping-app
+        app.kubernetes.io/instance: rmn-1
+    spec:
+      containers:
+        - name: http-ping-container
+          image: python:3.9
+          command:
+            - sh
+            - -c
+            - |
+              apt-get update && apt-get install -y dnsutils iputils-ping
+              python -m http.server 8080 &
+              while true; do
+                POD_IPS=$(nslookup http-ping-service | awk '/Address/ {print $2}' | tail -n +2)
+                for IP in $POD_IPS; do
+                  if [ "$IP" != "$(hostname -i)" ]; then
+                    LATENCY=$(ping -c 1 $IP | grep 'time=' | awk -F'time=' '{print $2}' | awk '{print $1}')
+                    echo "$IP ->> $LATENCY ms"
+                  fi
+                done
+                sleep 1
+              done
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rmn-2
+  labels:
+    app.kubernetes.io/instance: rmn-2
+spec:
+  selector:
+    matchLabels:
+      app: http-ping-app
+      app.kubernetes.io/instance: rmn-2
+  template:
+    metadata:
+      labels:
+        app: http-ping-app
+        app.kubernetes.io/instance: rmn-2
+    spec:
+      containers:
+        - name: http-ping-container
+          image: python:3.9
+          command:
+            - sh
+            - -c
+            - |
+              apt-get update && apt-get install -y dnsutils iputils-ping
+              python -m http.server 8080 &
+              while true; do
+                POD_IPS=$(nslookup http-ping-service | awk '/Address/ {print $2}' | tail -n +2)
+                for IP in $POD_IPS; do
+                  if [ "$IP" != "$(hostname -i)" ]; then
+                    LATENCY=$(ping -c 1 $IP | grep 'time=' | awk -F'time=' '{print $2}' | awk '{print $1}')
+                    echo "$IP ->> $LATENCY ms"
+                  fi
+                done
+                sleep 1
+              done
+          ports:
+            - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rmn-3
+  labels:
+    app.kubernetes.io/instance: rmn-3
+spec:
+  selector:
+    matchLabels:
+      app: http-ping-app
+      app.kubernetes.io/instance: rmn-3
+  template:
+    metadata:
+      labels:
+        app: http-ping-app
+        app.kubernetes.io/instance: rmn-3
     spec:
       containers:
         - name: http-ping-container


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates introduce enhancements and adjustments across both the framework and infrastructure components, focusing on Grafana integration and Chaos Mesh playground configurations. In the framework, the Grafana client configuration and annotation functionalities are streamlined for better token management and flexibility in dashboard annotation. For the infrastructure, the Chaos Mesh playground sees the introduction of new nodes specifically for the RMN environment, indicating an expansion or test scenario enhancement.

## What
- `framework/.changeset/v0.5.2.md`
  - Added a changelog entry for version v0.5.2, mentioning updates to chaos playground for RMN and support for multiple dashboard UIDs.
- `framework/grafana/grafana.go`
  - Modified `NewGrafanaClient` function to accept a `bearerToken` instead of an `apiKey`, aligning with more secure and standard authentication practices.
  - Removed unused structs and functions like `Annotation`, `AnnotationsQueryParams`, and `GetAnnotations` to streamline the codebase.
  - Updated `PostAnnotation` struct to support multiple `DashboardUIDs`, allowing annotations to be added across multiple dashboards.
  - Introduced a new method `Annotate` that iterates over multiple dashboard UIDs for annotations, enhancing the annotation feature to be more versatile and applicable to multiple dashboards simultaneously.
- `framework/grafana/grafana_test.go`
  - Updated integration test to reflect the new annotation method and verify functionality against multiple dashboard UIDs.
- `infra/chaosmesh-playground/dummy-cluster.yaml`
  - Renamed deployment names from `http-ping-deployment-X` to more descriptive names indicating their roles (`node-X`, `db-X`, `rmn-X`), improving clarity and manageability.
  - Added new deployments for `rmn-0` to `rmn-3`, expanding the Chaos Mesh playground with additional nodes for RMN, which could be aimed at testing resilience and network behaviors in a more complex setup.
