### PR TITLE
Fixes ethereum genesis generator image source

### DIFF
--- a/lib/docker/test_env/genesis_generator.go
+++ b/lib/docker/test_env/genesis_generator.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/docker"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/docker/ethereum"
 	"github.com/smartcontractkit/chainlink-testing-framework/lib/logging"
-	"github.com/smartcontractkit/chainlink-testing-framework/lib/mirror"
 )
 
 var generatorForkToImageMap = map[ethereum.Fork]string{
@@ -73,7 +72,8 @@ func NewEthGenesisGenerator(chainConfig config.EthereumChainConfig, generatedDat
 		opt(&g.EnvComponent)
 	}
 	// if the internal docker repo is set then add it to the version
-	g.EnvComponent.ContainerImage = mirror.AddMirrorToImageIfSet(g.EnvComponent.ContainerImage)
+	// genesis generator uses public ECRs only
+	// g.EnvComponent.ContainerImage = mirror.AddMirrorToImageIfSet(g.EnvComponent.ContainerImage)
 	return g, nil
 }
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the initialization logic of the Ethereum genesis generator by ensuring it only uses public ECRs, streamlining the setup process for Ethereum chain configurations in tests.

## What
- **lib/docker/test_env/genesis_generator.go**
  - Removed the line that applied an internal docker repository mirror to the `ContainerImage` property, commenting it out to clarify that genesis generator uses public ECRs only. This change ensures the image setup process is more straightforward and reliant on publicly available resources.
