### PR TITLE
retract lib@v1.99.0 tag

### DIFF
--- a/lib/go.mod
+++ b/lib/go.mod
@@ -218,6 +218,6 @@ require (
 retract (
 	// all of these tags were used, when testing new structure of the repository and by no mean represent latest versions
 	[v1.999.0-test-release, v1.999.999-test-release]
-	[v1.99.1, v1.99.9]
+	[v1.99.0, v1.99.9]
 	v1.50.0
 )


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes refine the version constraints for a package within the `go.mod` file, ensuring that the project dependencies are accurately specified, which is crucial for maintaining compatibility and stability across different environments.

## What
- **lib/go.mod**
  - Modified the version constraint in the `retract` section, changing from `[v1.99.1, v1.99.9]` to `[v1.99.0, v1.99.9]`. This alteration expands the range of retracted versions to include `v1.99.0`, ensuring that this version is also excluded from use, likely due to identified issues or incompatibilities.
