### PR TITLE
ton: minimal service profile

### DIFF
--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -58,6 +58,9 @@ type Input struct {
 	// GAPv2 specific params
 	HostNetworkMode  bool   `toml:"host_network_mode"`
 	CertificatesPath string `toml:"certificates_path"`
+
+	// Ton specific params
+	ServiceProfile string `toml:"service_profile" validate:"omitempty,oneof=core full"`
 }
 
 // Output is a blockchain network output, ChainID and one or more nodes that forms the network

--- a/framework/components/blockchain/ton.go
+++ b/framework/components/blockchain/ton.go
@@ -342,7 +342,6 @@ func newTon(in *Input) (*Output, error) {
 	networkName := network.Name
 	framework.L.Info().Str("output", string(networkName)).Msg("TON Docker network created")
 
-	containers := make([]testcontainers.Container, 0)
 	var genesisContainer testcontainers.Container
 
 	for _, svcName := range services {
@@ -356,7 +355,6 @@ func newTon(in *Input) (*Output, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to start %s: %v", tmpl.Name, err)
 		}
-		containers = append(containers, c)
 
 		if svcName == "genesis" {
 			genesisContainer = c

--- a/framework/examples/myproject/parallel_ton.toml
+++ b/framework/examples/myproject/parallel_ton.toml
@@ -1,9 +1,9 @@
 [blockchain_a]
 type = "ton"
 image = "ghcr.io/neodix42/mylocalton-docker:latest"
-port = "8000"
+port = "9000"
 
 [blockchain_b]
 type = "ton"
 image = "ghcr.io/neodix42/mylocalton-docker:latest"
-port = "8001"
+port = "9001"

--- a/framework/examples/myproject/smoke_ton.toml
+++ b/framework/examples/myproject/smoke_ton.toml
@@ -2,4 +2,3 @@
   type = "ton"
   image = "ghcr.io/neodix42/mylocalton-docker:latest"
   port = "8000"
-  


### PR DESCRIPTION
## Primary Changes

- Added `service_profile` configuration option with "core" (default) and "full" modes
- Core profile runs genesis node only for lightweight testing
- Full profile includes all services (genesis, HTTP API, faucet, explorer, indexing)

## Others
- Refactored service creation to use template-based approach for better maintainability
- Updated port allocation documentation to reflect service-specific assignments
- Removed CI-based service filtering in favor of explicit profile selection
- Updated example configurations to demonstrate profile usage
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the TON blockchain support in the testing framework by introducing service profiles, which allows for more flexible and specific configurations depending on the testing needs. Additionally, the updates facilitate better resource management and customization for TON blockchain testing environments.

## What
- **book/src/framework/components/blockchains/ton.md**
  - Added documentation for the new `service_profile` configuration option.
  - Replaced the default ports section with service profiles explanation and detailed the ports allocation based on the base port.
- **framework/components/blockchain/blockchain.go**
  - Introduced a new `ServiceProfile` field in the `Input` struct for TON specific parameters, allowing the selection between `core` and `full` profiles.
- **framework/components/blockchain/ton.go**
  - Added constants and a map to define the TON service profiles and their corresponding services.
  - Implemented the `resolveServices` method to determine the services to launch based on the selected profile.
  - Modified `newTon` function to utilize the service profile for setting up the TON environment with the appropriate services.
  - Updated service container templates to reflect the changes in service profiles and port configurations.
- **framework/examples/myproject/parallel_ton.toml and framework/examples/myproject/smoke_ton.toml**
  - Updated the base ports in example configurations to reflect the new port allocation strategy.
