### PR TITLE
ignore ryuk reaper for promtail

### DIFF
--- a/framework/.changeset/v0.6.7.md
+++ b/framework/.changeset/v0.6.7.md
@@ -1,0 +1,1 @@
+- Ignore TESTCONTAINERS_RYUK_DISABLED for promtail container

--- a/framework/examples/myproject/go.mod
+++ b/framework/examples/myproject/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/blocto/solana-go-sdk v1.30.0
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/go-resty/resty/v2 v2.16.3
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.6.5
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.6.6
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/framework/promtail.go
+++ b/framework/promtail.go
@@ -109,6 +109,9 @@ scrape_configs:
 }
 
 func NewPromtail() error {
+	// since this container is dynamic we write it in Go, but it is a part of observability stack
+	// hence, we never remove it with TESTCONTAINERS_RYUK_DISABLED but only with "ctf obs d"
+	_ = os.Setenv("TESTCONTAINERS_RYUK_DISABLED", "true")
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure the Promtail container, part of the observability stack, does not get removed when `TESTCONTAINERS_RYUK_DISABLED` is set, aligning with the intent to have more control over the observability components. Additionally, the update in the Go module for the Chainlink testing framework from `v0.6.5` to `v0.6.6` suggests improvements or fixes in the testing framework are being incorporated into the project.

## What
- **framework/.changeset/v0.6.7.md**
  - Added a note about ignoring `TESTCONTAINERS_RYUK_DISABLED` for the promtail container.
- **framework/examples/myproject/go.mod**
  - Updated dependency `github.com/smartcontractkit/chainlink-testing-framework/framework` from `v0.6.5` to `v0.6.6`.
- **framework/promtail.go**
  - Set `TESTCONTAINERS_RYUK_DISABLED` to `true` within `NewPromtail()` function to ensure the Promtail container is not removed inadvertently. This change emphasizes the container's role in observability and its need to persist irrespective of the `TESTCONTAINERS_RYUK_DISABLED` setting.
