### PR TITLE
Updates go and linting versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -88,7 +88,7 @@ jobs:
           use-go-cache: true
           go-cache-dep-path: ${{ matrix.project.path }}go.sum
       - name: golangci-lint ${{ needs.tools.outputs.golangci-lint-version }}
-        uses: golangci/golangci-lint-action@e0ebdd245eea59746bb0b28ea6a9871d3e35fbc9 # v6.3.3
+        uses: golangci/golangci-lint-action@818ec4d51a1feacefc42ff1b3ec25d4962690f39 # v6.4.1
         with:
           version: v${{ needs.tools.outputs.golangci-lint-version }}
           args: --out-format checkstyle:golangci-lint-report.xml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,9 +27,6 @@ linters-settings:
     local-prefixes: github.com/smartcontractkit/chainlink-testing-framework/lib
   gosec:
     exclude-generated: true
-  govet:
-    # report about shadowed variables
-    check-shadowing: false
   errorlint:
     # Allow formatting of errors without %w
     errorf: false
@@ -71,12 +68,8 @@ linters-settings:
       - name: modifies-parameter
       - name: identical-branches
       - name: get-return
-      # - name: flag-parameter
-      # - name: early-return
       - name: defer
       - name: constant-logical-expr
-      # - name: confusing-naming
-      # - name: confusing-results
       - name: bool-literal-in-expr
       - name: atomic
 issues:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.24.0
+golang 1.23.4
 nodejs 18.20.3
 k3d 5.6.3
 act 0.2.52

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.24
+golang 1.24.0
 nodejs 18.20.3
 k3d 5.6.3
 act 0.2.52

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,8 +1,8 @@
-golang 1.23.3
+golang 1.24
 nodejs 18.20.3
 k3d 5.6.3
 act 0.2.52
-golangci-lint 1.62.0
+golangci-lint 1.64.5
 actionlint 1.6.26
 shellcheck 0.9.0
 helm 3.15.2

--- a/parrot/go.mod
+++ b/parrot/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-testing-framework/parrot
 
-go 1.24.0
+go 1.23.6
 
 require (
 	github.com/go-chi/chi v1.5.5


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The updates in both the GitHub workflow configurations and tool versions aim to enhance the code quality and maintain compatibility with the latest versions of the tools used. Upgrading `golangci-lint` action and `golang` version ensures the use of the most recent features and improvements in linting and programming language standards. This allows for more efficient and thorough code checks, improving the overall codebase quality.

## What
- **.github/workflows/lint.yaml**
  - Updated the `golangci-lint-action` to version `v6.4.1`. This update will utilize the latest improvements and bug fixes in the linting process.
- **.tool-versions**
  - Upgraded `golang` version from `1.23.3` to `1.24`. This change ensures that the project stays up-to-date with the latest Go language features and optimizations.
  - Updated `golangci-lint` version from `1.62.0` to `1.64.5`. This version bump brings in the latest linting rules and performance improvements, helping to catch more potential issues and enhancing code quality.
