### PR TITLE
expose EVM public keys for tooling

### DIFF
--- a/book/src/framework/components/blockchains/evm.md
+++ b/book/src/framework/components/blockchains/evm.md
@@ -66,22 +66,36 @@ func TestDON(t *testing.T) {
 
 ## Test Private Keys
 
-For `Geth` and `Anvil` we use the same key
+For `Geth` we use
 ```
-Public: 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
-Private: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+	DefaultGethPrivateKey = `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+	DefaultGethPublicKey = `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`
+```
+
+For `Anvil` we use
+```
+	DefaultAnvilPrivateKey = `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+	AnvilPrivateKey1       = `0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d`
+	AnvilPrivateKey2       = `0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a`
+	AnvilPrivateKey3       = `0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6`
+	AnvilPrivateKey4       = `0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a`
+	
+	DefaultAnvilPublicKey  = `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
+	AnvilPublicKey1        = `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`
+	AnvilPublicKey2        = `0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC`
+	AnvilPublicKey3        = `0x90F79bf6EB2c4f870365E785982E1f101E93b906`
+	AnvilPublicKey4        = `0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65`
 ```
 
 For `Besu` keys are
 ```
-Public: 0xfe3b557e8fb62b89f4916b721be55ceb828dbd73
-Private: 0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63
-
-Public: 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
-Private: 0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3
-
-Public: 0xf17f52151EbEF6C7334FAD080c5704D77216b732
-Private: 0xae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f
+	DefaultBesuPrivateKey1 = "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"
+	DefaultBesuPrivateKey2 = "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3"
+	DefaultBesuPrivateKey3 = "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"
+	
+	DefaultBesuPublicKey1 = "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+	DefaultBesuPublicKey2 = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57"
+	DefaultBesuPublicKey3 = "0xf17f52151EbEF6C7334FAD080c5704D77216b732"
 ```
 
 More docs for `Besu` can be found [here](https://besu.hyperledger.org/private-networks/reference/accounts-for-testing)

--- a/framework/.changeset/v0.8.5.md
+++ b/framework/.changeset/v0.8.5.md
@@ -1,0 +1,1 @@
+- Expose public key constants for tooling

--- a/framework/components/blockchain/anvil.go
+++ b/framework/components/blockchain/anvil.go
@@ -8,6 +8,15 @@ import (
 
 const (
 	DefaultAnvilPrivateKey = `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+	AnvilPrivateKey1       = `0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d`
+	AnvilPrivateKey2       = `0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a`
+	AnvilPrivateKey3       = `0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6`
+	AnvilPrivateKey4       = `0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a`
+	DefaultAnvilPublicKey  = `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266`
+	AnvilPublicKey1        = `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`
+	AnvilPublicKey2        = `0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC`
+	AnvilPublicKey3        = `0x90F79bf6EB2c4f870365E785982E1f101E93b906`
+	AnvilPublicKey4        = `0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65`
 )
 
 func defaultAnvil(in *Input) {

--- a/framework/components/blockchain/besu.go
+++ b/framework/components/blockchain/besu.go
@@ -4,6 +4,9 @@ const (
 	DefaultBesuPrivateKey1 = "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"
 	DefaultBesuPrivateKey2 = "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3"
 	DefaultBesuPrivateKey3 = "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"
+	DefaultBesuPublicKey1  = "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
+	DefaultBesuPublicKey2  = "0x627306090abaB3A6e1400e9345bC60c78a8BEf57"
+	DefaultBesuPublicKey3  = "0xf17f52151EbEF6C7334FAD080c5704D77216b732"
 )
 
 func defaultBesu(in *Input) {

--- a/framework/components/blockchain/geth.go
+++ b/framework/components/blockchain/geth.go
@@ -50,6 +50,7 @@ const (
 }
 `
 	DefaultGethPrivateKey = `ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`
+	DefaultGethPublicKey  = `0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266`
 )
 
 var initScript = `


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes standardize and expand the handling of private and public keys across different Ethereum-based blockchains (Geth, Anvil, and Besu) within the framework. This includes the restructuring of how these keys are defined and used, ensuring that additional keys are available for Anvil, and aligning the documentation with these changes.

## What
- **book/src/framework/components/blockchains/evm.md**
  - Updated the documentation to reflect the new way of defining default private and public keys for Geth, Anvil, and Besu. This change makes it easier for developers to understand and use these keys within the context of the framework.
- **framework/.changeset/v0.8.5.md**
  - Introduced a changeset file that notes the exposure of public key constants for tooling, indicating a minor version update that focuses on improving development tools and processes.
- **framework/components/blockchain/anvil.go**
  - Added multiple private and public key constants specific to Anvil to facilitate testing and interaction with the Anvil blockchain component.
- **framework/components/blockchain/besu.go**
  - Added public key constants for Besu, aligning it with the changes made for Anvil and Geth, and supporting more comprehensive testing and blockchain interactions.
- **framework/components/blockchain/geth.go**
  - Included a `DefaultGethPublicKey` constant, ensuring that Geth configurations are consistent with Anvil and Besu in terms of both private and public key handling.
