### PR TITLE
[COP-1575 COP-1573] cache protos and other changes

### DIFF
--- a/framework/components/dockercompose/.changeset/v0.1.6.md
+++ b/framework/components/dockercompose/.changeset/v0.1.6.md
@@ -1,0 +1,3 @@
+- Added caching of protobuf files, to avoid constant download each time Beholder starts
+- Removed dynamic port mapping, since external ports are always static
+- Red Panda images will be pulled from Dockerhub instead of docker.redpanda.com to allow by-passing rate limiting by logging into Dockerhub

--- a/framework/components/dockercompose/chip_ingress_set/docker-compose.yml
+++ b/framework/components/dockercompose/chip_ingress_set/docker-compose.yml
@@ -43,8 +43,10 @@ services:
       retries: 10
 
   redpanda-0:
-    # using a specific version of the redpanda image to exclude potentially breaking changes
-    image: docker.redpanda.com/redpandadata/redpanda:v24.3.16
+    # modified from the original:
+    # - pin point a specific version of the redpanda image to exclude potentially breaking changes
+    # - pull image from dockerhub instead of docker.redpanda.com
+    image: redpandadata/redpanda:v24.3.16
     container_name: redpanda-0
     hostname: redpanda-0
     command:
@@ -74,9 +76,12 @@ services:
       start_period: 1s
 
   redpanda-console:
-    # using a specific version of the console image to ensure compatibility, because v3.x.x uses incompatible configuration format
+
     container_name: redpanda-console
-    image: docker.redpanda.com/redpandadata/console:v2.8.6
+    # modified from the original:
+    # - pin point a specific version of the console image to ensure compatibility, because v3.x.x uses incompatible configuration format
+    # - pull image from dockerhub instead of docker.redpanda.com
+    image: redpandadata/console:v2.8.6
     entrypoint: /bin/sh
     command: -c 'echo "$$CONSOLE_CONFIG_FILE" > /tmp/config.yml; /app/console'
     environment:

--- a/framework/components/dockercompose/go.mod
+++ b/framework/components/dockercompose/go.mod
@@ -7,12 +7,12 @@ replace github.com/smartcontractkit/chainlink-testing-framework/framework => ../
 require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
 	github.com/docker/docker v28.0.4+incompatible
-	github.com/docker/go-connections v0.5.0
 	github.com/google/go-github/v72 v72.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.0.0-00010101000000-000000000000
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.37.0
+	golang.org/x/oauth2 v0.25.0
 )
 
 require (
@@ -65,6 +65,7 @@ require (
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
+	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
@@ -201,7 +202,6 @@ require (
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect

--- a/framework/examples/myproject/go.mod
+++ b/framework/examples/myproject/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/blocto/solana-go-sdk v1.30.0
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/go-resty/resty/v2 v2.16.5
-	github.com/google/go-github/v72 v72.0.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.8.9
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.0.0-20250707095700-c7855f06ddd1
@@ -58,6 +57,7 @@ require (
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
+	github.com/google/go-github/v72 v72.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
@@ -382,7 +382,7 @@ require (
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
-	golang.org/x/oauth2 v0.27.0
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect

--- a/framework/examples/myproject/smoke_chip_ingress_test.go
+++ b/framework/examples/myproject/smoke_chip_ingress_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v72/github"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	chipingressset "github.com/smartcontractkit/chainlink-testing-framework/framework/components/dockercompose/chip_ingress_set"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 )
 
 type ChipConfig struct {
@@ -33,19 +31,10 @@ func TestChipIngressSmoke(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 
-		var client *github.Client
-		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-			ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-			tc := oauth2.NewClient(ctx, ts)
-			client = github.NewClient(tc)
-		} else {
-			client = github.NewClient(nil)
-		}
-
 		createTopicsErr := chipingressset.CreateTopics(ctx, out.RedPanda.KafkaExternalURL, []string{"cre"})
 		require.NoError(t, createTopicsErr, "failed to create topics")
 
-		err := chipingressset.DefaultRegisterAndFetchProtos(ctx, client, []chipingressset.ProtoSchemaSet{
+		err := chipingressset.DefaultRegisterAndFetchProtos(ctx, nil, []chipingressset.ProtoSchemaSet{
 			{
 				URI:           "https://github.com/smartcontractkit/chainlink-protos",
 				Ref:           "95decc005a91a1fd2621af9d9f00cb36d8061067",


### PR DESCRIPTION
- Added caching of protobuf files, to avoid constant download each time Beholder starts
- Removed dynamic port mapping, since external ports are always static
- Red Panda images will be pulled from Dockerhub instead of docker.redpanda.com to allow by-passing rate limiting by logging into Dockerhub
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the handling of protobuf files within the Beholder component, specifically adding caching to avoid repetitive downloads and simplifying GitHub client initialization for fetching protos. Docker components see adjustments in image sources and configuration to enhance performance and reliability. The Chip Ingress setup and test examples are refined for clarity and efficiency, notably removing unnecessary GitHub client creation steps.

## What
- **book/src/framework/components/chipingresset/chip_ingress.md**
  - Removed detailed GitHub client setup in favor of a simplified approach that dynamically creates the client if needed.
  - Added a section on Protobuf caching to store fetched protobuf files locally and reuse them.
- **framework/components/dockercompose/.changeset/v0.1.6.md**
  - New file detailing enhancements including protobuf file caching, removal of dynamic port mapping, and image source adjustments for Red Panda components.
- **framework/components/dockercompose/chip_ingress_set/chip_ingress.go**
  - Removed unused imports and simplified chip ingress setup by eliminating dynamic port mapping and directly using default ports.
- **framework/components/dockercompose/chip_ingress_set/docker-compose.yml**
  - Adjusted image sources for Red Panda and Red Panda Console to use Dockerhub, facilitating easier access and avoiding rate limiting issues.
- **framework/components/dockercompose/chip_ingress_set/protos.go**
  - Introduced caching for protobuf files to minimize repetitive downloads. A new approach for GitHub client creation was also implemented, creating the client dynamically when needed.
- **framework/components/dockercompose/go.mod**
  - Modifications in module dependencies, notably the addition of the `golang.org/x/oauth2` package for OAuth2 functionality, reflecting changes in how GitHub clients are managed.
- **framework/examples/myproject/go.mod**
  - Updated dependencies, reflecting changes across the project, including the addition and adjustment of modules related to GitHub client handling and protobuf processing.
- **framework/examples/myproject/smoke_chip_ingress_test.go**
  - Simplified test setup for Chip Ingress by removing explicit GitHub client creation, leveraging the new dynamic client creation process within the chip ingress component setup.
