### PR TITLE
Add otel-collector, connect to Loki, Tempo, Prometheus to receive Beholder metrics

### DIFF
--- a/framework/.changeset/v0.6.3.md
+++ b/framework/.changeset/v0.6.3.md
@@ -1,0 +1,1 @@
+- Add `otel-collector` and connect it with `Loki` and `Tempo`

--- a/framework/.changeset/v0.6.3.md
+++ b/framework/.changeset/v0.6.3.md
@@ -1,1 +1,3 @@
-- Add `otel-collector` and connect it with `Loki` and `Tempo`
+- Add otel-collector and connect it with Loki, Tempo and Prometheus
+- Tune Tempo, verify we can store traces for hours
+- Add basic tests to debug metrics, logs and traces endpoints

--- a/framework/cmd/observability/compose/conf/prometheus.yml
+++ b/framework/cmd/observability/compose/conf/prometheus.yml
@@ -2,6 +2,10 @@ global:
   scrape_interval: 10s
 
 scrape_configs:
+  - job_name: 'otel-collector'
+    scrape_interval: 10s
+    static_configs:
+      - targets: [ 'otel-collector:8889' ]
   - job_name: 'ctf'
     metrics_path: /metrics
     docker_sd_configs:

--- a/framework/cmd/observability/compose/conf/provisioning/datasources/loki.yaml
+++ b/framework/cmd/observability/compose/conf/provisioning/datasources/loki.yaml
@@ -1,6 +1,11 @@
 apiVersion: 1
 
 datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
   - name: Loki
     type: loki
     isDefault: true

--- a/framework/cmd/observability/compose/docker-compose.yaml
+++ b/framework/cmd/observability/compose/docker-compose.yaml
@@ -1,4 +1,29 @@
 services:
+  tempo:
+    image: grafana/tempo:2.3.1
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./tempo.yaml:/etc/tempo.yaml
+      - tempo_data:/tmp/tempo
+    ports:
+      - "3200:3200"   # tempo
+#      - "5317:4317"   # otlp grpc
+#      - "5318:4318"   # otlp http
+      - "9411:9411"   # zipkin
+      - "14268:14268" # jaeger ingest
+      - "14250:14250" # jaeger grpc
+      - "55680:55680" # otlp http legacy
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    volumes:
+      - ./otel.yaml:/etc/otel/config.yaml
+    command:
+      - '--config=/etc/otel/config.yaml'
+    ports:
+      - "4317:4317" #grpc
+      - "4318:4318" #http
+    depends_on:
+      - loki
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.51.0
     container_name: cadvisor
@@ -23,7 +48,7 @@ services:
       - '9099:9090'
 
   loki:
-    image: grafana/loki:2.5.0
+    image: grafana/loki:3.4.1
     volumes:
       - ./loki-config.yaml:/etc/loki/mounted-config.yaml
       - ./conf/provisioning/rules/rules.yml:/etc/loki/rules/fake/rules.yml
@@ -47,6 +72,10 @@ services:
       - ./conf/provisioning/dashboards/cadvisor/cadvisor.json:/var/lib/grafana/dashboards/cadvisor/cadvisor.json
     ports:
       - '3000:3000'
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
 
   pyroscope:
     image: 'pyroscope/pyroscope:latest'
@@ -106,3 +135,4 @@ volumes:
   grafana_home:
   grafana_logs:
   grafana_plugins:
+  tempo_data:

--- a/framework/cmd/observability/compose/docker-compose.yaml
+++ b/framework/cmd/observability/compose/docker-compose.yaml
@@ -20,8 +20,9 @@ services:
     command:
       - '--config=/etc/otel/config.yaml'
     ports:
-      - "4317:4317" #grpc
-      - "4318:4318" #http
+      - "4317:4317" # grpc
+      - "4318:4318" # http
+      - "8889:8889"  # Prometheus scrape target
     depends_on:
       - loki
   cadvisor:

--- a/framework/cmd/observability/compose/loki-config.yaml
+++ b/framework/cmd/observability/compose/loki-config.yaml
@@ -1,47 +1,40 @@
+
+# This is a complete configuration to deploy Loki backed by the filesystem.
+# The index will be shipped to the storage via tsdb-shipper.
+
 auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
 
 server:
   http_listen_port: 3100
