### PR TITLE
use nodesets everywhere

### DIFF
--- a/book/src/framework/components/chainlink/nodeset.md
+++ b/book/src/framework/components/chainlink/nodeset.md
@@ -41,7 +41,7 @@ This component requires some Blockchain to be deployed, add this to config
 
 Then configure NodeSet
 ```toml
-[nodeset]
+[[nodesets]]
   # unique NodeSet name
   name = "don"
   # amount of Chainlink nodes to spin up
@@ -55,7 +55,7 @@ Then configure NodeSet
   # P2P API port range start, each new node get port incremented (host machine)
   p2p_port_range_start = 12000
   
-  [nodeset.db]
+  [nodesets.db]
     # PostgreSQL image version and tag
     image = "postgres:12.0"
     # Pulls the image every time if set to 'true', used like that in CI. Can be set to 'false' to speed up local runs
@@ -63,9 +63,9 @@ Then configure NodeSet
     # PostgreSQL volume name
     volume_name = ""
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       # custom ports that plugins may need to expose and map to the host machine
       custom_ports = [14000, 14001]
       # A list of paths to capability binaries
@@ -96,16 +96,16 @@ Then configure NodeSet
       """
 
   # Outputs are the results of deploying a component that can be used by another component
-  [nodeset.out]
+  [nodesets.out]
     # If 'use_cache' equals 'true' we skip component setup when we run the test and return the outputs
     use_cache = true
     
     # Describes deployed or external Chainlink nodes
-    [[nodeset.out.cl_nodes]]
+    [[nodesets.out.cl_nodes]]
       use_cache = true
 
       # Describes deployed or external Chainlink node
-      [nodeset.out.cl_nodes.node]
+      [nodesets.out.cl_nodes.node]
         # API user name
         api_auth_user = 'notreal@fakeemail.ch'
         # API password
@@ -115,15 +115,15 @@ Then configure NodeSet
         p2p_url = "http://127.0.0.1:32996"
         url = "http://127.0.0.1:33096"
       # Describes PostgreSQL instance
-      [nodeset.out.cl_nodes.postgresql]
+      [nodesets.out.cl_nodes.postgresql]
         # PostgreSQL connection string
         # in case of using external database can be overriden
         url = "postgresql://chainlink:thispasswordislongenough@127.0.0.1:33094/chainlink?sslmode=disable"
     
     # Can have more than one node, fields are the same, see above ^^
-    [[nodeset.out.cl_nodes]]
-      [nodeset.out.cl_nodes.node]
-      [nodeset.out.cl_nodes.postgresql]
+    [[nodesets.out.cl_nodes]]
+      [nodesets.out.cl_nodes.node]
+      [nodesets.out.cl_nodes.postgresql]
     ...
 ```
 
