### PR TITLE
[DX-812] change default capabilities directory in Docker

### DIFF
--- a/book/src/framework/components/chainlink/node.md
+++ b/book/src/framework/components/chainlink/node.md
@@ -23,7 +23,7 @@ Here we provide full configuration reference, if you want to copy and run it, pl
     # A list of paths to capability binaries
     capabilities = ["./capability_1", "./capability_2"]
     # Default capabilities directory inside container
-    capabilities_container_dir = "/home/capabilities"
+    capabilities_container_dir = "/usr/local/bin"
     # Image to use, you can either provide "image" or "docker_file" + "docker_ctx" fields
     image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
     # Path to your Chainlink Dockerfile

--- a/book/src/framework/components/chainlink/nodeset.md
+++ b/book/src/framework/components/chainlink/nodeset.md
@@ -54,7 +54,7 @@ Then configure NodeSet
   http_port_range_start = 10000
   # P2P API port range start, each new node get port incremented (host machine)
   p2p_port_range_start = 12000
-  
+
   [nodesets.db]
     # PostgreSQL image version and tag
     image = "postgres:12.0"
@@ -71,7 +71,7 @@ Then configure NodeSet
       # A list of paths to capability binaries
       capabilities = ["./capability_1", "./capability_2"]
       # Default capabilities directory inside container
-      capabilities_container_dir = "/home/capabilities"
+      capabilities_container_dir = "/usr/local/bin"
       # Image to use, you can either provide "image" or "docker_file" + "docker_ctx" fields
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
       # Path to your Chainlink Dockerfile
@@ -99,7 +99,7 @@ Then configure NodeSet
   [nodesets.out]
     # If 'use_cache' equals 'true' we skip component setup when we run the test and return the outputs
     use_cache = true
-    
+
     # Describes deployed or external Chainlink nodes
     [[nodesets.out.cl_nodes]]
       use_cache = true
@@ -119,7 +119,7 @@ Then configure NodeSet
         # PostgreSQL connection string
         # in case of using external database can be overriden
         url = "postgresql://chainlink:thispasswordislongenough@127.0.0.1:33094/chainlink?sslmode=disable"
-    
+
     # Can have more than one node, fields are the same, see above ^^
     [[nodesets.out.cl_nodes]]
       [nodesets.out.cl_nodes.node]

--- a/book/src/framework/nodeset_capabilities.md
+++ b/book/src/framework/nodeset_capabilities.md
@@ -11,7 +11,7 @@ gh auth setup-git
 Download an example capability binary
 ```
 export export GOPRIVATE=github.com/smartcontractkit/capabilities
-go get github.com/smartcontractkit/capabilities/kvstore && go install github.com/smartcontractkit/capabilities/kvstore 
+go get github.com/smartcontractkit/capabilities/kvstore && go install github.com/smartcontractkit/capabilities/kvstore
 ```
 
 Create a configuration file `smoke.toml`
@@ -24,7 +24,7 @@ Create a configuration file `smoke.toml`
   name = "don"
   nodes = 5
   override_mode = "all"
-  
+
   [nodesets.db]
     image = "postgres:12.0"
 
@@ -34,7 +34,7 @@ Create a configuration file `smoke.toml`
       # path to your capability binaries
       capabilities = ["./kvstore"]
       # default capabilities directory
-      # capabilities_container_dir = "/home/capabilities"
+      # capabilities_container_dir = "/usr/local/bin"
       image = "public.ecr.aws/chainlink/chainlink:v2.17.0"
 ```
 
@@ -45,7 +45,7 @@ CTF_CONFIGS=smoke.toml go test -v -run TestNodeSet
 
 Now you can configure your capability using `clclient.CreateJobRaw($raw_toml)`.
 
-Capabilities are uploaded to `/home/capabilities` by default.
+Capabilities are uploaded to `/usr/local/bins` by default.
 
 Summary:
 - We deployed a node set with some capabilities

--- a/framework/.changeset/v0.8.3.md
+++ b/framework/.changeset/v0.8.3.md
@@ -1,0 +1,1 @@
+- change default capabilities directory to `/usr/local/bin`

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	DefaultHTTPPort     = "6688"
-	DefaultP2PPort      = "6690"
-	DefaultDebuggerPort = 40000
-	TmpImageName        = "chainlink-tmp:latest"
-	CustomPortSeparator = ":"
+	DefaultHTTPPort        = "6688"
+	DefaultP2PPort         = "6690"
+	DefaultDebuggerPort    = 40000
+	TmpImageName           = "chainlink-tmp:latest"
+	CustomPortSeparator    = ":"
+	DefaultCapabilitiesDir = "/usr/local/bin"
 )
 
 var (
@@ -301,7 +302,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		},
 	}
 	if in.Node.CapabilityContainerDir == "" {
-		in.Node.CapabilityContainerDir = "/home/capabilities"
+		in.Node.CapabilityContainerDir = DefaultCapabilitiesDir
 	}
 	for _, cp := range in.Node.CapabilitiesBinaryPaths {
 		cpPath := filepath.Base(cp)


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes focus on standardizing the capabilities directory across various configuration and documentation files to `/usr/local/bin`, improving consistency and potentially aligning with common practices for binary locations in container environments.

## What
- **book/src/framework/components/chainlink/node.md & nodeset.md**  
  - Changed `capabilities_container_dir` from `/home/capabilities` to `/usr/local/bin`. This alteration standardizes the directory used for capabilities across different Chainlink node configurations.
- **book/src/framework/nodeset_capabilities.md**  
  - Updated guidance on the default capabilities directory, changing references from `/home/capabilities` to `/usr/local/bin` in the documentation to reflect the new standard location for capability binaries.
- **framework/.changeset/v0.8.3.md**  
  - Added a changeset file indicating that the default capabilities directory has been updated to `/usr/local/bin`.
- **framework/components/clnode/clnode.go**  
  - Introduced a new constant `DefaultCapabilitiesDir` set to `/usr/local/bin`, replacing hardcoded paths in the node setup function to use this constant, thereby standardizing the capabilities directory path within the Chainlink node's internal configuration.
