### PR TITLE
Update docs, fix Pyroscope, pin observability stack versions

### DIFF
--- a/book/src/framework/nodeset_environment.md
+++ b/book/src/framework/nodeset_environment.md
@@ -5,14 +5,17 @@ Let's create a full-fledged set of Chainlink nodes connected to some blockchain.
 Create a configuration file `smoke.toml`
 ```toml
 [blockchain_a]
-  type = "anvil"
   docker_cmd_params = ["-b", "1"]
+  type = "anvil"
+
+[data_provider]
+  port = 9111
 
 [[nodesets]]
   name = "don"
   nodes = 5
   override_mode = "all"
-  
+
   [nodesets.db]
     image = "postgres:12.0"
 
@@ -24,34 +27,39 @@ Create a configuration file `smoke.toml`
 
 Create a file `smoke_test.go`
 ```golang
-package yourpackage_test
+package examples
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake"
 	ns "github.com/smartcontractkit/chainlink-testing-framework/framework/components/simple_node_set"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-type Config struct {
+type Cfg struct {
 	BlockchainA        *blockchain.Input `toml:"blockchain_a" validate:"required"`
-	NodeSet            *ns.Input         `toml:"nodeset" validate:"required"`
+	MockedDataProvider *fake.Input       `toml:"data_provider" validate:"required"`
+	NodeSets           []*ns.Input       `toml:"nodesets" validate:"required"`
 }
 
 func TestNodeSet(t *testing.T) {
-	in, err := framework.Load[Config](t)
+	in, err := framework.Load[Cfg](t)
 	require.NoError(t, err)
 
 	bc, err := blockchain.NewBlockchainNetwork(in.BlockchainA)
 	require.NoError(t, err)
-	out, err := ns.NewSharedDBNodeSet(in.NodeSet, bc)
+	_, err = fake.NewFakeDataProvider(in.MockedDataProvider)
+	require.NoError(t, err)
+	out, err := ns.NewSharedDBNodeSet(in.NodeSets[0], bc)
 	require.NoError(t, err)
 
 	t.Run("test something", func(t *testing.T) {
 		for _, n := range out.CLNodes {
 			require.NotEmpty(t, n.Node.ExternalURL)
-			require.NotEmpty(t, n.Node.HostP2PURL)
 		}
 	})
 }

--- a/book/src/framework/observability/observability_stack.md
+++ b/book/src/framework/observability/observability_stack.md
@@ -20,3 +20,11 @@ Read more about how to check [logs](logs.md) and [profiles](profiling.md)
 - [Prometheus](http://localhost:3000/explore?panes=%7B%22qZw%22:%7B%22datasource%22:%22PBFA97CFB590B2093%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%22,%22range%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22PBFA97CFB590B2093%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1)
 - [PostgreSQL](http://localhost:3000/d/000000039/postgresql-database?orgId=1&refresh=10s&var-DS_PROMETHEUS=PBFA97CFB590B2093&var-interval=$__auto_interval_interval&var-namespace=&var-release=&var-instance=postgres_exporter_0:9187&var-datname=All&var-mode=All&from=now-5m&to=now)
 - [Pyroscope](http://localhost:4040)
+
+## Developing
+
+Change compose files under `framework/cmd/observability` and restart the stack (removing volumes too)
+```
+just reload-cli && ctf obs r
+```
+

--- a/framework/.changeset/v0.9.0.md
+++ b/framework/.changeset/v0.9.0.md
@@ -1,0 +1,3 @@
+- Fix Solana container health check
+- Fix examples in framework docs
+- Fix Pyroscope and pin observability deps

--- a/framework/cmd/main.go
+++ b/framework/cmd/main.go
@@ -96,6 +96,18 @@ func main() {
 						Action:      func(c *cli.Context) error { return observabilityDown() },
 					},
 					{
+						Name:        "restart",
+						Usage:       "ctf obs r",
+						Aliases:     []string{"r"},
+						Description: "Restart a local observability stack",
+						Action: func(c *cli.Context) error {
+							if err := observabilityDown(); err != nil {
+								return err
+							}
+							return observabilityUp()
+						},
+					},
+					{
 						Name:        "load",
 						Usage:       "ctf obs l",
 						Aliases:     []string{"l"},

--- a/framework/cmd/observability/compose/docker-compose.yaml
+++ b/framework/cmd/observability/compose/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     privileged: true
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.4.1
     user: '0:0'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -84,14 +84,14 @@ services:
       - tempo
 
   pyroscope:
-    image: 'pyroscope/pyroscope:latest'
+    image: 'grafana/pyroscope:1.13.4'
     ports:
       - '4040:4040'
     command:
       - 'server'
 
   postgres_exporter_0:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: postgres_exporter_0
     environment:
       - DATA_SOURCE_NAME=postgresql://chainlink:thispasswordislongenough@host.docker.internal:13000/db_0?sslmode=disable
@@ -100,7 +100,7 @@ services:
     restart: unless-stopped
 
   postgres_exporter_1:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: postgres_exporter_1
     environment:
       - DATA_SOURCE_NAME=postgresql://chainlink:thispasswordislongenough@host.docker.internal:13000/db_1?sslmode=disable
@@ -109,7 +109,7 @@ services:
     restart: unless-stopped
 
   postgres_exporter_2:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: postgres_exporter_2
     environment:
       - DATA_SOURCE_NAME=postgresql://chainlink:thispasswordislongenough@host.docker.internal:13000/db_2?sslmode=disable
@@ -118,7 +118,7 @@ services:
     restart: unless-stopped
 
   postgres_exporter_3:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: postgres_exporter_3
     environment:
       - DATA_SOURCE_NAME=postgresql://chainlink:thispasswordislongenough@host.docker.internal:13000/db_3?sslmode=disable
@@ -127,7 +127,7 @@ services:
     restart: unless-stopped
 
   postgres_exporter_4:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.17.1
     container_name: postgres_exporter_4
     environment:
       - DATA_SOURCE_NAME=postgresql://chainlink:thispasswordislongenough@host.docker.internal:13000/db_4?sslmode=disable

--- a/framework/examples/myproject/example_components/mock-tester.go
+++ b/framework/examples/myproject/example_components/mock-tester.go
@@ -21,7 +21,7 @@ func NewDockerFakeTester(url string) error {
 		Cmd:        []string{"curl", "-v", url},
 		Labels:     framework.DefaultTCLabels(),
 		WaitingFor: wait.ForExit(),
-		Networks: []string{framework.DefaultNetworkName, "default_compose"},
+		Networks:   []string{framework.DefaultNetworkName, "default_compose"},
 	}
 	curlContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/framework/examples/myproject/go.mod
+++ b/framework/examples/myproject/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/blocto/solana-go-sdk v1.30.0
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/go-resty/resty/v2 v2.16.3
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.7.4
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9
 	github.com/smartcontractkit/chainlink-testing-framework/havoc v1.50.2
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.50.10
 	github.com/smartcontractkit/chainlink-testing-framework/wasp v1.50.2

--- a/justfile
+++ b/justfile
@@ -155,3 +155,7 @@ actionlint:
 # Serve MDBook locally
 book:
     cd book && mdbook serve -p 9999
+
+# Reload framework CLI for local development
+reload-cli:
+    cd framework/cmd && go get github.com/smartcontractkit/chainlink-testing-framework/framework/cmd && go install github.com/smartcontractkit/chainlink-testing-framework/framework/cmd && mv ~/go/bin/cmd ~/go/bin/ctf

--- a/wasp/examples/profiles/gun.go
+++ b/wasp/examples/profiles/gun.go
@@ -27,7 +27,7 @@ func (m *ExampleGun) Call(l *wasp.Generator) *wasp.Response {
 		SetResult(&result).
 		Get(m.target)
 	if err != nil {
-		return &wasp.Response{Data: result, Error: err.Error()}
+		return &wasp.Response{Data: result, Error: err.Error(), Failed: true}
 	}
 	if r.Status() != "200 OK" {
 		return &wasp.Response{Data: result, Error: "not 200", Failed: true}

--- a/wasp/examples/simple_rps/main_test.go
+++ b/wasp/examples/simple_rps/main_test.go
@@ -12,9 +12,6 @@ func TestGun(t *testing.T) {
 	srv := wasp.NewHTTPMockServer(nil)
 	srv.Run()
 
-	//branch := os.Getenv("BRANCH")
-	//commit := os.Getenv("COMMIT")
-
 	// define labels for differentiate one run from another
 	labels := map[string]string{
 		// check variables in dashboard/dashboard.go


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes aim to enhance the development experience and address issues within the testing framework, documentation, and example projects. These modifications include adding a new Docker command for restarting the observability stack, updating the documentation to reflect the latest configurations and testing methodologies, fixing health checks and dependencies, and ensuring that example projects are up-to-date with the current framework version.

## What
- **book/src/framework/nodeset_environment.md**
  - Added a new `[data_provider]` section with a `port` configuration.
  - Corrected the formatting and added missing newline characters for readability.
- **book/src/framework/observability/observability_stack.md**
  - Added a new section on developing with instructions to change compose files and commands to reload the CLI and observability stack.
- **framework/.changeset/v0.9.0.md**
  - Added a new changeset file describing fixes to Solana container health checks, examples in framework docs, and Pyroscope with pinned observability dependencies.
- **framework/cmd/main.go**
  - Introduced a new `restart` command under the `observability` command group to restart the local observability stack.
- **framework/cmd/observability/compose/docker-compose.yaml**
  - Updated images for Prometheus, Pyroscope, and postgres-exporter to specific versions instead of using the `latest` tag.
- **framework/examples/myproject/example_components/mock-tester.go**
  - Minor formatting change with no actual code or functionality change.
- **framework/examples/myproject/go.mod**
  - Updated the version of `github.com/smartcontractkit/chainlink-testing-framework/framework` from `v0.7.4` to `v0.8.9`.
- **justfile**
  - Added a new `reload-cli` command for local development that reloads the framework CLI.
- **wasp/examples/profiles/gun.go**
  - Ensured an error response is correctly marked as failed in the `NewExampleHTTPGun` function.
- **wasp/examples/simple_rps/main_test.go**
  - Removed commented-out code and updated labels in the test configuration for the generator.