-  grpc_listen_port: 9096
 
-limits_config:
-  unordered_writes: true
-
-ingester:
-  max_chunk_age: 1000h
 common:
-  path_prefix: /tmp/loki
-  storage:
-    filesystem:
-      chunks_directory: /tmp/loki/chunks
-      rules_directory: /tmp/loki/rules
-  replication_factor: 1
   ring:
-    instance_addr: 127.0.0.1
+    instance_addr: 0.0.0.0
     kvstore:
       store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
 
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
+    - from: 2020-05-15
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
 
-ruler:
-  alertmanager_url: http://localhost:9093
-# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
-# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
-#
-# Statistics help us better understand how Loki is used, and they show us performance
-# levels for most users. This helps us prioritize features and documentation.
-# For more information on what's sent, look at
-# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
-# Refer to the buildReport method to see what goes into a report.
-#
-# If you would like to disable reporting, uncomment the following lines:
-analytics:
-  reporting_enabled: false
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true

--- a/framework/cmd/observability/compose/otel.yaml
+++ b/framework/cmd/observability/compose/otel.yaml
@@ -22,13 +22,20 @@ exporters:
     endpoint: "http://tempo:4317"
     tls:
       insecure: true
+  prometheus:
+    endpoint: "0.0.0.0:8889"
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
+      processors: [batch]
       exporters: [debug, otlp]
     logs:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug, otlphttp/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, prometheus]

--- a/framework/cmd/observability/compose/otel.yaml
+++ b/framework/cmd/observability/compose/otel.yaml
@@ -1,0 +1,34 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
+  otlphttp/logs:
+    endpoint: "http://loki:3100/otlp"
+    tls:
+      insecure: true
+  otlp:
+    endpoint: "http://tempo:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug, otlp]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, otlphttp/logs]

--- a/framework/cmd/observability/compose/tempo.yaml
+++ b/framework/cmd/observability/compose/tempo.yaml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal

--- a/framework/cmd/observability/compose/tempo.yaml
+++ b/framework/cmd/observability/compose/tempo.yaml
@@ -8,6 +8,9 @@ distributor:
         grpc:
         http:
 
+overrides:
+  max_traces_per_user: 50000
+
 storage:
   trace:
     backend: local
@@ -15,3 +18,8 @@ storage:
       path: /tmp/tempo/blocks
     wal:
       path: /tmp/tempo/wal
+
+compactor:
+  compaction:
+    max_block_bytes: 1073741824   # 1GB max block size
+    max_compaction_objects: 1000000

