### PR TITLE
Utilize Static Binary for Parrot

### DIFF
--- a/parrot/.changeset/v0.6.2.md
+++ b/parrot/.changeset/v0.6.2.md
@@ -1,0 +1,1 @@
+- Statically linked binary

--- a/parrot/.goreleaser.yaml
+++ b/parrot/.goreleaser.yaml
@@ -30,9 +30,8 @@ builds:
       - amd64
       - arm64
     binary: parrot
-
-archives:
-  - formats: ['binary']
+    env:
+      - CGO_ENABLED=0
 
 dockers:
   - id: linux-amd64-parrot


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the Parrot binary is statically linked, enhancing its portability and reducing runtime dependencies. This update is crucial for ensuring that the binary can run in a wide range of environments without requiring specific shared libraries.

## What
- **parrot/.changeset/v0.6.2.md**
  - Added a new changeset file, marking the introduction of a statically linked binary. This indicates a new version release.
- **parrot/.goreleaser.yaml**
  - Removed the `archives` configuration that specifies the binary format, simplifying the release process.
  - Added `CGO_ENABLED=0` to the environment variables, ensuring that the Go compiler generates a statically linked binary. This change is key to making the binary more portable and self-contained.
