### PR TITLE
Adding new JIRA tickets with flake tests

### DIFF
--- a/tools/flakeguard/flaky_tests_db.json
+++ b/tools/flakeguard/flaky_tests_db.json
@@ -278,6 +278,20 @@
     "jira_assignee_id": "6175d3e016119e0069fdd14f",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
+  "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1::TestValidateSyncUSDCDomainsWithChainsConfig": {
+    "test_package": "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1",
+    "test_name": "TestValidateSyncUSDCDomainsWithChainsConfig",
+    "jira_ticket": "DX-195",
+    "jira_assignee_id": "6175d3e016119e0069fdd14f",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1::TestValidateSyncUSDCDomainsWithChainsConfig/#00": {
+    "test_package": "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1",
+    "test_name": "TestValidateSyncUSDCDomainsWithChainsConfig/#00",
+    "jira_ticket": "DX-195",
+    "jira_assignee_id": "6175d3e016119e0069fdd14f",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
   "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6::TestUpdateBidirectionalLanesChangeset": {
     "test_package": "github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_6",
     "test_name": "TestUpdateBidirectionalLanesChangeset",
@@ -345,6 +359,13 @@
     "test_package": "github.com/smartcontractkit/chainlink/deployment/common/proposalutils",
     "test_name": "TestBuildProposalFromBatchesV2",
     "jira_ticket": "DX-526",
+    "jira_assignee_id": "6175d3e016119e0069fdd14f",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset::TestAcceptOwnership": {
+    "test_package": "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset",
+    "test_name": "TestAcceptOwnership",
+    "jira_ticket": "DX-627",
     "jira_assignee_id": "6175d3e016119e0069fdd14f",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
@@ -514,6 +535,83 @@
     "jira_assignee_id": "638f597c3e79f12e57253913",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_0": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_0",
+    "jira_ticket": "DX-618",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_1_conditional": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_1_conditional",
+    "jira_ticket": "DX-619",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_1_logtrigger": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_1_logtrigger",
+    "jira_ticket": "DX-620",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_1_with_logtrigger_and_mercury_v02": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_1_with_logtrigger_and_mercury_v02",
+    "jira_ticket": "DX-621",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_1_with_mercury_v02": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_1_with_mercury_v02",
+    "jira_ticket": "DX-622",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_1_with_mercury_v03": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_1_with_mercury_v03",
+    "jira_ticket": "DX-623",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_2_conditional": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_2_conditional",
+    "jira_ticket": "DX-613",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_2_logtrigger": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_2_logtrigger",
+    "jira_ticket": "DX-614",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_2_with_logtrigger_and_mercury_v02": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_2_with_logtrigger_and_mercury_v02",
+    "jira_ticket": "DX-615",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_2_with_mercury_v02": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_2_with_mercury_v02",
+    "jira_ticket": "DX-616",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestAutomationNodeUpgrade/registry_2_2_with_mercury_v03": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestAutomationNodeUpgrade/registry_2_2_with_mercury_v03",
+    "jira_ticket": "DX-617",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
   "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestForwarderOCR2Basic": {
     "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
     "test_name": "TestForwarderOCR2Basic",
@@ -532,6 +630,13 @@
     "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
     "test_name": "TestKeeperBlockCountPerTurn/registry_1_2",
     "jira_ticket": "DX-556",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/integration-tests/smoke::TestKeeperJobReplacement": {
+    "test_package": "github.com/smartcontractkit/chainlink/integration-tests/smoke",
+    "test_name": "TestKeeperJobReplacement",
+    "jira_ticket": "DX-624",
     "jira_assignee_id": "638f597c3e79f12e57253913",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
@@ -598,6 +703,13 @@
     "jira_assignee_id": "638f597c3e79f12e57253913",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
+  "github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre::TestCRE_OCR3_PoR_Workflow_GatewayDon_MockedPrice": {
+    "test_package": "github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre",
+    "test_name": "TestCRE_OCR3_PoR_Workflow_GatewayDon_MockedPrice",
+    "jira_ticket": "DX-625",
+    "jira_assignee_id": "638f597c3e79f12e57253913",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
   "github.com/smartcontractkit/chainlink/v2/core/capabilities/compute::TestCache": {
     "test_package": "github.com/smartcontractkit/chainlink/v2/core/capabilities/compute",
     "test_name": "TestCache",
@@ -616,6 +728,13 @@
     "test_package": "github.com/smartcontractkit/chainlink/v2/core/capabilities/compute",
     "test_name": "TestComputeExecute",
     "jira_ticket": "DX-560",
+    "jira_assignee_id": "6115c23730fe4500702c1301",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/v2/core/capabilities/compute::TestComputeFetchMaxResponseSizeBytes": {
+    "test_package": "github.com/smartcontractkit/chainlink/v2/core/capabilities/compute",
+    "test_name": "TestComputeFetchMaxResponseSizeBytes",
+    "jira_ticket": "DX-626",
     "jira_assignee_id": "6115c23730fe4500702c1301",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
@@ -835,6 +954,13 @@
     "test_package": "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm",
     "test_name": "TestChainComponents/RunChainComponentsInLoopEvmTests/EVM_on_loop/QueryKeys/EVM_on_loop/QueryKeys_can_limit_results_with_cursor",
     "jira_ticket": "DX-401",
+    "skipped_at": "0001-01-01T00:00:00Z"
+  },
+  "github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer::TestEngineRegistry": {
+    "test_package": "github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer",
+    "test_name": "TestEngineRegistry",
+    "jira_ticket": "DX-588",
+    "jira_assignee_id": "6115c23730fe4500702c1301",
     "skipped_at": "0001-01-01T00:00:00Z"
   },
   "github.com/smartcontractkit/chainlink/v2/core/services/workflows::TestEngine_ConcurrentExecutions": {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The flaky tests database JSON has been updated to include new tests, marking them with specific JIRA tickets and assignees. This ensures that any flaky tests are tracked and managed properly, allowing for a more efficient way to identify and address issues in the test suite.

## What
- Added `TestValidateSyncUSDCDomainsWithChainsConfig` and related subtest in `github.com/smartcontractkit/chainlink/deployment/ccip/changeset/v1_5_1` with JIRA ticket DX-195.
- Added `TestAcceptOwnership` in `github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset` with JIRA ticket DX-627.
- Added multiple `TestAutomationNodeUpgrade` tests in `github.com/smartcontractkit/chainlink/integration-tests/smoke` with JIRA tickets ranging from DX-618 to DX-623 and DX-613 to DX-617.
- Added `TestCRE_OCR3_PoR_Workflow_GatewayDon_MockedPrice` in `github.com/smartcontractkit/chainlink/system-tests/tests/smoke/cre` with JIRA ticket DX-625.
- Added `TestComputeFetchMaxResponseSizeBytes` in `github.com/smartcontractkit/chainlink/v2/core/capabilities/compute` with JIRA ticket DX-626.
- Added `TestKeeperJobReplacement` in `github.com/smartcontractkit/chainlink/integration-tests/smoke` with JIRA ticket DX-624.
- Added `TestEngineRegistry` in `github.com/smartcontractkit/chainlink/v2/core/services/workflows/syncer` with JIRA ticket DX-588.
