### PR TITLE
[DX-1057] return github.Response from function that lists GH releases

### DIFF
--- a/lib/.changeset/v1.54.2.md
+++ b/lib/.changeset/v1.54.2.md
@@ -1,0 +1,1 @@
+- Return `*github.Response` from some `github` client functions


### PR DESCRIPTION
Required in order to debug intermittent GATI failures in the CI and to gather this kind of data:
```
Downloading cron capability binary version v1.0.2-alpha...
Request to GitHub failed with status code: 401
Response headers:
Header: X-Github-Media-Type: github.v3; format=json
Header: X-Ratelimit-Used: 1
Header: X-Xss-Protection: 0
Header: Content-Type: application/json; charset=utf-8
Header: Content-Length: 95
Header: X-Ratelimit-Reset: 1750068238
Header: Access-Control-Allow-Origin: *
Header: Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
Header: X-Frame-Options: deny
Header: Vary: Accept-Encoding, Accept, X-Requested-With
Header: Server: github.com
Header: Date: Mon, 16 Jun 2025 09:03:58 GMT
Header: X-Ratelimit-Remaining: 59
Header: X-Ratelimit-Resource: core
Header: X-Content-Type-Options: nosniff
Header: Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
Header: Content-Security-Policy: default-src 'none'
Header: X-Github-Request-Id: 19AD:301D05:EC8C6E6:F44D9BE:684FDDFE
Header: X-Ratelimit-Limit: 60
Header: Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
Error: failed to download cron capability: failed to list releases for capabilities: GET https://api.github.com/repos/smartcontractkit/capabilities/releases?per_page=20: 401 Bad credentials []
```
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that functions interacting with GitHub's API now return an additional `*github.Response` object. This change allows calling code to inspect the HTTP response from GitHub, facilitating better handling of errors, rate limiting, or other HTTP-specific information.

## What
- **lib/.changeset/v1.54.2.md**
  - Added a changeset file to document the return of `*github.Response` from some `github` client functions.
- **lib/client/github.go**
  - Modified `DownloadAssetFromRelease` signature to return `([]byte, *github.Response, error)` instead of `([]byte, error)`.
  - Updated all return statements in `DownloadAssetFromRelease` to include `ghResponse`, which is the GitHub response object obtained from the `ListReleases` API call.
