### PR TITLE
[DX-585] parrot custom startup time

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,6 +50,7 @@ test-all:
 
 goimports-all:
     @just _default_goimports k8s-test-runner
+    @just _default_goimports lib
     @just _default_goimports parrot
     @just _default_goimports tools/workflowresultparser
     @just _default_goimports tools/asciitable

--- a/lib/.changeset/v1.54.0.md
+++ b/lib/.changeset/v1.54.0.md
@@ -1,0 +1,1 @@
+- Fix tc logger for v0.36.0

--- a/lib/.changeset/v1.54.1.md
+++ b/lib/.changeset/v1.54.1.md
@@ -1,0 +1,1 @@
+- Make Parrot Docker container startup time configurable

--- a/lib/docker/test_env/parrot.go
+++ b/lib/docker/test_env/parrot.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	defaultParrotImage   = "kalverra/parrot"
-	defaultParrotVersion = "v0.6.2"
-	defaultParrotPort    = "80"
+	defaultParrotImage    = "kalverra/parrot"
+	defaultParrotVersion  = "v0.6.2"
+	defaultParrotPort     = "80"
 	defaultStartupTimeout = 10 * time.Second
 )
 
@@ -55,8 +55,8 @@ type ParrotAdapterResult struct {
 func NewParrot(networks []string, opts ...EnvComponentOption) *Parrot {
 	p := &Parrot{
 		EnvComponent: EnvComponent{
-			ContainerName:  fmt.Sprintf("%s-%s", "parrot", uuid.NewString()[0:3]),
-			Networks:       networks,
+			ContainerName: fmt.Sprintf("%s-%s", "parrot", uuid.NewString()[0:3]),
+			Networks:      networks,
 		},
 		l: log.Logger,
 	}

--- a/lib/docker/test_env/parrot.go
+++ b/lib/docker/test_env/parrot.go
@@ -24,6 +24,7 @@ const (
 	defaultParrotImage   = "kalverra/parrot"
 	defaultParrotVersion = "v0.6.2"
 	defaultParrotPort    = "80"
+	defaultStartupTimeout = 10 * time.Second
 )
 
 // Parrot is a test environment component that wraps a Parrot server.
@@ -56,7 +57,6 @@ func NewParrot(networks []string, opts ...EnvComponentOption) *Parrot {
 		EnvComponent: EnvComponent{
 			ContainerName:  fmt.Sprintf("%s-%s", "parrot", uuid.NewString()[0:3]),
 			Networks:       networks,
-			StartupTimeout: 10 * time.Second,
 		},
 		l: log.Logger,
 	}
@@ -64,6 +64,11 @@ func NewParrot(networks []string, opts ...EnvComponentOption) *Parrot {
 	for _, opt := range opts {
 		opt(&p.EnvComponent)
 	}
+
+	if p.StartupTimeout == 0 {
+		p.StartupTimeout = defaultStartupTimeout
+	}
+
 	return p
 }
 

--- a/lib/grafana/client.go
+++ b/lib/grafana/client.go
@@ -119,8 +119,8 @@ type GrafanaResponse struct {
 }
 
 // PostDashboard sends a request to create or update a Grafana dashboard.
-// It returns the response containing the dashboard details, the HTTP response, 
-// and any error encountered during the request. This function is useful for 
+// It returns the response containing the dashboard details, the HTTP response,
+// and any error encountered during the request. This function is useful for
 // programmatically managing Grafana dashboards.
 func (c *Client) PostDashboard(dashboard PostDashboardRequest) (GrafanaResponse, *resty.Response, error) {
 	var grafanaResp GrafanaResponse


### PR DESCRIPTION
Why? 10s wasn't enough on some local machines
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce improvements and configurations to the Parrot Docker container environment, specifically targeting startup times and logging functionality. They ensure more flexible and error-resilient integration setups, beneficial for environments where specific timing and logging configurations are critical for the successful deployment and operation of services.

## What
- **lib/.changeset/v1.54.0.md**
  - Added a new changeset file to document a fix in the tc logger compatibility with version 0.36.0.
- **lib/.changeset/v1.54.1.md**
  - Introduced a changeset detailing the new feature that allows configurable startup times for the Parrot Docker container.
- **lib/docker/test_env/parrot.go**
  - Added `defaultStartupTimeout` constant set to 10 seconds, ensuring a default startup time is defined.
  - Modified `NewParrot` function to initialize `StartupTimeout` with `defaultStartupTimeout` if not explicitly set, providing a configurable timeout feature for the Parrot Docker container startup.
