### PR TITLE
[CAPPL-921] add container retry to clnode, postgres, jd and evm blockchains

### DIFF
--- a/framework/.changeset/v0.9.1.md
+++ b/framework/.changeset/v0.9.1.md
@@ -1,0 +1,1 @@
+- Try to start EVM blockchain, JD, CL node and Postgres containers 3x

--- a/framework/components/blockchain/containers.go
+++ b/framework/components/blockchain/containers.go
@@ -64,7 +64,7 @@ func baseRequest(in *Input, useWS ExposeWs) testcontainers.ContainerRequest {
 
 func createGenericEvmContainer(in *Input, req testcontainers.ContainerRequest, useWS bool) (*Output, error) {
 	ctx := context.Background()
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(framework.L, ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/framework/components/blockchain/containers.go
+++ b/framework/components/blockchain/containers.go
@@ -64,7 +64,7 @@ func baseRequest(in *Input, useWS ExposeWs) testcontainers.ContainerRequest {
 
 func createGenericEvmContainer(in *Input, req testcontainers.ContainerRequest, useWS bool) (*Output, error) {
 	ctx := context.Background()
-	c, err := framework.StartContainerWithRetry(framework.L, ctx, testcontainers.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(ctx, framework.L, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -324,7 +324,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		}
 		req.KeepImage = false
 	}
-	c, err := framework.StartContainerWithRetry(framework.L, ctx, tc.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(ctx, framework.L, tc.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -324,7 +324,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		}
 		req.KeepImage = false
 	}
-	c, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(framework.L, ctx, tc.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/framework/components/jd/jd.go
+++ b/framework/components/jd/jd.go
@@ -117,7 +117,7 @@ func NewJD(in *Input) (*Output, error) {
 		req.KeepImage = false
 	}
 
-	c, err := framework.StartContainerWithRetry(framework.L, ctx, tc.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(ctx, framework.L, tc.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})

--- a/framework/components/jd/jd.go
+++ b/framework/components/jd/jd.go
@@ -116,10 +116,12 @@ func NewJD(in *Input) (*Output, error) {
 		}
 		req.KeepImage = false
 	}
-	c, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
+
+	c, err := framework.StartContainerWithRetry(framework.L, ctx, tc.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/framework/components/postgres/postgres.go
+++ b/framework/components/postgres/postgres.go
@@ -153,7 +153,7 @@ func NewPostgreSQL(in *Input) (*Output, error) {
 		}
 		framework.ResourceLimitsFunc(h, in.ContainerResources)
 	}
-	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(framework.L, ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Reuse:            true,

--- a/framework/components/postgres/postgres.go
+++ b/framework/components/postgres/postgres.go
@@ -153,7 +153,7 @@ func NewPostgreSQL(in *Input) (*Output, error) {
 		}
 		framework.ResourceLimitsFunc(h, in.ContainerResources)
 	}
-	c, err := framework.StartContainerWithRetry(framework.L, ctx, testcontainers.GenericContainerRequest{
+	c, err := framework.StartContainerWithRetry(ctx, framework.L, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 		Reuse:            true,

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -496,7 +496,7 @@ var NaiveRetrier = func(l zerolog.Logger, ctx context.Context, startErr error, r
 // StartContainerWithRetry attempts to start a container with 3 retry attempts.
 // It will try to start the container with the provided retriers, if none are provided it will use the default retrier, which
 // simply tries to start the container again without any modifications.
-func StartContainerWithRetry(l zerolog.Logger, ctx context.Context, req tc.GenericContainerRequest, retriers ...StartContainerRetrier) (tc.Container, error) {
+func StartContainerWithRetry(ctx context.Context, l zerolog.Logger, req tc.GenericContainerRequest, retriers ...StartContainerRetrier) (tc.Container, error) {
 	var (
 		ct  tc.Container
 		err error


### PR DESCRIPTION
Succesful run: https://github.com/smartcontractkit/chainlink/actions/runs/15484446872/job/43596302667?pr=18037
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the robustness and error handling of container start-up processes across various components (blockchain nodes, CL nodes, JD, and PostgreSQL) by introducing retries. This is particularly useful in environments where transient issues may temporarily prevent a container from starting successfully.

## What
- **framework/components/blockchain/containers.go**
  - Updated container start method to `framework.StartContainerWithRetry` for EVM containers. This change improves error handling by retrying container start-up, reducing the likelihood of failures due to transient issues.
- **framework/components/clnode/clnode.go**
  - Changed the method for starting containers to `framework.StartContainerWithRetry`. This modification ensures better stability by attempting to start the container multiple times in case of initial failure.
- **framework/components/jd/jd.go**
  - Updated container start method to `framework.StartContainerWithRetry`. Enhances reliability by trying to start the container multiple times if the first attempt fails.
- **framework/components/postgres/postgres.go**
  - Changed the PostgreSQL container start method to `framework.StartContainerWithRetry`. This adjustment aims to increase success rates of container starts by implementing a retry mechanism.
- **framework/docker.go**
  - Added `StartContainerWithRetry` function along with `NaiveRetrier` and helper functions. These additions provide the capability to retry starting containers with a simple retry strategy, thereby enhancing the resilience of the container start-up process.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The primary goal of these changes is to enhance the stability and reliability of container initialization in integration tests. By incorporating a retry mechanism when starting containers, we address transient issues that may occur due to various reasons such as network delays or resource constraints, ensuring a more robust setup for testing environments.

## What
- **framework/components/blockchain/containers.go**
  - Replaced `testcontainers.GenericContainer` call with `framework.StartContainerWithRetry` to attempt container start with retries.
- **framework/components/clnode/clnode.go**
  - Replaced `tc.GenericContainer` call with `framework.StartContainerWithRetry` for retrying container starts.
- **framework/components/jd/jd.go**
  - Replaced `tc.GenericContainer` call with `framework.StartContainerWithRetry` adding retry logic when starting containers.
- **framework/components/postgres/postgres.go**
  - Replaced `testcontainers.GenericContainer` with `framework.StartContainerWithRetry` to implement retry functionality on container start.
- **framework/docker.go**
  - Added `NaiveRetrier` function which attempts to restart the container with a simple retry logic.
  - Implemented `StartContainerWithRetry` function that tries to start a container with up to 3 retries using provided retriers or a default one.
  - Added `removeContainer` function to support retry logic by removing existing containers before retrying.
