### PR TITLE
Update nethermind ready state validation string

### DIFF
--- a/lib/.changeset/v1.54.4.md
+++ b/lib/.changeset/v1.54.4.md
@@ -1,0 +1,1 @@
+- Update `nethermind` ready state validation string.

--- a/lib/docker/test_env/nethermind_base.go
+++ b/lib/docker/test_env/nethermind_base.go
@@ -182,7 +182,7 @@ func (g *Nethermind) WaitUntilChainIsReady(ctx context.Context, waitTime time.Du
 	if g.GetEthereumVersion() == config_types.EthereumVersion_Eth1 {
 		return nil
 	}
-	waitForFirstBlock := tcwait.NewLogStrategy("Improved post-merge block").WithPollInterval(1 * time.Second).WithStartupTimeout(waitTime)
+	waitForFirstBlock := tcwait.NewLogStrategy("Received New Block").WithPollInterval(1 * time.Second).WithStartupTimeout(waitTime)
 	return waitForFirstBlock.WaitUntilReady(ctx, *g.GetContainer())
 }
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance clarity and accuracy in the Nethermind blockchain client's operational status monitoring by updating a log string used for ready state validation and documenting the update. This aims to improve the readability and maintainability of the codebase.

## What
- **lib/.changeset/v1.54.4.md**
  - Added a changeset file to document the update of the `nethermind` ready state validation string. This helps in tracking changes and their rationale.
- **lib/docker/test_env/nethermind_base.go**
  - Modified the log strategy string from "Improved post-merge block" to "Received New Block" in `WaitUntilChainIsReady` function. This change refines the description of the log strategy to more accurately reflect its purpose, which is to wait for a new block as an indicator that the chain is ready.
