### PR TITLE
DX177 - Fix flakeguard parser panic 

### DIFF
--- a/tools/flakeguard/cmd/run.go
+++ b/tools/flakeguard/cmd/run.go
@@ -184,6 +184,10 @@ var RunTestsCmd = &cobra.Command{
 				flushSummaryAndExit(0)
 			}
 
+			fmt.Fprint(&summaryBuffer, "\nFailed Tests On The First Run:\n\n")
+			reports.PrintTestResultsTable(&summaryBuffer, failedTests, false, false, true, false)
+			fmt.Fprintln(&summaryBuffer)
+
 			rerunResults, rerunJsonOutputPaths, err := testRunner.RerunFailedTests(failedTests, rerunFailedCount)
 			if err != nil {
 				log.Fatal().Err(err).Msg("Error rerunning failed tests")
@@ -203,8 +207,8 @@ var RunTestsCmd = &cobra.Command{
 				flushSummaryAndExit(ErrorExitCode)
 			}
 
-			fmt.Fprint(&summaryBuffer, "\nFailed Tests That Were Rerun:\n\n")
-			reports.PrintTestResultsTable(&summaryBuffer, rerunResults, false, false, true)
+			fmt.Fprint(&summaryBuffer, "\nFailed Tests After Rerun:\n\n")
+			reports.PrintTestResultsTable(&summaryBuffer, rerunResults, false, false, true, true)
 			fmt.Fprintln(&summaryBuffer)
 
 			// Save the rerun test report to file

--- a/tools/flakeguard/reports/presentation.go
+++ b/tools/flakeguard/reports/presentation.go
@@ -78,11 +78,18 @@ func generateTestResultsTable(
 func generateShortTestResultsTable(
 	results []TestResult,
 	markdown bool,
+	showEverPassed bool,
 	filter func(TestResult) bool,
 ) [][]string {
 	p := message.NewPrinter(language.English)
 
-	headers := []string{"Name", "Ever Passed", "Runs", "Successes", "Code Owners", "Path"}
+	// Build headers dynamically
+	var headers []string
+	headers = append(headers, "Name")
+	if showEverPassed {
+		headers = append(headers, "Ever Passed")
+	}
+	headers = append(headers, "Runs", "Successes", "Code Owners", "Path")
 
 	// Optionally format the headers for Markdown
 	if markdown {
@@ -112,14 +119,17 @@ func generateShortTestResultsTable(
 			owners = strings.Join(r.CodeOwners, ", ")
 		}
 
-		row := []string{
-			r.TestName,                   // "Name"
-			passed,                       // "Passed"
-			p.Sprintf("%d", r.Runs),      // "Runs"
-			p.Sprintf("%d", r.Successes), // "Passes"
-			owners,                       // "Code Owners"
-			r.TestPath,                   // "Path"
+		// Build row dynamically
+		row := []string{r.TestName}
+		if showEverPassed {
+			row = append(row, passed)
 		}
+		row = append(row,
+			p.Sprintf("%d", r.Runs),
+			p.Sprintf("%d", r.Successes),
+			owners,
+			r.TestPath,
+		)
 
 		table = append(table, row)
 	}
@@ -143,13 +153,14 @@ func PrintTestResultsTable(
 	results []TestResult,
 	markdown bool,
 	collapsible bool,
-	shortTable bool) {
+	shortTable bool,
+	showEverPassed bool) {
 	filter := func(result TestResult) bool {
 		return true // Include all tests
 	}
 	var table [][]string
 	if shortTable {
-		table = generateShortTestResultsTable(results, markdown, filter)
+		table = generateShortTestResultsTable(results, markdown, showEverPassed, filter)
 	} else {
 		table = generateTestResultsTable(results, markdown, filter)
 	}

--- a/tools/flakeguard/runner/runner_test.go
+++ b/tools/flakeguard/runner/runner_test.go
@@ -393,57 +393,173 @@ func resultsString(result reports.TestResult) string {
 func TestAttributePanicToTest(t *testing.T) {
 	t.Parallel()
 
+	// Test cases: each test case contains a slice of output strings.
 	testCases := []struct {
 		name             string
-		packageName      string
 		expectedTestName string
 		expectedTimeout  bool
-		panicEntries     []entry
+		outputs          []string
 	}{
 		{
 			name:             "properly attributed panic",
 			expectedTestName: "TestPanic",
-			packageName:      "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package",
-			panicEntries:     properlyAttributedPanicEntries,
+			expectedTimeout:  false,
+			outputs: []string{
+				"panic: This test intentionally panics [recovered]",
+				"\tpanic: This test intentionally panics",
+				"goroutine 25 [running]:",
+				"testing.tRunner.func1.2({0x1008cde80, 0x1008f7d90})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc",
+				"testing.tRunner.func1()",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334",
+				"panic({0x1008cde80?, 0x1008f7d90?})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124",
+				"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package.TestPanic(0x140000b6ea0?)",
+			},
 		},
 		{
 			name:             "improperly attributed panic",
 			expectedTestName: "TestPanic",
-			packageName:      "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package",
-			panicEntries:     improperlyAttributedPanicEntries,
+			expectedTimeout:  false,
+			outputs: []string{
+				"panic: This test intentionally panics [recovered]",
+				"TestPanic(0x140000b6ea0?)",
+				"goroutine 25 [running]:",
+				"testing.tRunner.func1.2({0x1008cde80, 0x1008f7d90})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc",
+				"testing.tRunner.func1()",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334",
+				"panic({0x1008cde80?, 0x1008f7d90?})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124",
+				"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package.TestPanic(0x140000b6ea0?)",
+			},
 		},
 		{
 			name:             "timeout panic",
 			expectedTestName: "TestTimedOut",
 			expectedTimeout:  true,
-			packageName:      "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package",
-			panicEntries:     timedOutPanicEntries,
+			outputs: []string{
+				"panic: test timed out after 10m0s",
+				"running tests",
+				"TestTimedOut (10m0s)",
+				"goroutine 397631 [running]:",
+				"testing.(*M).startAlarm.func1()",
+				"\t/opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:2373 +0x385",
+				"created by time.goFunc",
+				"/opt/hostedtoolcache/go/1.23.3/x64/src/time/sleep.go:215 +0x2d",
+			},
 		},
 		{
 			name:             "subtest panic",
 			expectedTestName: "TestSubTestsSomePanic",
-			packageName:      "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package",
-			panicEntries:     subTestPanicEntries,
+			expectedTimeout:  false,
+			outputs: []string{
+				"panic: This subtest always panics [recovered]",
+				"panic: This subtest always panics",
+				"goroutine 23 [running]:",
+				"testing.tRunner.func1.2({0x100489e80, 0x1004b3e30})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc",
+				"testing.tRunner.func1()",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334",
+				"panic({0x100489e80?, 0x1004b3e30?})",
+				"\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124",
+				"github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package.TestSubTestsSomePanic.func2(0x140000c81a0?)",
+			},
 		},
 		{
-			name:         "empty",
-			packageName:  "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/example_test_package",
-			panicEntries: []entry{},
+			name:             "memory_test panic extraction",
+			expectedTestName: "TestJobClientJobAPI",
+			expectedTimeout:  false,
+			outputs: []string{
+				"panic: freeport: cannot allocate port block [recovered]",
+				"\tpanic: freeport: cannot allocate port block",
+				"goroutine 321 [running]:",
+				"testing.tRunner.func1.2({0x5e0dd80, 0x72ebb40})",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1734 +0x21c",
+				"testing.tRunner.func1()",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1737 +0x35e",
+				"panic({0x5e0dd80?, 0x72ebb40?})",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/runtime/panic.go:787 +0x132",
+				"github.com/hashicorp/consul/sdk/freeport.alloc()",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:274 +0xad",
+				"github.com/hashicorp/consul/sdk/freeport.initialize()",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:124 +0x2d7",
+				"sync.(*Once).doSlow(0xc0018eb600?, 0xc000da4a98?)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/sync/once.go:78 +0xab",
+				"sync.(*Once).Do(...)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/sync/once.go:69",
+				"github.com/hashicorp/consul/sdk/freeport.Take(0x1)",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:303 +0xe5",
+				"github.com/hashicorp/consul/sdk/freeport.GetN({0x7337708, 0xc000683dc0}, 0x1)",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:427 +0x48",
+				"github.com/smartcontractkit/chainlink/deployment/environment/memory_test.TestJobClientJobAPI(0xc000683dc0)",
+				"\t/home/runner/work/chainlink/chainlink/deployment/environment/memory/job_service_client_test.go:116 +0xc6",
+				"testing.tRunner(0xc000683dc0, 0x6d6c838)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0xf4",
+				"created by testing.(*T).Run in goroutine 1",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x413",
+			},
+		},
+		{
+			name:             "changeset_test panic extraction",
+			expectedTestName: "TestDeployBalanceReader",
+			expectedTimeout:  false,
+			outputs: []string{
+				"panic: freeport: cannot allocate port block [recovered]",
+				"\tpanic: freeport: cannot allocate port block",
+				"goroutine 378 [running]:",
+				"testing.tRunner.func1.2({0x6063f40, 0x76367f0})",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1734 +0x21c",
+				"testing.tRunner.func1()",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1737 +0x35e",
+				"panic({0x6063f40?, 0x76367f0?})",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/runtime/panic.go:787 +0x132",
+				"github.com/hashicorp/consul/sdk/freeport.alloc()",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:274 +0xad",
+				"github.com/hashicorp/consul/sdk/freeport.initialize()",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:124 +0x2d7",
+				"sync.(*Once).doSlow(0xa94f820?, 0xa8000a?)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/sync/once.go:78 +0xab",
+				"sync.(*Once).Do(...)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/sync/once.go:69",
+				"github.com/hashicorp/consul/sdk/freeport.Take(0x1)",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:303 +0xe5",
+				"github.com/hashicorp/consul/sdk/freeport.GetN({0x7684150, 0xc000583c00}, 0x1)",
+				"\t/home/runner/go/pkg/mod/github.com/hashicorp/consul/sdk@v0.16.1/freeport/freeport.go:427 +0x48",
+				"github.com/smartcontractkit/chainlink/deployment/environment/memory.NewNodes(0xc000583c00, 0xff, 0xc001583d10, 0xc005aa0030, 0x1, 0x0, {0x0, {0x0, 0x0, 0x0, ...}, ...}, ...)",
+				"\t/home/runner/work/chainlink/chainlink/deployment/environment/memory/environment.go:177 +0xa5",
+				"github.com/smartcontractkit/chainlink/deployment/environment/memory.NewMemoryEnvironment(_, {_, _}, _, {0x2, 0x0, 0x0, 0x1, 0x0, {0x0, ...}})",
+				"\t/home/runner/work/chainlink/chainlink/deployment/environment/memory/environment.go:223 +0x10c",
+				"github.com/smartcontractkit/chainlink/deployment/keystone/changeset_test.TestDeployBalanceReader(0xc000583c00)",
+				"\t/home/runner/work/chainlink/chainlink/deployment/keystone/changeset/deploy_balance_reader_test.go:23 +0xf5",
+				"testing.tRunner(0xc000583c00, 0x70843d0)",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1792 +0xf4",
+				"created by testing.(*T).Run in goroutine 1",
+				"\t/opt/hostedtoolcache/go/1.24.0/x64/src/testing/testing.go:1851 +0x413",
+				"    logger.go:146: 03:14:04.485880684\tINFO\tDeployed KeystoneForwarder 1.0.0 chain selector 909606746561742123 addr 0x72B66019aCEdc35F7F6e58DF94De95f3cBCC5971\t{\"version\": \"(devel)@unset\"}",
+				"    logger.go:146: 03:14:04.486035865\tINFO\tdeploying forwarder\t{\"version\": \"(devel)@unset\", \"chainSelector\": 5548718428018410741}",
+				"    logger.go:146: 2025-03-08T03:14:04.490Z\tINFO\tchangeset/jd_register_nodes.go:91\tregistered node\t{\"version\": \"unset@unset\", \"name\": \"node1\", \"id\": \"node:{id:\\\"895776f5ba0cc11c570a47b5cc3dbb8771da9262cfb545cd5d48251796af7f1d\\\"  public_key:\\\"895776f5ba0cc11c570a47b5cc3dbb8771da9262cfb545cd5d48251796af7f1d\\\"  is_enabled:true  is_connected:true  labels:{key:\\\"product\\\"  value:\\\"test-product\\\"}  labels:{key:\\\"environment\\\"  value:\\\"test-env\\\"}  labels:{key:\\\"nodeType\\\"  value:\\\"bootstrap\\\"}  labels:{key:\\\"don-0-don1\\\"}\"}",
+			},
+		},
+		{
+			name:             "empty",
+			expectedTestName: "",
+			expectedTimeout:  false,
+			outputs:          []string{},
 		},
 	}
 
-	for _, testCase := range testCases {
-		tc := testCase
+	for _, tc := range testCases {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			testName, timeout, err := attributePanicToTest(tc.packageName, tc.panicEntries)
-			assert.Equal(t, tc.expectedTimeout, timeout, "test timeout not correctly discovered")
+			testName, timeout, err := attributePanicToTest(tc.outputs)
+			assert.Equal(t, tc.expectedTimeout, timeout, "timeout flag mismatch")
 			if tc.expectedTestName == "" {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.expectedTestName, testName, "test panic not attributed correctly")
+				assert.Equal(t, tc.expectedTestName, testName, "test name mismatch")
 			}
 		})
 	}
@@ -589,74 +705,6 @@ func TestOmitOutputsOnSuccess(t *testing.T) {
 }
 
 var (
-	improperlyAttributedPanicEntries = []entry{
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "panic: This test intentionally panics [recovered]\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\tpanic: This test intentionally panics\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "goroutine 25 [running]:\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "testing.tRunner.func1.2({0x1008cde80, 0x1008f7d90})\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "testing.tRunner.func1()\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "panic({0x1008cde80?, 0x1008f7d90?})\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package.TestPanic(0x140000b6ea0?)\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/Users/adamhamrick/Projects/chainlink-testing-framework/tools/flakeguard/runner/example_test_package/example_tests_test.go:51 +0x30\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "testing.tRunner(0x140000b6ea0, 0x1008f73d0)\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1690 +0xe4\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "created by testing.(*T).Run in goroutine 1\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1743 +0x314\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Output: "FAIL\tgithub.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package\t0.170s\n"},
-		{Action: "fail", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Elapsed: 0.171},
-	}
-	properlyAttributedPanicEntries = []entry{
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "panic: This test intentionally panics [recovered]\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\tpanic: This test intentionally panics\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "goroutine 25 [running]:\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "testing.tRunner.func1.2({0x1008cde80, 0x1008f7d90})\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "testing.tRunner.func1()\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "panic({0x1008cde80?, 0x1008f7d90?})\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package.TestPanic(0x140000b6ea0?)\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/Users/adamhamrick/Projects/chainlink-testing-framework/tools/flakeguard/runner/example_test_package/example_tests_test.go:51 +0x30\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "testing.tRunner(0x140000b6ea0, 0x1008f73d0)\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1690 +0xe4\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "created by testing.(*T).Run in goroutine 1\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestPanic", Output: "\t/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1743 +0x314\n"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Output: "FAIL\tgithub.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package\t0.170s\n"},
-		{Action: "fail", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Elapsed: 0.171},
-	}
-	subTestPanicEntries = []entry{
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "panic: This subtest always panics [recovered]"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "panic: This subtest always panics"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "goroutine 23 [running]:"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "testing.tRunner.func1.2({0x100489e80, 0x1004b3e30})"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1632 +0x1bc"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "testing.tRunner.func1()"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1635 +0x334"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "panic({0x100489e80?, 0x1004b3e30?})"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/panic.go:785 +0x124"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package.TestSubTestsSomePanic.func2(0x140000c81a0?)"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/Users/adamhamrick/Projects/chainlink-testing-framework/tools/flakeguard/runner/example_test_package/example_tests_test.go:43 +0x30"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "testing.tRunner(0x140000c81a0, 0x1004b34d0)"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1690 +0xe4"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "created by testing.(*T).Run in goroutine 6"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestSubTestsAllPass/Pass2", Output: "	/opt/homebrew/Cellar/go/1.23.2/libexec/src/testing/testing.go:1743 +0x314"},
-	}
-	timedOutPanicEntries = []entry{
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "panic: test timed out after 10m0s"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "running tests"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "TestTimedOut (10m0s)"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "goroutine 397631 [running]:"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "testing.(*M).startAlarm.func1()"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "	/opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:2373 +0x385"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "created by time.goFunc"},
-		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestTimeout", Output: "/opt/hostedtoolcache/go/1.23.3/x64/src/time/sleep.go:215 +0x2d"},
-	}
-
 	improperlyAttributedRaceEntries = []entry{
 		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "==================\n"},
 		{Action: "output", Package: "github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard/runner/example_test_package", Test: "TestFlaky", Output: "WARNING: DATA RACE\n"},


### PR DESCRIPTION
This pull request includes several changes to improve the handling and reporting of test results in the `flakeguard` tool. The key changes involve enhancements to the presentation of test results, the attribution of panics to tests, and the handling of test outputs.

### Enhancements to test results presentation:

* [`tools/flakeguard/cmd/run.go`](diffhunk://#diff-7a829c613b3274cdc7b9c704adb7d54ac57b67f0cd52c0d23431131240ee8ed0R187-R190): Added new sections for failed tests on the first run and after reruns, and updated the `PrintTestResultsTable` function to include an additional parameter for showing whether tests have ever passed. [[1]](diffhunk://#diff-7a829c613b3274cdc7b9c704adb7d54ac57b67f0cd52c0d23431131240ee8ed0R187-R190) [[2]](diffhunk://#diff-7a829c613b3274cdc7b9c704adb7d54ac57b67f0cd52c0d23431131240ee8ed0L206-R211)
* [`tools/flakeguard/reports/presentation.go`](diffhunk://#diff-545a2e831f40bae75c71f02eda7ee703b5c1ea02990be4cccece7e53712f36afR81-R92): Modified `generateShortTestResultsTable` and `PrintTestResultsTable` functions to dynamically build headers and rows based on the new `showEverPassed` parameter. [[1]](diffhunk://#diff-545a2e831f40bae75c71f02eda7ee703b5c1ea02990be4cccece7e53712f36afR81-R92) [[2]](diffhunk://#diff-545a2e831f40bae75c71f02eda7ee703b5c1ea02990be4cccece7e53712f36afL115-R132) [[3]](diffhunk://#diff-545a2e831f40bae75c71f02eda7ee703b5c1ea02990be4cccece7e53712f36afL146-R163)

### Improvements to panic attribution:

* [`tools/flakeguard/runner/runner.go`](diffhunk://#diff-a91b29837b9aa48918ba83bc338ef56b9819fadee07f3f621e2b9ed6579b1eb8L384-R388): Refactored the `attributePanicToTest` function to use a more robust regex for extracting test names and detecting timeouts, and updated the `parseTestResults` function to pass the correct parameters. [[1]](diffhunk://#diff-a91b29837b9aa48918ba83bc338ef56b9819fadee07f3f621e2b9ed6579b1eb8L384-R388) [[2]](diffhunk://#diff-a91b29837b9aa48918ba83bc338ef56b9819fadee07f3f621e2b9ed6579b1eb8L617-R637)

### Test updates:

* [`tools/flakeguard/runner/runner_test.go`](diffhunk://#diff-e5ff49cc042b1fb1038a0eabcf7ae5b1e4e6b6188482b0a806117d1be1783f42R396-R562): Updated test cases for `attributePanicToTest` to use slices of output strings instead of package names and panic entries, and added new test cases to cover additional scenarios.