@@ -141,7 +141,7 @@ import (
 
 type Config struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input         `toml:"nodesets" validate:"required"`
 }
 
 func TestMe(t *testing.T) {

--- a/book/src/framework/components/external.md
+++ b/book/src/framework/components/external.md
@@ -20,18 +20,18 @@ For example, to integrate with remote `k8s` environment you can use `CTF_CONFIGS
       http_url = "http://127.0.0.1:8545"
       ws_url = "ws://127.0.0.1:8545"
 
-[nodeset]
+[[nodesets]]
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
   ...
 
-  [nodeset.out]
+  [nodesets.out]
     use_cache = true
 
-    [[nodeset.out.cl_nodes]]
+    [[nodesets.out.cl_nodes]]
       use_cache = true
 
-      [nodeset.out.cl_nodes.node]
+      [nodesets.out.cl_nodes.node]
         # set up your user/password for API authorization
         api_auth_user = 'notreal@fakeemail.ch'
         api_auth_password = 'fj293fbBnlQ!f9vNs'
@@ -39,7 +39,7 @@ For example, to integrate with remote `k8s` environment you can use `CTF_CONFIGS
         p2p_url = "http://127.0.0.1:12000"
         url = "http://127.0.0.1:10000"
 
-      [nodeset.out.cl_nodes.postgresql]
+      [nodesets.out.cl_nodes.postgresql]
         # set up a database URL so tests can connect to your database if needed
         url = "postgresql://chainlink:thispasswordislongenough@127.0.0.1:13000/db_0?sslmode=disable"
       

--- a/book/src/framework/components/state.md
+++ b/book/src/framework/components/state.md
@@ -12,7 +12,7 @@ Defaults are:
 - [NodeSet](../components/chainlink/nodeset.md) (Delve debugger): `40000..400XX` (if you are using debug image)
 - Shared `PostgreSQL` volume is called `postgresql_data`
 ```
-[nodeset]
+[[nodesets]]
   # HTTP API port range start, each new node get port incremented (host machine)
   http_port_range_start = 10000
   # P2P API port range start, each new node get port incremented (host machine)
@@ -20,7 +20,7 @@ Defaults are:
 ```
 - [PostgreSQL](../components/chainlink/nodeset.md): `13000` (we do not allow to have multiple databases for now, for simplicity)
 ```
-    [nodeset.node_specs.db]
+    [nodesets.node_specs.db]
       # PostgreSQL volume name
       volume_name = "a"
       # PostgreSQL port (host machine)
@@ -34,7 +34,7 @@ When you run `ctf d rm` database volume will be **removed**.
 
 One node set is enough for any kind of testing, if you need more nodes consider extending your existing node set:
 ```
-[nodeset]
+[[nodesets]]
   nodes = 10
 ```
 </div>
@@ -43,17 +43,17 @@ One node set is enough for any kind of testing, if you need more nodes consider 
 
 You can also define a custom set of ports for any node.
 ```toml
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "each"
   
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       # here we defined 2 new ports to listen and mapped them to our host machine
       # syntax is "host:docker"
       custom_ports = ["14000:15000"]

--- a/book/src/framework/nodeset_capabilities.md
+++ b/book/src/framework/nodeset_capabilities.md
@@ -20,17 +20,17 @@ Create a configuration file `smoke.toml`
   type = "anvil"
   docker_cmd_params = ["-b", "1"]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
   
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       # path to your capability binaries
       capabilities = ["./kvstore"]
       # default capabilities directory

--- a/book/src/framework/nodeset_compatibility.md
+++ b/book/src/framework/nodeset_compatibility.md
@@ -8,45 +8,45 @@ Create a configuration file `smoke.toml`
   type = "anvil"
   docker_cmd_params = ["-b", "1"]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "each"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       user_config_overrides = "      [Log]\n      level = 'info'\n      "
       user_secrets_overrides = ""
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       user_config_overrides = "      [Log]\n      level = 'info'\n      "
       user_secrets_overrides = ""
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       user_config_overrides = "      [Log]\n      level = 'info'\n      "
       user_secrets_overrides = ""
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       user_config_overrides = "      [Log]\n      level = 'info'\n      "
       user_secrets_overrides = ""
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       user_config_overrides = "      [Log]\n      level = 'info'\n      "
       user_secrets_overrides = ""

--- a/book/src/framework/nodeset_docker_rebuild.md
+++ b/book/src/framework/nodeset_docker_rebuild.md
@@ -8,17 +8,17 @@ Create a configuration file `smoke.toml`
   type = "anvil"
   docker_cmd_params = ["-b", "1"]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
   
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       # Dockerfile path is relative to "docker_ctx"
       docker_file = "core/chainlink.Dockerfile"
       docker_ctx = "../.."

--- a/book/src/framework/nodeset_environment.md
+++ b/book/src/framework/nodeset_environment.md
@@ -8,17 +8,17 @@ Create a configuration file `smoke.toml`
   type = "anvil"
   docker_cmd_params = ["-b", "1"]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
   
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 ```
 

--- a/framework/.changeset/v0.7.3.md
+++ b/framework/.changeset/v0.7.3.md
@@ -1,0 +1,1 @@
+- Use nodesets slice everywhere to ease multi-DON configuration

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -111,13 +111,9 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 	eg := &errgroup.Group{}
 	mu := &sync.Mutex{}
 	for i := 0; i < in.Nodes; i++ {
-		var overrideIdx int
+		overrideIdx := i
 		var nodeName string
-		switch in.OverrideMode {
-		case "each":
-			overrideIdx = i
-		case "all":
-			overrideIdx = 0
+		if in.OverrideMode == "all" {
 			if len(in.NodeSpecs[overrideIdx].Node.CustomPorts) > 0 {
 				return nil, fmt.Errorf("custom_ports can be used only with override_mode = 'each'")
 			}

--- a/framework/components/simple_node_set/nodeset_test.go
+++ b/framework/components/simple_node_set/nodeset_test.go
@@ -39,34 +39,7 @@ func checkBasicOutputs(t *testing.T, output *ns.Output) {
 
 func TestSmokeComponentDockerNodeSetSharedDB(t *testing.T) {
 	testCases := []testCase{
-		{
-			name: "2 nodes cluster, override mode 'all'",
-			bcInput: &blockchain.Input{
-				Type:    "anvil",
-				Image:   "f4hrenh9it/foundry",
-				Port:    "8545",
-				ChainID: "31337",
-			},
-			nodeSetInput: &ns.Input{
-				Name:         "don-1",
-				Nodes:        2,
-				OverrideMode: "all",
-				DbInput: &postgres.Input{
-					Image: "postgres:12.0",
-				},
-				NodeSpecs: []*clnode.Input{
-					{
-						Node: &clnode.NodeInput{
-							Image: "public.ecr.aws/chainlink/chainlink:v2.17.0",
-							Name:  "cl-node",
-						},
-					},
-				},
-			},
-			assertion: func(t *testing.T, output *ns.Output) {
-				checkBasicOutputs(t, output)
-			},
-		},
+		// only 'each' mode is available when using as code to simplify configuration
 		{
 			name: "2 nodes cluster, override mode 'each'",
 			bcInput: &blockchain.Input{

--- a/framework/config.go
+++ b/framework/config.go
@@ -167,11 +167,11 @@ func transformAllOverrideModeForNodeSets(data []byte) ([]byte, error) {
 		}
 		nodes, ok := nodeset["nodes"].(int64)
 		if !ok || nodes <= 0 {
-			return nil, fmt.Errorf("invalid nodes count")
+			return nil, fmt.Errorf("nodesets.nodes must be provided")
 		}
 		specs, ok := nodeset["node_specs"].([]interface{})
 		if !ok || len(specs) == 0 {
-			return nil, fmt.Errorf("node_specs must be provided")
+			return nil, fmt.Errorf("nodesets.node_specs must be provided")
 		}
 		firstSpec := specs[0].(map[string]interface{})
 		expanded := make([]interface{}, nodes)

--- a/framework/config.go
+++ b/framework/config.go
@@ -88,7 +88,7 @@ func mergeInputs[T any]() (*T, error) {
 			fmt.Println(string(data))
 		}
 
-		data, err = transformAllOverrideModeForNodeSet(data)
+		data, err = transformAllOverrideModeForNodeSets(data)
 		if err != nil {
 			return nil, fmt.Errorf("error transforming node specs: %w", err)
 		}
@@ -146,38 +146,44 @@ func validate(s interface{}) error {
 	return nil
 }
 
-// transformAllOverrideModeForNodeSet we need this function so the test logic can be the same in both "each" and "all" override modes
+// transformAllOverrideModeForNodeSets we need this function so the test logic can be the same in both "each" and "all" override modes
 // we can't do UnmarshalTOML or UnmarshalText because our TOML library do not support it
-func transformAllOverrideModeForNodeSet(data []byte) ([]byte, error) {
+func transformAllOverrideModeForNodeSets(data []byte) ([]byte, error) {
 	var config map[string]interface{}
 	if err := toml.Unmarshal(data, &config); err != nil {
 		return nil, err
 	}
-	nodeset, ok := config["nodeset"].(map[string]interface{})
+	nodesets, ok := config["nodesets"].([]interface{})
 	if !ok {
 		return data, nil
 	}
-	if nodeset["override_mode"] != "all" {
-		return data, nil
-	}
-	nodes, ok := nodeset["nodes"].(int64)
-	if !ok || nodes <= 0 {
-		return nil, fmt.Errorf("invalid nodes count")
-	}
-	specs, ok := nodeset["node_specs"].([]interface{})
-	if !ok || len(specs) == 0 {
-		return nil, fmt.Errorf("node_specs must be provided")
-	}
-	firstSpec := specs[0].(map[string]interface{})
-	expanded := make([]interface{}, nodes)
-	for i := range expanded {
-		newSpec := make(map[string]interface{})
-		for k, v := range firstSpec {
-			newSpec[k] = v
+	for _, nodesetInterface := range nodesets {
+		nodeset, ok := nodesetInterface.(map[string]interface{})
+		if !ok {
+			continue
 		}
-		expanded[i] = newSpec
+		if nodeset["override_mode"] != "all" {
+			continue
+		}
+		nodes, ok := nodeset["nodes"].(int64)
+		if !ok || nodes <= 0 {
+			return nil, fmt.Errorf("invalid nodes count")
+		}
+		specs, ok := nodeset["node_specs"].([]interface{})
+		if !ok || len(specs) == 0 {
+			return nil, fmt.Errorf("node_specs must be provided")
+		}
+		firstSpec := specs[0].(map[string]interface{})
+		expanded := make([]interface{}, nodes)
+		for i := range expanded {
+			newSpec := make(map[string]interface{})
+			for k, v := range firstSpec {
+				newSpec[k] = v
+			}
+			expanded[i] = newSpec
+		}
+		nodeset["node_specs"] = expanded
 	}
-	nodeset["node_specs"] = expanded
 	return toml.Marshal(config)
 }
 

--- a/framework/examples/myproject/chaos/chaos.toml
+++ b/framework/examples/myproject/chaos/chaos.toml
@@ -6,15 +6,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/chaos/chaos_blockchain_evm_gas_test.go
+++ b/framework/examples/myproject/chaos/chaos_blockchain_evm_gas_test.go
@@ -18,7 +18,7 @@ import (
 type CfgGas struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestBlockchainGasChaos(t *testing.T) {
@@ -31,7 +31,7 @@ func TestBlockchainGasChaos(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	c, err := clclient.New(out.CLNodes)

--- a/framework/examples/myproject/chaos/chaos_blockchain_evm_reorg_test.go
+++ b/framework/examples/myproject/chaos/chaos_blockchain_evm_reorg_test.go
@@ -19,7 +19,7 @@ type CfgReorgTwoChains struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	BlockchainB        *blockchain.Input `toml:"blockchain_b" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestBlockchainReorgChaos(t *testing.T) {
@@ -56,9 +56,9 @@ func TestBlockchainReorgChaos(t *testing.T) {
 		},
 	}, bcB)
 	// override the configuration to connect with 2 networks
