### PR TITLE
[TT-1953] explain how to use requests per minute or hour

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -100,6 +100,7 @@
       - [Start local observability stack](./libs/wasp/how-to/start_local_observability_stack.md)
       - [Try it out quickly](./libs/wasp/how-to/run_included_tests.md)
       - [Chose between RPS and VUs](./libs/wasp/how-to/chose_rps_vu.md)
+      - [Configure requests per minute or hour](./libs/wasp/how-to/rps_per_minute.md)
       - [Define NFRs and check alerts](./libs/wasp/how-to/define_nfr_check_alerts.md)
       - [Use labels](./libs/wasp/how-to/use_labels.md)
       - [Incorporate load tests in your workflow](./libs/wasp/how-to/incorporate_load_tests.md)

--- a/book/src/libs/wasp/components/generator.md
+++ b/book/src/libs/wasp/components/generator.md
@@ -10,7 +10,7 @@ A **Generator** is a component that encapsulates all the characteristics of load
 * [Sampling](./sampler.md)
 * Timeouts
 
-> [!WARNING]  
+> [!WARNING]
 > RPS load type can only be used with a `Gun`, while VUs can only be used with a `VirtualUser`.
 
 ---

--- a/book/src/libs/wasp/how-to/chose_rps_vu.md
+++ b/book/src/libs/wasp/how-to/chose_rps_vu.md
@@ -2,7 +2,7 @@
 
 When writing a test, you need to decide whether to use **RPS** or **VUs** as your load type.
 
-> [!WARNING]  
+> [!WARNING]
 > RPS load type can only be used with a `Gun`, and VUs can only be used with a `VirtualUser`.
 
 ---
@@ -15,6 +15,9 @@ You should use **RPS** when your goal is to measure **throughput**. This load ty
 * The system's response time has no impact on the rate of load generation.
 
 In an RPS-based test, new requests are sent continuously, regardless of how long previous requests take.
+
+> [!NOTE]
+> [Read here](./libs/wasp/how-to/rps_per_minute.md) how to define the RPS load in terms of requests per minute or per hour instead of default per second.
 
 ### Example RPS Test Diagram
 ```mermaid
@@ -105,5 +108,5 @@ In this model, `VU2` starts only after `VU1` has finished its iteration.
     - Workflows that involve multiple steps.
     - Scenarios where response time impacts the load generation rate.
 
-> [!NOTE]  
+> [!NOTE]
 > Learn more about open and closed models [here](https://grafana.com/docs/k6/latest/using-k6/scenarios/concepts/open-vs-closed/).

--- a/book/src/libs/wasp/how-to/rps_per_minute.md
+++ b/book/src/libs/wasp/how-to/rps_per_minute.md
@@ -1,0 +1,20 @@
+# WASP - How to configure requests per minute or hour
+
+By default, WASP schedule describes requests **per second**, but what if you want to define the load in terms of requests **per minute** or **per hour**? `RateLimitUnitDuration` to the rescue!
+
+If you want to execute 10 requests per minute, you'd use this generator config:
+```go
+gen, err := wasp.NewGenerator(&wasp.Config{
+    LoadType: wasp.RPS,
+    Schedule:   wasp.Plain(10, 2*time.Hour),      // plain line profile - 10 requests per minute for 2h
+    Gun:        NewExampleHTTPGun(srv.URL()),
+    Labels:     labels,
+    LokiConfig: wasp.NewEnvLokiConfig(),
+    RateLimitUnitDuration: time.Minute,           // <---- this is the key setting
+})
+if err != nil {
+    panic(err)
+}
+```
+
+In other words you could say that `RateLimitUnitDuration` represents the *denominator* of rate limit duration and RPS value in the schedule the *numeral*.


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce documentation updates and a new section to guide users on configuring request rates per minute or hour, instead of the default per second. This addition aims to provide flexibility in load testing configurations, catering to scenarios where requests per second might not be the most appropriate metric.

## What
- **book/src/SUMMARY.md**
  - Added a new entry for "Configure requests per minute or hour" under the "How to" section. This change makes it easier for users to find information on configuring request rates in terms other than the default per second.
- **book/src/libs/wasp/components/generator.md**
  - Minor formatting change in the warning message about using RPS with `Gun` and VUs with `VirtualUser`. This change improves the readability of the documentation.
- **book/src/libs/wasp/how-to/chose_rps_vu.md**
  - Updated the warning and note formatting for consistency. Added a note directing readers to the new "Configure requests per minute or hour" section for more information on defining load in terms of requests per minute or hour. This addition helps users understand the options for configuring load tests more flexibly.
- **book/src/libs/wasp/how-to/rps_per_minute.md**
  - Introduced a new file explaining how to configure the load in terms of requests per minute or hour using `RateLimitUnitDuration`. This guidance is crucial for users needing to define load testing metrics more aligned with their specific testing scenarios.
