### PR TITLE
[TT-1997] validator & gh client

### DIFF
--- a/framework/go.mod
+++ b/framework/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/docker/go-connections v0.5.0
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.22.1
 	github.com/go-resty/resty/v2 v2.15.3
 	github.com/google/uuid v1.6.0
@@ -89,8 +91,6 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect

--- a/lib/client/github.go
+++ b/lib/client/github.go
@@ -2,10 +2,15 @@ package client
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	// import for side effect of sql packages
 	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
 
 	"github.com/google/go-github/v41/github"
 	"golang.org/x/oauth2"
@@ -40,21 +45,77 @@ func NewGithubClient(token string) *GithubClient {
 
 // ListLatestReleases lists the latest releases for a given repository
 func (g *GithubClient) ListLatestReleases(org, repository string, count int) ([]*github.RepositoryRelease, error) {
-	ctx := context.Background()
+	ctx, cancelFn := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancelFn()
 	releases, _, err := g.client.Repositories.ListReleases(ctx, org, repository, &github.ListOptions{PerPage: count})
 	return releases, err
 }
 
 // ListLatestCLCoreReleases lists the latest releases for the Chainlink core repository
 func (g *GithubClient) ListLatestCLCoreReleases(count int) ([]*github.RepositoryRelease, error) {
-	ctx := context.Background()
+	ctx, cancelFn := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancelFn()
 	releases, _, err := g.client.Repositories.ListReleases(ctx, "smartcontractkit", "chainlink", &github.ListOptions{PerPage: count})
 	return releases, err
 }
 
 // ListLatestCLCoreTags lists the latest tags for the Chainlink core repository
 func (g *GithubClient) ListLatestCLCoreTags(count int) ([]*github.RepositoryTag, error) {
-	ctx := context.Background()
+	ctx, cancelFn := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancelFn()
 	tags, _, err := g.client.Repositories.ListTags(ctx, "smartcontractkit", "chainlink", &github.ListOptions{PerPage: count})
 	return tags, err
+}
+
+func (g *GithubClient) DownloadAssetFromRelease(owner, repository, releaseTag, assetName string) ([]byte, error) {
+	var content []byte
+
+	// assuming 180s is enough to fetch releases, find the asset we need and download it
+	// some assets might be 30+ MB, so we need to give it some time (for really slow connections)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancelFn()
+	ghReleases, _, err := g.client.Repositories.ListReleases(ctx, owner, repository, &github.ListOptions{PerPage: 20})
+	if err != nil {
+		return content, errors.Wrapf(err, "failed to list releases for %s", repository)
+	}
+
+	var ghRelease *github.RepositoryRelease
+	for _, release := range ghReleases {
+		if release.TagName == nil {
+			continue
+		}
+
+		if *release.TagName == releaseTag {
+			ghRelease = release
+			break
+		}
+	}
+
+	if ghRelease == nil {
+		return content, errors.New("failed to find release with tag: " + releaseTag)
+	}
+
+	var assetID int64
+	for _, asset := range ghRelease.Assets {
+		if strings.Contains(asset.GetName(), assetName) {
+			assetID = asset.GetID()
+			break
+		}
+	}
+
+	if assetID == 0 {
+		return content, fmt.Errorf("failed to find asset %s for %s", assetName, *ghRelease.TagName)
+	}
+
+	asset, _, err := g.client.Repositories.DownloadReleaseAsset(ctx, owner, repository, assetID, g.client.Client())
+	if err != nil {
+		return content, errors.Wrapf(err, "failed to download asset %s for %s", assetName, *ghRelease.TagName)
+	}
+
+	content, err = io.ReadAll(asset)
+	if err != nil {
+		return content, err
+	}
+
+	return content, nil
 }


### PR DESCRIPTION
* exposes Validator & Translator, so that we can add new test config validations from tests and provide custom error messages
* adds asset-downloading function to Github Client
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes aim to enhance configuration validation, improve error handling, and extend functionality in the GitHub client interface. Specifically, the introduction of translations for validation messages allows for more user-friendly feedback, while the addition of context timeouts to GitHub API calls ensures that operations do not hang indefinitely. The new `DownloadAssetFromRelease` function in the GitHub client provides a way to programmatically download assets from a repository's release, which can be useful for automated deployment or updates.

## What
- **framework/config.go**
  - Added imports for `github.com/go-playground/locales/en` and `github.com/go-playground/universal-translator` to support translation of validation error messages.
  - Initialized `Validator` with `validator.New(validator.WithRequiredStructEnabled())` and set up a translator for English.
  - Modified `validateWithCustomErr` to use the global `Validator` and `ValidatorTranslator` for error messages, including a fallback to a default message format if the custom message is not specific enough.
- **framework/go.mod**
  - Added `github.com/go-playground/locales v0.14.1` and `github.com/go-playground/universal-translator v0.18.1` to the module dependencies for supporting translations in validation.
- **lib/client/github.go**
  - Added a timeout of 180 seconds to context in `ListLatestReleases`, `ListLatestCLCoreReleases`, and `ListLatestCLCoreTags` functions to prevent hanging during GitHub API calls.
  - Implemented a new function `DownloadAssetFromRelease` that fetches a specified asset from a release in a GitHub repository. This function handles finding the release by tag, identifying the asset by name, and downloading it, all within a timeout constraint.