-	in.NodeSet.NodeSpecs[0].Node.TestConfigOverrides = srcNetworkCfg + dstNetworkConfig
+	in.NodeSets[0].NodeSpecs[0].Node.TestConfigOverrides = srcNetworkCfg + dstNetworkConfig
 	// create a node set
-	nodesOut, err := ns.NewSharedDBNodeSet(in.NodeSet, bcA)
+	nodesOut, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bcA)
 	require.NoError(t, err)
 
 	c, err := clclient.New(nodesOut.CLNodes)

--- a/framework/examples/myproject/chaos/chaos_docker_test.go
+++ b/framework/examples/myproject/chaos/chaos_docker_test.go
@@ -17,7 +17,7 @@ import (
 type CfgChaos struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestChaos(t *testing.T) {
@@ -28,7 +28,7 @@ func TestChaos(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	c, err := clclient.New(out.CLNodes)

--- a/framework/examples/myproject/chaos/chaos_gas.toml
+++ b/framework/examples/myproject/chaos/chaos_gas.toml
@@ -6,15 +6,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/chaos/chaos_reorg.toml
+++ b/framework/examples/myproject/chaos/chaos_reorg.toml
@@ -12,15 +12,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/fake.toml
+++ b/framework/examples/myproject/fake.toml
@@ -5,15 +5,15 @@
 [fake]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/fork_plus_offchain.toml
+++ b/framework/examples/myproject/fork_plus_offchain.toml
@@ -17,15 +17,15 @@
 
 [contracts_src]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/go.mod
+++ b/framework/examples/myproject/go.mod
@@ -11,9 +11,10 @@ replace (
 require (
 	github.com/block-vision/sui-go-sdk v1.0.6
 	github.com/blocto/solana-go-sdk v1.30.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/go-resty/resty/v2 v2.16.3
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.1
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.2
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2
@@ -83,7 +84,6 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/framework/examples/myproject/performance_baseline.toml
+++ b/framework/examples/myproject/performance_baseline.toml
@@ -5,15 +5,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/performance_baseline_test.go
+++ b/framework/examples/myproject/performance_baseline_test.go
@@ -19,7 +19,7 @@ import (
 type CfgLoad struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestPerformanceBaseline(t *testing.T) {
@@ -30,7 +30,7 @@ func TestPerformanceBaseline(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	var lokiCfg *wasp.LokiConfig

--- a/framework/examples/myproject/quick-deploy.toml
+++ b/framework/examples/myproject/quick-deploy.toml
@@ -4,15 +4,15 @@
 
 [contracts_src]
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:15.6"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/scalability.toml
+++ b/framework/examples/myproject/scalability.toml
@@ -6,15 +6,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/scalability_test.go
+++ b/framework/examples/myproject/scalability_test.go
@@ -19,7 +19,7 @@ import (
 type CfgScalability struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestScalability(t *testing.T) {
@@ -31,7 +31,7 @@ func TestScalability(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	var lokiCfg *wasp.LokiConfig

--- a/framework/examples/myproject/smoke.toml
+++ b/framework/examples/myproject/smoke.toml
@@ -6,15 +6,15 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/smoke_import.toml
+++ b/framework/examples/myproject/smoke_import.toml
@@ -3,15 +3,15 @@
   docker_cmd_params = ["-b", "1"]
   type = "anvil"
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/smoke_limited_resources.toml
+++ b/framework/examples/myproject/smoke_limited_resources.toml
@@ -10,22 +10,22 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-    [nodeset.db.resources]
+    [nodesets.db.resources]
       cpus = 1
       memory_mb = 1048
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 
-      [nodeset.node_specs.node.resources]
+      [nodesets.node_specs.node.resources]
         cpus = 1
         memory_mb = 1048

--- a/framework/examples/myproject/smoke_logs_test.go
+++ b/framework/examples/myproject/smoke_logs_test.go
@@ -15,7 +15,7 @@ import (
 type CfgLogs struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestLogsSmoke(t *testing.T) {
@@ -45,7 +45,7 @@ func TestLogsSmoke(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	t.Run("test something", func(t *testing.T) {

--- a/framework/examples/myproject/smoke_sui.toml
+++ b/framework/examples/myproject/smoke_sui.toml
@@ -6,35 +6,35 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodeset]]
   name = "don"
   nodes = 5
   override_mode = "each"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"

--- a/framework/examples/myproject/smoke_sui_test.go
+++ b/framework/examples/myproject/smoke_sui_test.go
@@ -20,7 +20,7 @@ import (
 type CfgSui struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestSuiSmoke(t *testing.T) {
@@ -44,14 +44,14 @@ func TestSuiSmoke(t *testing.T) {
 
 	fmt.Printf("Sui host HTTP URL: %s", bc.Nodes[0].ExternalHTTPUrl)
 	fmt.Printf("Sui internal (docker) HTTP URL: %s", bc.Nodes[0].InternalHTTPUrl)
-	for _, n := range in.NodeSet.NodeSpecs {
+	for _, n := range in.NodeSets[0].NodeSpecs {
 		// configure each CL node for Sui, just an example
 		n.Node.TestConfigOverrides = `
 											[Log]
 											level = 'info'
 `
 	}
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, nil)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], nil)
 	require.NoError(t, err)
 
 	t.Run("test something", func(t *testing.T) {

--- a/framework/examples/myproject/smoke_test.go
+++ b/framework/examples/myproject/smoke_test.go
@@ -3,6 +3,7 @@ package examples
 import (
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
@@ -14,7 +15,7 @@ import (
 type Cfg struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestSmoke(t *testing.T) {
@@ -25,8 +26,9 @@ func TestSmoke(t *testing.T) {
 	require.NoError(t, err)
 	_, err = fake.NewFakeDataProvider(in.MockerDataProvider)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
+	spew.Dump(in.NodeSets[0])
 
 	t.Run("test something", func(t *testing.T) {
 		for _, n := range out.CLNodes {

--- a/framework/examples/myproject/upgrade.toml
+++ b/framework/examples/myproject/upgrade.toml
@@ -6,35 +6,35 @@
 [data_provider]
   port = 9111
 
-[nodeset]
+[[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "each"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.16.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.16.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.16.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.16.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.16.0"

--- a/framework/examples/myproject/upgrade_test.go
+++ b/framework/examples/myproject/upgrade_test.go
@@ -36,7 +36,7 @@ const (
 type CfgReload struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
 	MockerDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestUpgrade(t *testing.T) {
@@ -49,7 +49,7 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	// deploy first time
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	c, err := clclient.New(out.CLNodes)
@@ -57,18 +57,18 @@ func TestUpgrade(t *testing.T) {
 	_, _, err = c[0].CreateJobRaw(testJob)
 	require.NoError(t, err)
 
-	in.NodeSet.NodeSpecs[0].Node.Image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
-	in.NodeSet.NodeSpecs[0].Node.UserConfigOverrides = `
+	in.NodeSets[0].NodeSpecs[0].Node.Image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+	in.NodeSets[0].NodeSpecs[0].Node.UserConfigOverrides = `
 											[Log]
 											level = 'info'
 	`
-	in.NodeSet.NodeSpecs[4].Node.Image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
-	in.NodeSet.NodeSpecs[4].Node.UserConfigOverrides = `
+	in.NodeSets[0].NodeSpecs[4].Node.Image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
+	in.NodeSets[0].NodeSpecs[4].Node.UserConfigOverrides = `
 											[Log]
 											level = 'info'
 	`
 
-	out, err = ns.UpgradeNodeSet(t, in.NodeSet, bc, 3*time.Second)
+	out, err = ns.UpgradeNodeSet(t, in.NodeSets[0], bc, 3*time.Second)
 	require.NoError(t, err)
 
 	jobs, _, err := c[0].ReadJobs()

--- a/framework/examples/myproject_cll/jd.toml
+++ b/framework/examples/myproject_cll/jd.toml
@@ -5,14 +5,14 @@
 
 [jd]
 
-[nodeset]
+[[nodesets]]
   nodes = 5
   override_mode = "all"
 
-  [nodeset.db]
+  [nodesets.db]
     image = "postgres:12.0"
 
-  [[nodeset.node_specs]]
+  [[nodesets.node_specs]]
 
-    [nodeset.node_specs.node]
+    [nodesets.node_specs.node]
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enable more flexible configuration for Chainlink node sets by allowing multiple node sets (`nodesets`) to be defined within the configuration files. This update supports more complex test scenarios and environments by providing the ability to specify various node set configurations, including different Chainlink node versions or custom configurations for specific tests.

## What
- Changed configuration key from `nodeset` to `[[nodesets]]` across multiple TOML configuration files to support defining multiple node sets.
- Updated the Golang structure field from `NodeSet` to `NodeSets` and changed its type to a slice to handle multiple node sets.
- Adjusted TOML and Golang code snippets to reflect the new configuration setup that supports multiple node sets.
- Added a new changeset file `v0.7.3.md` indicating the update for supporting multi-node set configurations.
