### PR TITLE
feat: add time advance call to anvil client

### DIFF
--- a/framework/rpc/rpc.go
+++ b/framework/rpc/rpc.go
@@ -58,7 +58,7 @@ func (m *RPCClient) EVMIncreaseTime(seconds uint64) error {
 		"jsonrpc": "2.0",
 		"method":  "evm_increaseTime",
 		"params":  []interface{}{seconds},
-		"id":      rand.Int(),
+		"id":      rand.Int(), //nolint:gosec
 	}
 	if _, err := m.client.R().SetBody(payload).Post(m.URL); err != nil {
 		return errors.Wrap(err, "evm_increaseTime")

--- a/framework/rpc/rpc.go
+++ b/framework/rpc/rpc.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"strconv"

--- a/framework/rpc/rpc.go
+++ b/framework/rpc/rpc.go
@@ -51,6 +51,21 @@ func New(url string, headers http.Header) *RPCClient {
 	}
 }
 
+// EVMIncreaseTime jumps forward in time by `seconds`.
+// The parameter is a JSON number (in seconds)
+func (m *RPCClient) EVMIncreaseTime(seconds uint64) error {
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "evm_increaseTime",
+		"params":  []interface{}{seconds},
+		"id":      rand.Int(),
+	}
+	if _, err := m.client.R().SetBody(payload).Post(m.URL); err != nil {
+		return errors.Wrap(err, "evm_increaseTime")
+	}
+	return nil
+}
+
 // AnvilAutoImpersonate sets auto impersonification to true or false
 func (m *RPCClient) AnvilAutoImpersonate(b bool) error {
 	//nolint:gosec

--- a/framework/rpc/rpc_test.go
+++ b/framework/rpc/rpc_test.go
@@ -272,7 +272,7 @@ func TestRPCAPI(t *testing.T) {
 
 		// Assert the delta is at least the requested advance
 		// (Anvil should add exactly `advance`, but we allow >= to be safe.)
-		require.GreaterOrEqual(t, int64(t2-t1), int64(advance), "timestamp did not advance by expected seconds")
+		require.GreaterOrEqual(t, t2-t1, advance, "timestamp did not advance by expected seconds")
 
 		t.Logf("advanced time by %d seconds: %d -> %d (Δ=%d)", advance, t1, t2, t2-t1)
 	})

--- a/framework/rpc/rpc_test.go
+++ b/framework/rpc/rpc_test.go
@@ -243,4 +243,38 @@ func TestRPCAPI(t *testing.T) {
 			require.GreaterOrEqual(t, int64(block.Transactions().Len()), txnInBlock)
 		}
 	})
+
+	t.Run("(anvil) evm_increaseTime advances timestamp", func(t *testing.T) {
+		ac, err := StartAnvil([]string{"--no-mine"})
+		require.NoError(t, err)
+		client, err := ethclient.Dial(ac.URL)
+		require.NoError(t, err)
+
+		anvil := New(ac.URL, nil)
+
+		// Mine an initial block to establish a baseline timestamp
+		require.NoError(t, anvil.AnvilMine([]interface{}{1}))
+
+		// Read latest header/time
+		h1, err := client.HeaderByNumber(context.Background(), nil)
+		require.NoError(t, err)
+		t1 := h1.Time // uint64 (seconds)
+
+		// Jump forward in time, then mine exactly one block so the new timestamp is materialized
+		advance := uint64(60) // 1 minute
+		require.NoError(t, anvil.EVMIncreaseTime(advance))
+		require.NoError(t, anvil.AnvilMine([]interface{}{1}))
+
+		// Read new header/time
+		h2, err := client.HeaderByNumber(context.Background(), nil)
+		require.NoError(t, err)
+		t2 := h2.Time
+
+		// Assert the delta is at least the requested advance
+		// (Anvil should add exactly `advance`, but we allow >= to be safe.)
+		require.GreaterOrEqual(t, int64(t2-t1), int64(advance), "timestamp did not advance by expected seconds")
+
+		t.Logf("advanced time by %d seconds: %d -> %d (Δ=%d)", advance, t1, t2, t2-t1)
+	})
+
 }


### PR DESCRIPTION
Add support to call the advance time from anvil. This will be useful in the MCMS fork test use cases where we need to advance the timelock time in order to not wait the elapsed time during fork tests.

## AI Summary
This pull request adds support for advancing the EVM time in Anvil via the `evm_increaseTime` RPC method. It introduces a new method in the `RPCClient` and a corresponding integration test to verify its functionality.

**EVM time manipulation support:**

* Added a new method `EVMIncreaseTime` to the `RPCClient` in `rpc.go` to send the `evm_increaseTime` RPC call, allowing tests to programmatically advance the EVM's internal clock.

**Testing:**

* Added an integration test in `rpc_test.go` that verifies the `evm_increaseTime` method correctly advances the blockchain timestamp when used with Anvil. The test mines a block, advances time, mines another block, and checks the timestamp difference.
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a new function for advancing the EVM's time in tests, update the import path for the `math/rand` package to `math/rand/v2`, and add a comprehensive test to validate the `EVMIncreaseTime` function's behavior. These changes are aimed at enhancing testing capabilities in blockchain simulations, particularly for scenarios that require time manipulation.

## What
- **framework/rpc/rpc.go**
  - Import path for `math/rand` updated to `math/rand/v2`. This change modernizes the codebase by adopting the latest version of the `math/rand` package, which may include optimizations or new features.
  - Added the `EVMIncreaseTime` function. This function allows advancing the EVM's virtual time by a specified number of seconds, enabling more dynamic and temporal test scenarios.

- **framework/rpc/rpc_test.go**
  - Added a test case `(anvil) evm_increaseTime advances timestamp` to validate the behavior of the newly introduced `EVMIncreaseTime` function. This test ensures that the blockchain's timestamp advances correctly when the function is invoked, enhancing confidence in time-dependent contract testing.
