### PR TITLE
Seth more gas conservative tip

### DIFF
--- a/seth/.changeset/v1.51.1.md
+++ b/seth/.changeset/v1.51.1.md
@@ -1,0 +1,1 @@
+- Use more conservative gas tip estimation, i.e. call `FeeHistory` endpoint with tip percentile corresponding to given priory and then select median value

--- a/seth/gas_adjuster.go
+++ b/seth/gas_adjuster.go
@@ -504,28 +504,18 @@ func classifyCongestion(congestionMetric float64) string {
 }
 
 func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historicalGasTipCap float64, err error) {
-	estimator := NewGasEstimator(m)
-	stats, err := estimator.Stats(m.Cfg.Network.GasPriceEstimationBlocks, 99)
-	if err != nil {
-		L.Debug().
-			Msgf("Failed to get fee history due to: %s", err.Error())
+	var percentileTip float64
 
-		return
-	}
-
+	// based on priority decide, which tip percentile to use, when calling FeeHistory
 	switch priority {
 	case Priority_Degen:
-		baseFee = stats.GasPrice.Max
-		historicalGasTipCap = stats.TipCap.Max
+		percentileTip = 100
 	case Priority_Fast:
-		baseFee = stats.GasPrice.Perc99
-		historicalGasTipCap = stats.TipCap.Perc99
+		percentileTip = 99
 	case Priority_Standard:
-		baseFee = stats.GasPrice.Perc50
-		historicalGasTipCap = stats.TipCap.Perc50
+		percentileTip = 50
 	case Priority_Slow:
-		baseFee = stats.GasPrice.Perc25
-		historicalGasTipCap = stats.TipCap.Perc25
+		percentileTip = 25
 	default:
 		err = fmt.Errorf("unknown priority: %s", priority)
 		L.Debug().
@@ -533,8 +523,46 @@ func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historical
 			Msgf("Unknown priority: %s", err.Error())
 
 		return
-
 	}
+
+	// TODO remove me
+	// percentileTip = 99
+
+	estimator := NewGasEstimator(m)
+	stats, err := estimator.Stats(m.Cfg.Network.GasPriceEstimationBlocks, percentileTip)
+	if err != nil {
+		L.Debug().
+			Msgf("Failed to get fee history due to: %s", err.Error())
+
+		return
+	}
+
+	// base fee should still be based on priority, because FeeHistory returns whole history, not just the requested percentile
+	// for the base fee (as opposed to tip cap)
+	switch priority {
+	case Priority_Degen:
+		baseFee = stats.GasPrice.Max
+		// historicalGasTipCap = stats.TipCap.Max
+	case Priority_Fast:
+		baseFee = stats.GasPrice.Perc99
+		// historicalGasTipCap = stats.TipCap.Perc99
+	case Priority_Standard:
+		baseFee = stats.GasPrice.Perc50
+		// historicalGasTipCap = stats.TipCap.Perc50
+	case Priority_Slow:
+		baseFee = stats.GasPrice.Perc25
+		// historicalGasTipCap = stats.TipCap.Perc25
+	default:
+		err = fmt.Errorf("unknown priority: %s", priority)
+		L.Debug().
+			Str("Priority", priority).
+			Msgf("Unknown priority: %s", err.Error())
+
+		return
+	}
+
+	// since we have already requested reward percentiles based on priority, let's now use the median, i.e. most common tip
+	historicalGasTipCap = stats.TipCap.Perc50
 
 	return
 }

