### PR TITLE
[TT-1992] use publicly available ethereum-genesis-generator image

### DIFF
--- a/.github/workflows/update-internal-mirrors.yaml
+++ b/.github/workflows/update-internal-mirrors.yaml
@@ -52,7 +52,7 @@ jobs:
           # - name: gcr.io/prysmaticlabs/prysm/validator
           #   expression: '^v[0-9]+\.[0-9]+\.[0-9]+$'
           - name: tofelb/ethereum-genesis-generator
-            expression: '^v?[0-9]+\.[0-9]+\.[0-9]+(\-slots\-per\-epoch)?'
+            expression: '.*'
     # This one only has latest tag, probably only want to update it when we know for sure it's a new version we want
     #  - name: protolambda/eth2-val-tools
     #   expression: 'latest'

--- a/lib/docker/ethereum/images.go
+++ b/lib/docker/ethereum/images.go
@@ -25,6 +25,6 @@ const (
 	RethBaseImageName    = "ghcr.io/paradigmxyz/reth"
 	rethGitRepo          = "paradigmxyz/reth"
 
-	GenesisGeneratorDenebImage    = "public.ecr.aws/w0i8p0z9/ethereum-genesis-generator:main-8a8fb99" // latest one
+	GenesisGeneratorDenebImage    = "tofelb/ethereum-genesis-generator:3.3.5-main-8a8fb99" // latest one, copy of public.ecr.aws/w0i8p0z9/ethereum-genesis-generator:main-8a8fb99
 	GenesisGeneratorShanghaiImage = "tofelb/ethereum-genesis-generator:2.0.5"
 )


### PR DESCRIPTION
Why?

CI has no access to our mirror of `public.ecr.aws/w0i8p0z9/ethereum-genesis-generator`