### PR TITLE
namespace-scoped chaos runner

### DIFF
--- a/havoc/.changeset/v1.50.4.md
+++ b/havoc/.changeset/v1.50.4.md
@@ -1,0 +1,1 @@
+- Namespace-scoped chaos runner with main-stage tested experiments 

--- a/havoc/go.mod
+++ b/havoc/go.mod
@@ -4,11 +4,14 @@ go 1.22.5
 
 require (
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20240821051457-da69c6d9617a
+	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chainlink-testing-framework/lib/grafana v1.50.0
 	k8s.io/api v0.31.2
+	k8s.io/apimachinery v0.31.2
 	k8s.io/client-go v0.31.2
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.0
 )
 
@@ -34,7 +37,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20240326122733-6f96a993222b // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -66,10 +68,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.31.0 // indirect
-	k8s.io/apimachinery v0.31.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/havoc/template.go
+++ b/havoc/template.go
@@ -1,0 +1,293 @@
+package havoc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func defaultListeners(l zerolog.Logger) []ChaosListener {
+	return []ChaosListener{
+		NewChaosLogger(l),
+	}
+}
+
+type ChaosRunner struct {
+	l zerolog.Logger
+	c client.Client
+}
+
+// NewNamespaceRunner creates a new namespace-scoped chaos runner
+func NewNamespaceRunner(l zerolog.Logger, c client.Client) *ChaosRunner {
+	return &ChaosRunner{
+		l: l,
+		c: c,
+	}
+}
+
+type PodPartitionCfg struct {
+	Namespace             string
+	Description           string
+	LabelFromKey          string
+	LabelFromValues       []string
+	LabelToKey            string
+	LabelToValues         []string
+	InjectionDuration     time.Duration
+	ExperimentCreateDelay time.Duration
+}
+
+func (cr *ChaosRunner) RunPodPartition(ctx context.Context, cfg PodPartitionCfg) (*Chaos, error) {
+	experiment, err := NewChaos(ChaosOpts{
+		Object: &v1alpha1.NetworkChaos{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       string(v1alpha1.TypeNetworkChaos),
+				APIVersion: "chaos-mesh.org/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("partition-%s", uuid.NewString()[0:5]),
+				Namespace: cfg.Namespace,
+			},
+			Spec: v1alpha1.NetworkChaosSpec{
+				Action:   v1alpha1.PartitionAction,
+				Duration: ptr.To[string]((cfg.InjectionDuration).String()),
+				PodSelector: v1alpha1.PodSelector{
+					Mode: v1alpha1.AllMode,
+					Selector: v1alpha1.PodSelectorSpec{
+						GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+							Namespaces: []string{cfg.Namespace},
+							ExpressionSelectors: v1alpha1.LabelSelectorRequirements{
+								{
+									Operator: "In",
+									Key:      cfg.LabelFromKey,
+									Values:   cfg.LabelFromValues,
+								},
+							},
+						},
+					},
+				},
+				Target: &v1alpha1.PodSelector{
+					Mode: v1alpha1.AllMode,
+					Selector: v1alpha1.PodSelectorSpec{
+						GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+							Namespaces: []string{cfg.Namespace},
+							ExpressionSelectors: v1alpha1.LabelSelectorRequirements{
+								{
+									Operator: "In",
+									Key:      cfg.LabelToKey,
+									Values:   cfg.LabelToValues,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Listeners: defaultListeners(cr.l),
+		Logger:    &cr.l,
+		Client:    cr.c,
+	})
+	if err != nil {
+		return nil, err
+	}
+	experiment.Create(ctx)
+	return experiment, nil
+}
+
+type PodDelayCfg struct {
+	Namespace             string
+	Description           string
+	Latency               time.Duration
+	Jitter                time.Duration
+	Correlation           string
+	LabelKey              string
+	LabelValues           []string
+	InjectionDuration     time.Duration
+	ExperimentCreateDelay time.Duration
+}
+
+func (cr *ChaosRunner) RunPodDelay(ctx context.Context, cfg PodDelayCfg) (*Chaos, error) {
+	experiment, err := NewChaos(ChaosOpts{
+		Object: &v1alpha1.NetworkChaos{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       string(v1alpha1.TypeNetworkChaos),
+				APIVersion: "chaos-mesh.org/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("delay-%s", uuid.NewString()[0:5]),
+				Namespace: cfg.Namespace,
+			},
+			Spec: v1alpha1.NetworkChaosSpec{
+				Action:   v1alpha1.DelayAction,
+				Duration: ptr.To[string]((cfg.InjectionDuration).String()),
+				TcParameter: v1alpha1.TcParameter{
+					Delay: &v1alpha1.DelaySpec{
+						Latency:     cfg.Latency.String(),
+						Correlation: cfg.Correlation,
+						Jitter:      cfg.Jitter.String(),
+					},
+				},
+				PodSelector: v1alpha1.PodSelector{
+					Mode: v1alpha1.AllMode,
+					Selector: v1alpha1.PodSelectorSpec{
+						GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+							Namespaces: []string{cfg.Namespace},
+							ExpressionSelectors: v1alpha1.LabelSelectorRequirements{
+								{
+									Operator: "In",
+									Key:      cfg.LabelKey,
+									Values:   cfg.LabelValues,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Listeners: defaultListeners(cr.l),
+		Logger:    &cr.l,
+		Client:    cr.c,
+	})
+	if err != nil {
+		return nil, err
+	}
+	experiment.Create(ctx)
+	return experiment, nil
+}
+
+type PodFailCfg struct {
+	Namespace             string
+	Description           string
+	LabelKey              string
+	LabelValues           []string
+	InjectionDuration     time.Duration
+	ExperimentCreateDelay time.Duration
+}
+
+func (cr *ChaosRunner) RunPodFail(ctx context.Context, cfg PodFailCfg) (*Chaos, error) {
+	experiment, err := NewChaos(ChaosOpts{
+		Description: cfg.Description,
+		DelayCreate: cfg.ExperimentCreateDelay,
+		Object: &v1alpha1.PodChaos{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       string(v1alpha1.TypePodChaos),
+				APIVersion: "chaos-mesh.org/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("fail-%s", uuid.NewString()[0:5]),
+				Namespace: cfg.Namespace,
+			},
+			Spec: v1alpha1.PodChaosSpec{
+				Action:   v1alpha1.PodFailureAction,
+				Duration: ptr.To[string](cfg.InjectionDuration.String()),
+				ContainerSelector: v1alpha1.ContainerSelector{
+					PodSelector: v1alpha1.PodSelector{
+						Mode: v1alpha1.AllMode,
+						Selector: v1alpha1.PodSelectorSpec{
+							GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+								Namespaces: []string{cfg.Namespace},
+								ExpressionSelectors: v1alpha1.LabelSelectorRequirements{
+									{
+										Operator: "In",
+										Key:      cfg.LabelKey,
+										Values:   cfg.LabelValues,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Listeners: defaultListeners(cr.l),
+		Logger:    &cr.l,
+		Client:    cr.c,
+	})
+	if err != nil {
+		return nil, err
+	}
+	experiment.Create(ctx)
+	return experiment, nil
+}
+
+type NodeCPUStressConfig struct {
+	Namespace               string
+	Description             string
+	Cores                   int
+	CoreLoadPercentage      int // 0-100
+	LabelKey                string
+	LabelValues             []string
+	InjectionDuration       time.Duration
+	ExperimentTotalDuration time.Duration
+	ExperimentCreateDelay   time.Duration
+}
+
+func (cr *ChaosRunner) RunPodStressCPU(ctx context.Context, cfg NodeCPUStressConfig) (*Schedule, error) {
+	experiment, err := NewSchedule(ScheduleOpts{
+		Description: cfg.Description,
+		DelayCreate: cfg.ExperimentCreateDelay,
+		Duration:    cfg.ExperimentTotalDuration,
+		Object: &v1alpha1.Schedule{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Schedule",
+				APIVersion: "chaos-mesh.org/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "stress",
+				Namespace: cfg.Namespace,
+			},
+			Spec: v1alpha1.ScheduleSpec{
+				Schedule:          "@every 1m",
+				ConcurrencyPolicy: v1alpha1.ForbidConcurrent,
+				Type:              v1alpha1.ScheduleTypeStressChaos,
+				HistoryLimit:      2,
+				ScheduleItem: v1alpha1.ScheduleItem{
+					EmbedChaos: v1alpha1.EmbedChaos{
+						StressChaos: &v1alpha1.StressChaosSpec{
+							ContainerSelector: v1alpha1.ContainerSelector{
+								PodSelector: v1alpha1.PodSelector{
+									Mode: v1alpha1.AllMode,
+									Selector: v1alpha1.PodSelectorSpec{
+										GenericSelectorSpec: v1alpha1.GenericSelectorSpec{
+											Namespaces: []string{cfg.Namespace},
+											ExpressionSelectors: v1alpha1.LabelSelectorRequirements{
+												{
+													Operator: "In",
+													Key:      cfg.LabelKey,
+													Values:   cfg.LabelValues,
+												},
+											},
+										},
+									},
+								},
+							},
+							Stressors: &v1alpha1.Stressors{
+								CPUStressor: &v1alpha1.CPUStressor{
+									Stressor: v1alpha1.Stressor{
+										Workers: cfg.Cores,
+									},
+									Load: ptr.To[int](cfg.CoreLoadPercentage),
+								},
+							},
+							Duration: ptr.To[string](cfg.InjectionDuration.String()),
+						},
+					},
+				},
+			},
+		},
+		Listeners: defaultListeners(cr.l),
+		Logger:    &cr.l,
+		Client:    cr.c,
+	})
+	if err != nil {
+		return nil, err
+	}
+	experiment.Create(ctx)
+	return experiment, nil
+}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce new functionalities for namespace-scoped chaos testing using Chaos Mesh, making it easier to manage and target chaos experiments at specific namespaces and conditions within a Kubernetes cluster. These changes allow for more precise control over chaos experiments, targeting specific pods and nodes with network partitioning, delays, failures, and CPU stress tests, providing a broad range of testing capabilities for reliability engineering.

## What
- **havoc/.changeset/v1.50.4.md**
  - Added file to document the new version update for the havoc package, specifically detailing the addition of a namespace-scoped chaos runner with main-stage tested experiments.
- **havoc/template.go**
  - Added the `havoc` package and implemented several functions to support chaos testing within Kubernetes namespaces.
    - Implemented `NewNamespaceRunner` to create a chaos runner scoped to a single namespace.
    - Added `RunPodPartition` to create and manage network partition chaos experiments targeting specific pods based on labels.
    - Added `RunPodDelay` to introduce network delay to communications between selected pods.
    - Added `RunPodFail` to simulate pod failures within the specified namespace.
    - Introduced `RunPodStressCPU` to stress test CPUs of selected pods, allowing for the simulation of high CPU load conditions.
  - Each function utilizes a configuration struct to specify target pods, duration, and other parameters, making the chaos experiments highly customizable.
  - Utilized `ChaosListener` for logging chaos events, enhancing observability and debugging capabilities.
  - Integrated with the Chaos Mesh API, leveraging `v1alpha1` API objects like `NetworkChaos`, `PodChaos`, and `Schedule` to configure and execute chaos experiments.
