### PR TITLE
Use only Geth in eth-clients tests

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,5 +1,6 @@
 name: (all packages) Docker Test Env tests
 on:
+
   pull_request_review:
     types: [submitted]
   pull_request:
@@ -44,7 +45,7 @@ jobs:
           set -euo pipefail
           # disabled, because we want to use a multiline output of go list command
           # shellcheck disable=SC2046
-          go test -timeout 20m -json -parallel 2 -cover -covermode=atomic -coverprofile=unit-test-coverage.out $(go list ./... | grep /docker/test_env) -run '${{ matrix.test.tests }}' 2>&1 | tee /tmp/gotest.log | ../gotestloghelper -ci
+          go test -v -timeout 20m -json -parallel 2 -cover -covermode=atomic -coverprofile=unit-test-coverage.out $(go list ./... | grep /docker/test_env) -run '${{ matrix.test.tests }}' 2>&1 | tee /tmp/gotest.log | ../gotestloghelper -ci
       - name: Publish Artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,8 +19,9 @@ jobs:
           - name: eth_env
             tests: TestEthEnv
           # ticket: DX-194
-#          - name: eth_clients
+          - name: eth_clients
 #            tests: TestBesu|TestGeth|TestNethermind|TestErigon
+            tests: TestGeth
           - name: other
             tests: TestPostgres|TestMockServer|TestKillgrave
     steps:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -18,8 +18,9 @@ jobs:
         test:
           - name: eth_env
             tests: TestEthEnv
-          - name: eth_clients
-            tests: TestBesu|TestGeth|TestNethermind|TestErigon
+          # ticket: DX-194
+#          - name: eth_clients
+#            tests: TestBesu|TestGeth|TestNethermind|TestErigon
           - name: other
             tests: TestPostgres|TestMockServer|TestKillgrave
     steps:


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes remove the `eth_clients` test matrix option temporarily, indicated by commenting it out, to possibly address an issue or perform maintenance without disrupting the entire testing workflow.

## What
- **.github/workflows/docker-test.yml**
  - Temporarily commented out the `eth_clients` matrix option. This omission will skip tests for Ethereum client implementations like Besu, Geth, Nethermind, and Erigon during the Docker test workflow. The tests for `eth_env` and `other` categories remain unaffected.
