### PR TITLE
Chore: Extend input with platform image

### DIFF
--- a/book/src/framework/components/blockchains/sui.md
+++ b/book/src/framework/components/blockchains/sui.md
@@ -9,6 +9,7 @@ API is available on [localhost:9000](http://localhost:9000)
   type = "sui"
   image = "mysten/sui-tools:mainnet" # if omitted default is mysten/sui-tools:devnet
   contracts_dir = "$your_dir"
+  image_platform = "linux/amd64" # default one
 ```
 
 ## Usage

--- a/framework/.changeset/v0.9.5.md
+++ b/framework/.changeset/v0.9.5.md
@@ -1,0 +1,1 @@
+- Sui image platform param

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -58,6 +58,9 @@ type Input struct {
 	// GAPv2 specific params
 	HostNetworkMode  bool   `toml:"host_network_mode"`
 	CertificatesPath string `toml:"certificates_path"`
+
+	// Optional params
+	ImagePlatform *string `toml:"image_platform"`
 }
 
 // Output is a blockchain network output, ChainID and one or more nodes that forms the network

--- a/framework/components/blockchain/sui.go
+++ b/framework/components/blockchain/sui.go
@@ -99,6 +99,12 @@ func newSui(in *Input) (*Output, error) {
 
 	bindPort := fmt.Sprintf("%s/tcp", in.Port)
 
+	// default to amd64, unless otherwise specified
+	imagePlatform := "linux/amd64"
+	if in.ImagePlatform != nil {
+		imagePlatform = *in.ImagePlatform
+	}
+
 	req := testcontainers.ContainerRequest{
 		Image:        in.Image,
 		ExposedPorts: []string{in.Port, DefaultFaucetPort},
@@ -112,7 +118,7 @@ func newSui(in *Input) (*Output, error) {
 			h.PortBindings = framework.MapTheSamePort(bindPort, DefaultFaucetPort)
 			framework.ResourceLimitsFunc(h, in.ContainerResources)
 		},
-		ImagePlatform: "linux/amd64",
+		ImagePlatform: imagePlatform,
 		Env: map[string]string{
 			"RUST_LOG": "off,sui_node=info",
 		},


### PR DESCRIPTION
Allows specifying the `ImagePlatform` field in `Input` which is useful for cases like `sui` to when doing local testing. 

In local we use the `arm64/v8` platform instead of `amd64` for Sui. This might not be available in other chains so it's currently set to an optional config and used only for Sui node spec.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce an optional `ImagePlatform` parameter to the blockchain component configuration, allowing configuration of the image platform for blockchain nodes, and modify the Sui blockchain component to utilize this new parameter if provided, defaulting to "linux/amd64" if not specified. This flexibility can be crucial for environments that require specific image architectures.

## What
- **framework/components/blockchain/blockchain.go**:  
  - Added a new optional field `ImagePlatform *string` to the `Input` struct. This allows specifying the platform of the Docker image to use for the blockchain node, providing flexibility for cross-platform deployments.
- **framework/components/blockchain/sui.go**:  
  - Modified the `newSui` function to use the `ImagePlatform` from the input configuration if available. Defaults to "linux/amd64" if `ImagePlatform` is not specified. This ensures that the specified or default architecture is used when pulling and running the Docker image for the Sui node.
