### PR TITLE
set global log level

### DIFF
--- a/tools/flakeguard/go.mod
+++ b/tools/flakeguard/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/chainlink-testing-framework/tools/flakeguard
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/andygrunwald/go-jira v1.16.0

--- a/tools/flakeguard/main.go
+++ b/tools/flakeguard/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"os"
 	"time"
 
@@ -29,13 +28,16 @@ func Execute() {
 }
 
 func init() {
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	zerolog.TimeFieldFormat = time.RFC3339Nano
-	log.Logger = log.Output(zerolog.ConsoleWriter{
-		Out:        io.Discard,
-		TimeFormat: "15:04:05.00", // hh:mm:ss.ss format
-	})
+	// log.Logger = log.Output(zerolog.ConsoleWriter{
+	// Out:        io.Discard,
+	// TimeFormat: "15:04:05.00", // hh:mm:ss.ss format
+	// })
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	log.Info().Msg("FlakeGuard tool initialized - 0.0.1")
 
 	rootCmd.AddCommand(cmd.FindTestsCmd)
 	rootCmd.AddCommand(cmd.RunTestsCmd)

--- a/tools/flakeguard/runner/parser/parser.go
+++ b/tools/flakeguard/runner/parser/parser.go
@@ -291,13 +291,13 @@ func (p *defaultParser) processEvent(state *testProcessingState, rawEv rawEventD
 			return
 		}
 
-		if panicStarted := startPanicRe.MatchString(event.Output); panicStarted {
+		if startPanicRe.MatchString(event.Output) {
 			state.panicDetectionMode = true
 			state.detectedEntries = append(state.detectedEntries, rawEv)
 			return
 		}
 
-		if raceStarted := startRaceRe.MatchString(event.Output); raceStarted {
+		if startRaceRe.MatchString(event.Output) {
 			state.raceDetectionMode = true
 			state.detectedEntries = append(state.detectedEntries, rawEv)
 			return


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the logging level for the flakeguard tool to aid in debugging and refine the event processing logic within the parser to enhance readability and efficiency.

## What
- **tools/flakeguard/main.go**
  - Added `zerolog.SetGlobalLevel(zerolog.DebugLevel)` to set the global logging level to Debug. This will help in producing more detailed logs useful for debugging.

- **tools/flakeguard/runner/parser/parser.go**
  - Simplified conditionals within `processEvent` method by removing unnecessary variable assignments. This streamlines the logic for detecting panic and race conditions in test output, making the code more concise and readable.