--- a/framework/cmd/otel_test.go
+++ b/framework/cmd/otel_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSendLogsToOTELCollector(t *testing.T) {
+	t.Skip("run manually to debug otel-collector")
+	res, err := resource.New(context.Background(),
+		resource.WithAttributes(
+			semconv.ServiceName("test-logging-service"),
+			semconv.ServiceVersion("1.0.0"),
+		),
+	)
+	if err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+	logs := generateLogRecords(res)
+	jsonData, _ := json.MarshalIndent(logs, "", "  ")
+	t.Logf("Sending logs payload:\n%s\n", string(jsonData))
+	err = sendLogsToCollector(logs)
+	if err != nil {
+		t.Fatalf("failed to send logs: %v", err)
+	}
+	t.Log("Logs sent successfully!")
+}
+
+func TestSendTracesToOTELCollector(t *testing.T) {
+	t.Skip("run manually to debug otel-collector")
+	res, err := resource.New(context.Background(),
+		resource.WithAttributes(
+			semconv.ServiceName("test-tracing-service"),
+			semconv.ServiceVersion("1.0.0"),
+			attribute.String("environment", "test"),
+		),
+	)
+	if err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+	traceData := generateTraceData(res)
+	jsonData, _ := json.MarshalIndent(traceData, "", "  ")
+	t.Logf("Sending traces payload:\n%s\n", string(jsonData))
+	err = sendTracesToCollector(traceData)
+	if err != nil {
+		t.Fatalf("failed to send traces: %v", err)
+	}
+	t.Log("Traces sent successfully to OTEL Collector!")
+}
+
+func generateLogRecords(res *resource.Resource) map[string]interface{} {
+	now := time.Now()
+	nanos := now.UnixNano()
+
+	return map[string]interface{}{
+		"resourceLogs": []interface{}{
+			map[string]interface{}{
+				"resource": map[string]interface{}{
+					"attributes": resourceToAttributes(res),
+				},
+				"scopeLogs": []interface{}{
+					map[string]interface{}{
+						"scope": map[string]interface{}{
+							"name":    "test-logger",
+							"version": "1.0",
+						},
+						"logRecords": []interface{}{
+							map[string]interface{}{
+								"timeUnixNano":         nanos,
+								"severityText":         "INFO",
+								"severityNumber":       9,
+								"body":                 map[string]interface{}{"stringValue": "Test log message"},
+								"attributes":           []interface{}{},
+								"observedTimeUnixNano": nanos,
+							},
+							map[string]interface{}{
+								"timeUnixNano":   nanos + 1,
+								"severityText":   "ERROR",
+								"severityNumber": 17,
+								"body":           map[string]interface{}{"stringValue": "Test error occurred"},
+								"attributes": []interface{}{
+									map[string]interface{}{
+										"key":   "error.code",
+										"value": map[string]interface{}{"stringValue": "500"},
+									},
+								},
+								"observedTimeUnixNano": nanos + 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateTraceData(res *resource.Resource) map[string]interface{} {
+	now := time.Now()
+	traceID := generateRandomHex(32)      // 16 bytes hex encoded
+	spanID := generateRandomHex(16)       // 8 bytes hex encoded
+	parentSpanID := generateRandomHex(16) // 8 bytes hex encoded
+
+	return map[string]interface{}{
+		"resourceSpans": []interface{}{
+			map[string]interface{}{
+				"resource": map[string]interface{}{
+					"attributes": resourceToAttributes(res),
+				},
+				"scopeSpans": []interface{}{
+					map[string]interface{}{
+						"scope": map[string]interface{}{
+							"name":    "test-tracer",
+							"version": "1.0",
+						},
+						"spans": []interface{}{
+							// Parent span
+							map[string]interface{}{
+								"traceId":           traceID,
+								"spanId":            parentSpanID,
+								"parentSpanId":      "",
+								"name":              "test-parent-operation",
+								"kind":              trace.SpanKindInternal,
+								"startTimeUnixNano": now.UnixNano(),
+								"endTimeUnixNano":   now.Add(100 * time.Millisecond).UnixNano(),
+								"attributes": []interface{}{
+									map[string]interface{}{
+										"key":   "http.method",
+										"value": map[string]interface{}{"stringValue": "GET"},
+									},
+									map[string]interface{}{
+										"key":   "http.route",
+										"value": map[string]interface{}{"stringValue": "/api/test"},
+									},
+								},
+								"status": map[string]interface{}{
+									"code": 0, // Unset
+								},
+								"traceState": "",
+							},
+							// Child span
+							map[string]interface{}{
+								"traceId":           traceID,
+								"spanId":            spanID,
+								"parentSpanId":      parentSpanID,
+								"name":              "test-child-operation",
+								"kind":              trace.SpanKindServer,
+								"startTimeUnixNano": now.Add(10 * time.Millisecond).UnixNano(),
+								"endTimeUnixNano":   now.Add(80 * time.Millisecond).UnixNano(),
+								"attributes": []interface{}{
+									map[string]interface{}{
+										"key":   "db.system",
+										"value": map[string]interface{}{"stringValue": "postgres"},
+									},
+									map[string]interface{}{
+										"key":   "db.operation",
+										"value": map[string]interface{}{"stringValue": "SELECT"},
+									},
+								},
+								"status": map[string]interface{}{
+									"code": 0,
+								},
+								"traceState": "",
+								"events": []interface{}{
+									map[string]interface{}{
+										"timeUnixNano": now.Add(20 * time.Millisecond).UnixNano(),
+										"name":         "test-cache-hit",
+										"attributes": []interface{}{
+											map[string]interface{}{
+												"key":   "cache.key",
+												"value": map[string]interface{}{"stringValue": "user:test123"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceToAttributes(res *resource.Resource) []interface{} {
+	attrs := []interface{}{}
+	for _, kv := range res.Attributes() {
+		attrs = append(attrs, map[string]interface{}{
+			"key":   string(kv.Key),
+			"value": map[string]interface{}{"stringValue": kv.Value.AsString()},
+		})
+	}
+	return attrs
+}
+
+func sendLogsToCollector(logs map[string]interface{}) error {
+	jsonData, err := json.Marshal(logs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal logs: %w", err)
+	}
+	req, err := http.NewRequest("POST", "http://localhost:4318/v1/logs", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func sendTracesToCollector(traces map[string]interface{}) error {
+	jsonData, err := json.Marshal(traces)
+	if err != nil {
+		return fmt.Errorf("failed to marshal traces: %w", err)
+	}
+	req, err := http.NewRequest("POST", "http://localhost:4318/v1/traces", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func generateRandomHex(length int) string {
+	bytes := make([]byte, length/2) // 2 chars per byte
+	if _, err := rand.Read(bytes); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(bytes)
+}

--- a/framework/components/blockchain/anvil_zksync.go
+++ b/framework/components/blockchain/anvil_zksync.go
@@ -51,7 +51,7 @@ func newAnvilZksync(in *Input) (*Output, error) {
 	}
 
 	defer func() {
-		// delete the folder wether it was successful or not
+		// delete the folder whether it was successful or not
 		_ = os.RemoveAll(tempDir)
 	}()
 

--- a/framework/examples/myproject/go.mod
+++ b/framework/examples/myproject/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/blocto/solana-go-sdk v1.30.0
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/go-resty/resty/v2 v2.16.3
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.5.8
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.6.3
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -29,6 +29,9 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/urfave/cli/v2 v2.27.5
+	go.opentelemetry.io/otel v1.24.0
+	go.opentelemetry.io/otel/sdk v1.24.0
+	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/ratelimit v0.3.1
 	golang.org/x/oauth2 v0.11.0
 	golang.org/x/sync v0.10.0
@@ -150,11 +153,8 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
-	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	golang.org/x/arch v0.11.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the observability and monitoring capabilities within the framework by integrating OpenTelemetry Collector (otel-collector) with existing monitoring tools like Loki, Tempo, and Prometheus. This integration aims to provide a unified approach to observing metrics, logs, and traces, improving the debugging and monitoring experience. Additionally, the updates include basic tests for metrics, logs, and traces endpoints to ensure reliability and functionality of the observability setup.

## What
- **framework/.changeset/v0.6.3.md**
  - Added otel-collector and connected it with Loki, Tempo, and Prometheus. Added basic tests for debugging metrics, logs, and traces endpoints.
- **framework/cmd/observability/compose/conf/prometheus.yml**
  - Added a new job for scraping metrics from otel-collector.
- **framework/cmd/observability/compose/conf/provisioning/datasources/loki.yaml**
  - Included Tempo as a new datasource in the Grafana provisioning configuration.
- **framework/cmd/observability/compose/docker-compose.yaml**
  - Introduced services for Tempo and otel-collector with their respective configurations and dependencies. Updated Loki image version to 3.4.1 and added dependency management for grafana service.
- **framework/cmd/observability/compose/loki-config.yaml**
  - Updated Loki configuration for better performance and compliance with newer version specifications.
- **framework/cmd/observability/compose/otel.yaml**
  - Created a new OpenTelemetry Collector configuration file to define receivers, processors, and exporters for metrics, logs, and traces.
- **framework/cmd/observability/compose/tempo.yaml**
  - Introduced a new configuration file for Tempo to specify its server, distributor, overrides, storage, and compactor settings.
- **framework/cmd/otel_test.go**
  - Added basic tests to verify the functionality of metrics, logs, and traces endpoints with the OpenTelemetry Collector.
- **framework/components/blockchain/anvil_zksync.go**
  - Corrected a typo in a comment.
- **framework/examples/myproject/go.mod**
  - Updated the version of the chainlink-testing-framework to v0.6.3 to incorporate the latest changes.
- **framework/go.mod**
  - Added dependencies for OpenTelemetry (`go.opentelemetry.io/otel`, `go.opentelemetry.io/otel/sdk`, `go.opentelemetry.io/otel/trace`) to support the integration with otel-collector.
