### PR TITLE
fix: flakeguard user test mapping

### DIFF
--- a/tools/flakeguard/.gitignore
+++ b/tools/flakeguard/.gitignore
@@ -9,3 +9,4 @@ test-output-*.json
 transformed-output-*.json
 flakeguard_raw_output/
 flakeguard_raw_output_transformed/
+.envrc

--- a/tools/flakeguard/user_mapping.json
+++ b/tools/flakeguard/user_mapping.json
@@ -79,4 +79,4 @@
         "jira_user_id": "712020:0f7e9a75-6933-4dcb-91fd-b6bf1c903d6f",
         "pillar_name": "Foundation"
     }
-] 
+]

--- a/tools/flakeguard/user_test_mapping.json
+++ b/tools/flakeguard/user_test_mapping.json
@@ -28,20 +28,24 @@
         "pattern": "github.com/smartcontractkit/chainlink/v2/core/services/relay.*"
     },
     {
-        "jira_user_id": "6175d3e016119e0069fdd14f",
-        "pattern": "github.com/smartcontractkit/chainlink/deployment.*"
-    },
-    {
-        "jira_user_id": "638f597c3e79f12e57253913",
-        "pattern": "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
-    },
-    {
         "jira_user_id": "6115c23730fe4500702c1301",
         "pattern": "github.com/smartcontractkit/chainlink/v2/core/services.*"
     },
     {
         "jira_user_id": "6115c23730fe4500702c1301",
         "pattern": "github.com/smartcontractkit/chainlink/v2/core/capabilities.*"
+    },
+    {
+        "jira_user_id": "638f597c3e79f12e57253913",
+        "pattern": "github.com/smartcontractkit/chainlink/deployment/data-feeds/changeset"
+    },
+    {
+        "jira_user_id": "712020:0403445b-a590-4e71-944c-e5b3c681dafb",
+        "pattern": "github.com/smartcontractkit/chainlink/deployment/ccip.*"
+    },
+    {
+        "jira_user_id": "6175d3e016119e0069fdd14f",
+        "pattern": "github.com/smartcontractkit/chainlink/deployment.*"
     },
     {
         "jira_user_id": "638f597c3e79f12e57253913",


### PR DESCRIPTION
### Changes

- Reorder mappings so `github.com/smartcontractkit/chainlink/deployment.*` doesn't swallow all mappings (https://github.com/smartcontractkit/chainlink-testing-framework/blob/96212dfb45f083f6358e7a85f4e0e85d35353168/tools/flakeguard/mapping/mapping.go#L94-L96)
  - Group core together, and deployment together
- Add entry for `deployment/ccip/*` as per @AnieeG's instructions - should now map to @b-gopalswami.
- Add .envrc to .gitignore

### Context

https://chainlink-core.slack.com/archives/C01Q2AWSLLR/p1747410482645319

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve project configuration, user mappings, and test patterns for better management and organization. By updating `.gitignore`, user mappings, and test patterns, the project ensures sensitive configurations are ignored, team members are correctly mapped to their respective pillars, and test responsibilities are accurately assigned.

## What
- **tools/flakeguard/.gitignore**
  - Added `.envrc` to the list. This prevents environment configuration files from being tracked, enhancing security and personal configuration management.
- **tools/flakeguard/user_mapping.json**
  - No specific changes to summarize; this file was touched but without a clear diff to detail.
- **tools/flakeguard/user_test_mapping.json**
  - Updated test patterns for various `jira_user_id`s. This refines the association between users and the test suites they are responsible for, ensuring alerts and issues are routed to the correct individuals.
    - Added new patterns for user `6115c23730fe4500702c1301` to cover services and capabilities, broadening their test coverage responsibility.
    - Adjusted patterns for user `6175d3e016119e0069fdd14f`, moving from a general deployment pattern to more specific ones, clarifying their focus areas in test coverage.
    - Introduced patterns for user `712020:0403445b-a590-4e71-944c-e5b3c681dafb` related to CCIP deployments, ensuring new areas of the codebase are under surveillance.
