### PR TITLE
[DX-1255] Fix private plugins build

### DIFF
--- a/framework/.changeset/v0.9.8.md
+++ b/framework/.changeset/v0.9.8.md
@@ -1,0 +1,1 @@
+- Disable private plugins when building CL image

--- a/framework/docker.go
+++ b/framework/docker.go
@@ -360,9 +360,9 @@ func BuildImageOnce(once *sync.Once, dctx, dfile, nameAndTag string) error {
 func BuildImage(dctx, dfile, nameAndTag string) error {
 	dfilePath := filepath.Join(dctx, dfile)
 	if os.Getenv("CTF_CLNODE_DLV") == "true" {
-		return RunCommand("docker", "build", "--build-arg", `GO_GCFLAGS=all=-N -l`, "-t", nameAndTag, "-f", dfilePath, dctx)
+		return RunCommand("docker", "build", "--build-arg", `GO_GCFLAGS=all=-N -l`, "--build-arg", "CHAINLINK_USER=chainlink", "--build-arg", "CL_INSTALL_PRIVATE_PLUGINS=false", "-t", nameAndTag, "-f", dfilePath, dctx)
 	}
-	return RunCommand("docker", "build", "-t", nameAndTag, "-f", dfilePath, dctx)
+	return RunCommand("docker", "build", "--build-arg", "CHAINLINK_USER=chainlink", "--build-arg", "CL_INSTALL_PRIVATE_PLUGINS=false", "-t", nameAndTag, "-f", dfilePath, dctx)
 }
 
 // RemoveTestContainers removes all test containers, volumes and CTF docker network


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that when building the Chainlink node image, private plugins are disabled explicitly by passing `CL_INSTALL_PRIVATE_PLUGINS=false` as a build argument. This modification standardizes the build process to avoid unintentional inclusion of private plugins, enhancing security and consistency across environments.

## What
- **framework/.changeset/v0.9.8.md**
  - Added a changeset file to document the disabling of private plugins in the Chainlink image build process.
- **framework/docker.go**
  - Modified `BuildImage` and `BuildImageOnce` functions to include two new `--build-arg` parameters: `CHAINLINK_USER=chainlink` and `CL_INSTALL_PRIVATE_PLUGINS=false`. This ensures that during the Docker image build process, the environment is set up without private plugins and with a specified user.
