### PR TITLE
Extend clclient to support querying /v2/keys/workflow

### DIFF
--- a/framework/clclient/client.go
+++ b/framework/clclient/client.go
@@ -945,6 +945,31 @@ func (c *ChainlinkClient) ImportVRFKey(vrfExportKey *VRFExportKey) (*VRFKey, *ht
 	return vrfKey, resp.RawResponse, err
 }
 
+// ReadWorkflowKeys reads all Workflow keys from the Chainlink node
+func (c *ChainlinkClient) ReadWorkflowKeys() (*WorkflowKeys, *http.Response, error) {
+	workflowKeys := &WorkflowKeys{}
+	framework.L.Info().Str(NodeURL, c.Config.URL).Msg("Reading Workflow Keys")
+	resp, err := c.APIClient.R().
+		SetResult(workflowKeys).
+		Get("/v2/keys/workflow")
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(workflowKeys.Data) == 0 {
+		framework.L.Warn().Str(NodeURL, c.Config.URL).Msg("Found no Workflow Keys on the node")
+	}
+	return workflowKeys, resp.RawResponse, err
+}
+
+// MustReadWorkflowKeys reads all Workflow keys from the Chainlink node
+func (c *ChainlinkClient) MustReadWorkflowKeys() (*WorkflowKeys, *http.Response, error) {
+	workflowKeys, res, err := c.ReadWorkflowKeys()
+	if err != nil {
+		return nil, res, err
+	}
+	return workflowKeys, res, VerifyStatusCode(res.StatusCode, http.StatusOK)
+}
+
 // CreateCSAKey creates a CSA key on the Chainlink node, only 1 CSA key per node
 func (c *ChainlinkClient) CreateCSAKey() (*CSAKey, *http.Response, error) {
 	csaKey := &CSAKey{}

--- a/framework/clclient/models.go
+++ b/framework/clclient/models.go
@@ -211,6 +211,22 @@ type VRFKeys struct {
 	Data []VRFKey `json:"data"`
 }
 
+// WorkflowKeyAttributes is the model that represents the created workflow key attributes when read
+type WorkflowKeyAttributes struct {
+	PublicKey string `json:"publicKey"`
+}
+
+// WorkflowKey is the model that represents the created workflow key when read
+type WorkflowKey struct {
+	ID         string
+	Attributes WorkflowKeyAttributes
+}
+
+// WorkflowKeys is the model that represents the created workflow keys when read
+type WorkflowKeys struct {
+	Data []WorkflowKey `json:"data"`
+}
+
 // OCRKeys is the model that represents the created OCR keys when read
 type OCRKeys struct {
 	Data []OCRKeyData `json:"data"`


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce functionality for reading and managing Workflow keys within the Chainlink client framework. This enhancement is crucial for supporting operations related to Workflow keys, such as reading existing keys from a Chainlink node, which is an addition to the existing capabilities around VRF and CSA keys.

## What
- **framework/clclient/client.go**
  - Added `ReadWorkflowKeys()` function to fetch all Workflow keys from a Chainlink node. This function logs the operation and handles the response, including a warning log if no keys are found.
  - Added `MustReadWorkflowKeys()` function that ensures the Workflow keys are read from the Chainlink node, enforcing a check on the HTTP response status code to be `200 OK`.
- **framework/clclient/models.go**
  - Introduced new types `WorkflowKeyAttributes`, `WorkflowKey`, and `WorkflowKeys` to model the Workflow key data structure. These types are essential for parsing and holding the data fetched from the Chainlink node regarding Workflow keys.
