### PR TITLE
[DX-1052] Allow passing custom env vars to Chainlink Node containers

### DIFF
--- a/book/src/framework/components/chainlink/node.md
+++ b/book/src/framework/components/chainlink/node.md
@@ -47,6 +47,9 @@ Here we provide full configuration reference, if you want to copy and run it, pl
       mySecret = 'a'
       """
 
+    [cl_node.node.env_vars]
+      MY_FIRST_ENV_VAR = "env var value"
+
   # Outputs are the results of deploying a component that can be used by another component
   [cl_node.out]
     # If 'use_cache' equals 'true' we skip component setup when we run the test and return the outputs

--- a/framework/.changeset/v0.9.3.md
+++ b/framework/.changeset/v0.9.3.md
@@ -1,0 +1,1 @@
+- Allow passing custom env vars to Chainlink Node containers

--- a/framework/components/clnode/clnode.go
+++ b/framework/components/clnode/clnode.go
@@ -61,6 +61,7 @@ type NodeInput struct {
 	CustomPorts             []string                      `toml:"custom_ports"`
 	DebuggerPort            int                           `toml:"debugger_port"`
 	ContainerResources      *framework.ContainerResources `toml:"resources"`
+	EnvVars                 map[string]string             `toml:"env_vars"`
 }
 
 // Output represents Chainlink node output, nodes and databases connection URLs
@@ -245,6 +246,7 @@ func newNode(in *Input, pgOut *postgres.Output) (*NodeOut, error) {
 		NetworkAliases: map[string][]string{
 			framework.DefaultNetworkName: {containerName},
 		},
+		Env:          in.Node.EnvVars,
 		ExposedPorts: exposedPorts,
 		Entrypoint:   generateEntryPoint(),
 		WaitingFor: wait.ForHTTP("/").

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -155,6 +155,7 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 					TestSecretsOverrides:    in.NodeSpecs[overrideIdx].Node.TestSecretsOverrides,
 					UserSecretsOverrides:    in.NodeSpecs[overrideIdx].Node.UserSecretsOverrides,
 					ContainerResources:      in.NodeSpecs[overrideIdx].Node.ContainerResources,
+					EnvVars:                 in.NodeSpecs[overrideIdx].Node.EnvVars,
 				},
 			}
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce the capability to pass custom environment variables to Chainlink Node containers, enhancing flexibility for configuration without altering the existing setup.

## What
- **book/src/framework/components/chainlink/node.md**
  - Added documentation for the new `[cl_node.node.env_vars]` configuration block, allowing users to specify custom environment variables for the Chainlink Node.
- **framework/.changeset/v0.9.3.md**
  - Added a changeset file describing the new feature of allowing custom environment variables to be passed to Chainlink Node containers.
- **framework/components/clnode/clnode.go**
  - Modified the `NodeInput` struct to include a new `EnvVars` map to hold custom environment variables.
  - Adjusted the `newNode` function to pass these custom environment variables to the Chainlink Node container upon creation.
- **framework/components/simple_node_set/node_set.go**
  - Ensured that the custom environment variables are also considered in the `simple_node_set` component, allowing them to be passed through to each Chainlink Node in a node set.
