### PR TITLE
Sui starter

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Vulnerability Check
+        uses: smartcontractkit/.github/actions/dependency-review@0cc355785130a83a540187b609c5521094baed92 # dependency-review@1.0.0
+        with:
+          config-preset: default-vulnerability-check-high

--- a/framework/.changeset/v0.6.1.md
+++ b/framework/.changeset/v0.6.1.md
@@ -1,0 +1,1 @@
+- Allow nil blockchains output in Sui case

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -125,9 +125,11 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 
 		eg.Go(func() error {
 			var net string
-			net, err := clnode.NewNetworkCfgOneNetworkAllNodes(bcOut)
-			if err != nil {
-				return err
+			if bcOut != nil {
+				net, err = clnode.NewNetworkCfgOneNetworkAllNodes(bcOut)
+				if err != nil {
+					return err
+				}
 			}
 			if in.NodeSpecs[overrideIdx].Node.TestConfigOverrides != "" {
 				net = in.NodeSpecs[overrideIdx].Node.TestConfigOverrides

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -125,6 +125,7 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 
 		eg.Go(func() error {
 			var net string
+			var err error
 			if bcOut != nil {
 				net, err = clnode.NewNetworkCfgOneNetworkAllNodes(bcOut)
 				if err != nil {

--- a/framework/examples/myproject/smoke_sui.toml
+++ b/framework/examples/myproject/smoke_sui.toml
@@ -1,3 +1,40 @@
+
 [blockchain_a]
-  type = "sui"
   image = "mysten/sui-tools:mainnet"
+  type = "sui"
+
+[data_provider]
+  port = 9111
+
+[nodeset]
+  name = "don"
+  nodes = 5
+  override_mode = "each"
+
+  [nodeset.db]
+    image = "postgres:12.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+
+  [[nodeset.node_specs]]
+
+    [nodeset.node_specs.node]
+      image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/smoke_sui_test.go
+++ b/framework/examples/myproject/smoke_sui_test.go
@@ -11,11 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/clclient"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake"
+	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
 )
 
 type CfgSui struct {
-	BlockchainA *blockchain.Input `toml:"blockchain_a" validate:"required"`
+	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
+	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
+	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
 }
 
 func TestSuiSmoke(t *testing.T) {
@@ -34,12 +39,22 @@ func TestSuiSmoke(t *testing.T) {
 	_, err = framework.ExecContainer(bc.ContainerName, []string{"ls", "-lah"})
 	require.NoError(t, err)
 
-	t.Run("test something", func(t *testing.T) {
-		// use internal URL to connect Chainlink nodes
-		_ = bc.Nodes[0].DockerInternalHTTPUrl
-		// use host URL to interact
-		_ = bc.Nodes[0].HostHTTPUrl
+	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
+	require.NoError(t, err)
 
+	fmt.Printf("Sui host HTTP URL: %s", bc.Nodes[0].HostHTTPUrl)
+	fmt.Printf("Sui internal (docker) HTTP URL: %s", bc.Nodes[0].DockerInternalHTTPUrl)
+	for _, n := range in.NodeSet.NodeSpecs {
+		// configure each CL node for Sui, just an example
+		n.Node.TestConfigOverrides = `
+											[Log]
+											level = 'info'
+`
+	}
+	out, err := ns.NewSharedDBNodeSet(in.NodeSet, nil)
+	require.NoError(t, err)
+
+	t.Run("test something", func(t *testing.T) {
 		cli := sui.NewSuiClient(bc.Nodes[0].HostHTTPUrl)
 
 		signerAccount, err := signer.NewSignertWithMnemonic(bc.NetworkSpecificData.SuiAccount.Mnemonic)
@@ -49,5 +64,14 @@ func TestSuiSmoke(t *testing.T) {
 		})
 		require.NoError(t, err)
 		fmt.Printf("My funds: %v\n", rsp)
+		clClients, err := clclient.New(out.CLNodes)
+		require.NoError(t, err)
+		// create jobs, etc
+		for _, c := range clClients {
+			_ = c
+			// create jobs
+			//_, _, err := c.CreateJobRaw(`...`)
+			//require.NoError(t, err)
+		}
 	})
 }

--- a/infra/chaosmesh-playground/devbox.lock
+++ b/infra/chaosmesh-playground/devbox.lock
@@ -1,6 +1,9 @@
 {
   "lockfile_version": "1",
   "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?lastModified=1741865919&narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D"
+    },
     "k9s@0.32.7": {
       "last_modified": "2025-01-19T08:16:51Z",
       "resolved": "github:NixOS/nixpkgs/50165c4f7eb48ce82bd063e1fb8047a0f515f8ce#k9s",


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new GitHub workflow for dependency review, update node set configurations for better chaos testing and environment alignment, expand a test configuration for a blockchain project, and update the devbox lock with new package versions. These updates are aimed at improving security, testing capabilities, and ensuring compatibility with current software versions.

## What
- **.github/workflows/dependency-review.yml**
  - Added a new file to define a GitHub Actions workflow for dependency review. This includes steps to check out the code and run a vulnerability check using a predefined configuration.

- **framework/components/simple_node_set/node_set.go**
  - Modified to conditionally set network configuration if `bcOut` is not nil, enhancing compatibility with different testing scenarios.

- **framework/examples/myproject/smoke_sui.toml**
  - Added configurations for a data provider and a node set with specific node specifications, including database and Chainlink node images, to facilitate more comprehensive testing environments.

- **framework/examples/myproject/smoke_sui_test.go**
  - Expanded to include setup for a mock data provider and a shared database for node sets, alongside adjustments to test configurations for Chainlink nodes to include logging levels. This allows for more extensive testing scenarios involving Chainlink nodes and blockchain interactions.

- **infra/chaosmesh-playground/devbox.lock**
  - Updated package versions and added a new package entry for NixOS/nixpkgs, ensuring the development environment is up-to-date and includes the latest software improvements and security patches.
