### PR TITLE
TON: return container in the blockchain output

### DIFF
--- a/book/src/framework/components/blockchains/ton.md
+++ b/book/src/framework/components/blockchains/ton.md
@@ -48,6 +48,8 @@ func TestTonSmoke(t *testing.T) {
 
   bc, err := blockchain.NewBlockchainNetwork(in.BlockchainA)
   require.NoError(t, err)
+  // we can also explicitly terminate the container after the test
+  defer bc.Container.Terminate(t.Context())
 
   var client ton.APIClientWrapped
 

--- a/framework/.changeset/v0.10.2.md
+++ b/framework/.changeset/v0.10.2.md
@@ -1,0 +1,1 @@
+- Adds Container field in the TON blockchain output

--- a/framework/components/blockchain/ton.go
+++ b/framework/components/blockchain/ton.go
@@ -123,6 +123,7 @@ func newTon(in *Input) (*Output, error) {
 		Type:          in.Type,
 		Family:        FamilyTon,
 		ContainerName: name,
+		Container:     c,
 		Nodes: []*Node{{
 			// Note: define if we need more access other than the global config(tonutils-go only uses liteclients defined in the config)
 			ExternalHTTPUrl: fmt.Sprintf("%s:%s", "localhost", ports.SimpleServer),

--- a/framework/examples/myproject/smoke_ton_test.go
+++ b/framework/examples/myproject/smoke_ton_test.go
@@ -24,6 +24,8 @@ func TestTonSmoke(t *testing.T) {
 
 	bc, err := blockchain.NewBlockchainNetwork(in.BlockchainA)
 	require.NoError(t, err)
+	// we can also explicitly terminate the container after the test
+	defer bc.Container.Terminate(t.Context())
 
 	var client ton.APIClientWrapped
 	t.Run("setup:connect", func(t *testing.T) {


### PR DESCRIPTION
This PR adds `Container` in the TON blockchain output

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that resources are cleaned up properly after tests by explicitly terminating containers. Also, by adding the Container field to the TON blockchain output, it allows for a direct interface with the container, potentially enabling more detailed manipulation or inspection as part of test teardown or setup procedures. This is crucial for maintaining a clean test environment and avoiding conflicts or resource leakage that could affect subsequent tests.

## What
- **book/src/framework/components/blockchains/ton.md**
  - Added comments to highlight the possibility of explicitly terminating the container after tests. This change instructs developers on how to ensure resources are properly cleaned up.
- **framework/.changeset/v0.10.2.md**
  - New changeset file indicating the addition of the Container field in the TON blockchain output, which is a significant update for the framework.
- **framework/components/blockchain/ton.go**
  - Added the `Container` field to the `Output` struct. This change allows direct access to the container instance, facilitating operations like explicit termination or inspection within the test framework.
- **framework/examples/myproject/smoke_ton_test.go**
  - Similar to the change in the book documentation, added comments and a line of code to explicitly terminate the container after the test. This ensures that the test environment is cleaned up properly, preventing potential conflicts in subsequent tests.
