### PR TITLE
Use offline mode for Anvil ZK

### DIFF
--- a/framework/components/blockchain/anvil_zksync.go
+++ b/framework/components/blockchain/anvil_zksync.go
@@ -72,7 +72,8 @@ func newAnvilZksync(in *Input) (*Output, error) {
 		"-c",
 		"/root/.foundry/bin/anvil-zksync" +
 			" --chain-id " + in.ChainID +
-			" --port " + in.Port}
+			" --port " + in.Port +
+			" --offline"}
 
 	framework.L.Info().Any("Cmd", strings.Join(req.Entrypoint, " ")).Msg("Creating anvil zkSync with command")
 


### PR DESCRIPTION
The mainnet fork was default and it is not working out of the box. I moved to `--offline` that doesn't fork, and that also is of my preference.

<img width="943" alt="Screenshot 2025-05-12 at 2 53 12 PM" src="https://github.com/user-attachments/assets/5cd028ab-f2bf-4981-ace5-193f29cdce3e" />
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the Anvil zkSync Docker container runs in offline mode by adding an `--offline` flag to its execution command. This is crucial for scenarios where network isolation is required or in testing environments where external network access should be limited to simulate or enforce certain conditions.

## What
- **framework/components/blockchain/anvil_zksync.go**
  - Added the `--offline` flag to the Anvil zkSync container's entrypoint command. This modification allows the container to operate without needing external network access, providing a more controlled environment for testing or specific operational requirements.