--- a/seth/gas_adjuster.go
+++ b/seth/gas_adjuster.go
@@ -506,7 +506,7 @@ func classifyCongestion(congestionMetric float64) string {
 func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historicalGasTipCap float64, err error) {
 	var percentileTip float64
 
-	// based on priority decide, which tip percentile to use, when calling FeeHistory
+	// based on priority decide, which percentile to use to get historical tip values, when calling FeeHistory
 	switch priority {
 	case Priority_Degen:
 		percentileTip = 100
@@ -525,9 +525,6 @@ func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historical
 		return
 	}
 
-	// TODO remove me
-	// percentileTip = 99
-
 	estimator := NewGasEstimator(m)
 	stats, err := estimator.Stats(m.Cfg.Network.GasPriceEstimationBlocks, percentileTip)
 	if err != nil {
@@ -537,21 +534,16 @@ func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historical
 		return
 	}
 
-	// base fee should still be based on priority, because FeeHistory returns whole history, not just the requested percentile
-	// for the base fee (as opposed to tip cap)
+	// base fee should still be based on priority, because FeeHistory returns whole base fee history, not just the requested percentile
 	switch priority {
 	case Priority_Degen:
 		baseFee = stats.GasPrice.Max
-		// historicalGasTipCap = stats.TipCap.Max
 	case Priority_Fast:
 		baseFee = stats.GasPrice.Perc99
-		// historicalGasTipCap = stats.TipCap.Perc99
 	case Priority_Standard:
 		baseFee = stats.GasPrice.Perc50
-		// historicalGasTipCap = stats.TipCap.Perc50
 	case Priority_Slow:
 		baseFee = stats.GasPrice.Perc25
-		// historicalGasTipCap = stats.TipCap.Perc25
 	default:
 		err = fmt.Errorf("unknown priority: %s", priority)
 		L.Debug().

--- a/seth/gas_test.go
+++ b/seth/gas_test.go
@@ -13,7 +13,7 @@ func TestGasEstimator(t *testing.T) {
 	c := newClient(t)
 	bn, err := c.Client.BlockNumber(context.Background())
 	require.NoError(t, err, "BlockNumber should not error")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		_, err := c.DeployContractFromContractStore(c.NewTXOpts(), "NetworkDebugSubContract")
 		require.NoError(t, err, "Deploying contract should not error")
 	}
@@ -35,4 +35,10 @@ func TestGasEstimator(t *testing.T) {
 	require.GreaterOrEqual(t, suggestions.TipCap.Perc75, suggestions.TipCap.Perc50, "Suggested 75th percentile tip cap should be greater than or equal to 50th percentile")
 	require.GreaterOrEqual(t, suggestions.TipCap.Perc99, suggestions.TipCap.Perc75, "Suggested 99th percentile tip cap should be greater than or equal to 75th percentile")
 	require.GreaterOrEqual(t, suggestions.TipCap.Max, suggestions.TipCap.Perc99, "Suggested max tip cap should be greater than or equal to 99th percentile")
+}
+
+func TestGasEstimations(t *testing.T) {
+	c := newClient(t)
+	txOpts := c.NewTXOpts()
+	_ = txOpts
 }

--- a/seth/gas_test.go
+++ b/seth/gas_test.go
@@ -36,9 +36,3 @@ func TestGasEstimator(t *testing.T) {
 	require.GreaterOrEqual(t, suggestions.TipCap.Perc99, suggestions.TipCap.Perc75, "Suggested 99th percentile tip cap should be greater than or equal to 75th percentile")
 	require.GreaterOrEqual(t, suggestions.TipCap.Max, suggestions.TipCap.Perc99, "Suggested max tip cap should be greater than or equal to 99th percentile")
 }
-
-func TestGasEstimations(t *testing.T) {
-	c := newClient(t)
-	txOpts := c.NewTXOpts()
-	_ = txOpts
-}

--- a/seth/seth.toml
+++ b/seth/seth.toml
@@ -49,7 +49,7 @@ root_key_funds_buffer = 10 # 10 ether
 
 # feature-flagged expriments; first one sets funds return priority to 'slow' (core only!), second one
 # sets the tip/base fee to the higher value in case there's 3+ orders of magnitude difference between them
-experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]
+# experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]
 
 # when enabled when creating a new Seth client we will send 10k wei from root address to root address
 # to make sure transaction can be submitted and mined
@@ -80,6 +80,32 @@ key_sync_retries = 10
 
 [block_stats]
 rpc_requests_per_second_limit = 15
+
+[[networks]]
+name = "Ethereum_Mainnet"
+dial_timeout = "1m"
+transaction_timeout = "30s"
+eip_1559_dynamic_fees = true
+
+# automated gas estimation
+gas_price_estimation_enabled = true
+gas_price_estimation_blocks = 20
+gas_price_estimation_tx_priority = "standard"
+# how many times to try fetching & calculating gas price data in case of errors, defaults to 1 if empty
+gas_price_estimation_attempt_count = 2
+# urls_secret = ["xxx"]
+
+# gas limits
+transfer_gas_fee = 21_000
+# gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
+# gas_limit = 14_000_000
+
+# manual settings, used when gas_price_estimation_enabled is false or when it fails
+# legacy transactions
+gas_price = 1_000_000_000
+# EIP-1559 transactions
+gas_fee_cap = 25_000_000_000
+gas_tip_cap = 5_000_000_000
 
 [[networks]]
 name = "Anvil"


### PR DESCRIPTION
This pull request includes several changes to improve the gas estimation process and configuration in the `seth` package. The most important changes include updating the gas tip estimation logic, modifying the test cases, and adding new network configurations.

Improvements to gas estimation:

* Updated the gas tip estimation logic to use a percentile-based approach based on priority and select the median value for historical gas tip caps. (`seth/gas_adjuster.go`)
* Added a more conservative gas tip estimation by calling the `FeeHistory` endpoint with the tip percentile corresponding to the given priority and selecting the median value. (`seth/.changeset/v1.51.1.md`)

Configuration changes:

* Commented out the experiments related to slow funds return and EIP-1559 fee equalizer. (`seth/seth.toml`)
* Added new network configurations for `Ethereum_Mainnet` including automated gas estimation settings and manual gas price settings. (`seth/seth.toml`)
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a more nuanced approach to gas tip estimation based on transaction priority and expand network configuration options. By adjusting the percentile of gas tip estimation according to priority, the system aims to provide more accurate and potentially cost-effective gas price suggestions. Additionally, updating the test loop and tweaking configuration settings further align the system's functionality with its operational environment and intended use cases.

## What
- **seth/.changeset/v1.51.1.md**
  - Added a note about using more conservative gas tip estimation by calling `FeeHistory` with a tip percentile corresponding to given priority and selecting the median value.
- **seth/gas_adjuster.go**
  - Introduced a switch-case to select the percentileTip based on transaction priority for the `FeeHistory` endpoint.
  - Changed the stats fetching to use the newly defined `percentileTip` instead of a hard-coded value.
  - Adjusted the assignment of `historicalGasTipCap` to always use the median value (`Perc50`), aiming for a more balanced approach across different transaction priorities.
- **seth/gas_test.go**
  - Replaced a for loop with a `range` over an integer, simplifying the test setup for deploying contracts and estimating gas.
- **seth/seth.toml**
  - Commented out `experiments_enabled` configuration, potentially to toggle experimental features more easily.
  - Added a new network configuration for "Ethereum_Mainnet" with detailed settings including automated gas estimation, gas limits, and manual gas price settings for both legacy and EIP-1559 transactions.
