### PR TITLE
Fixes Bullet Point for Guide

### DIFF
--- a/tools/flakeguard/e2e-flaky-test-guide.md
+++ b/tools/flakeguard/e2e-flaky-test-guide.md
@@ -106,7 +106,7 @@ It is sometimes the case that tests only fail in CI environments because those e
 
 * Splitting the tests into different workflows, each running on `ubuntu-latest`
 * Moving more resource-hungry tests to run only on nightly cadences
-* 
+* Try removing `t.Parallel()` from subtests, as too many tests trying to run at once will often hurt stability and runtimes on smaller machines
 
 ### 7. Fix It!
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The change provides a concrete suggestion for improving test stability and runtimes in CI environments, particularly on smaller machines. It advises against using `t.Parallel()` in subtests to prevent issues arising from too many tests running simultaneously.

## What
- **tools/flakeguard/e2e-flaky-test-guide.md**
  - Added a suggestion to remove `t.Parallel()` from subtests to enhance test stability and efficiency on smaller machines. This is aimed at addressing situations where tests only fail in CI due to limited resources.
