### PR TITLE
feat(sui): support host port mapping

### DIFF
--- a/framework/examples/myproject/smoke_ton.toml
+++ b/framework/examples/myproject/smoke_ton.toml
@@ -1,6 +1,6 @@
 [blockchain_a]
   type = "ton"
-  image = "ghcr.io/neodix42/mylocalton-docker:latest"
+  image = "ghcr.io/neodix42/mylocalton-docker:dev"
   port = "8000"
   
   [blockchain_a.custom_env]


### PR DESCRIPTION
Allow a different port other than 9000 for sui to be mapped on the host since 9000 can be consumed by other apps.

Also updated the docker image used by ton smoke as the existing one[ no longer working](https://github.com/smartcontractkit/chainlink-testing-framework/actions/runs/16928769678/job/47969566622)

```
=== RUN   TestTonSmoke/setup:connect
    smoke_ton_test.go:35: 
        	Error Trace:	/home/runner/work/chainlink-testing-framework/chainlink-testing-framework/framework/examples/myproject/smoke_ton_test.go:35
        	Error:      	Received unexpected error:
        	            	Get "http://localhost:8000/localhost.global.config.json": read tcp [::1]:44428->[::1]:8000: read: connection reset by peer
        	Test:       	TestTonSmoke/setup:connect
        	Messages:   	Failed to get config from URL
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-500
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that Sui blockchain components correctly manage default and user-specified ports, improving usability and flexibility. The update in the example project aims to align with development standards by using a development image version.

## What
- `framework/components/blockchain/sui.go`
  - Added an import for `"github.com/docker/go-connections/nat"` to handle NAT port mappings more effectively.
  - Modified the `defaultSui` function to set `in.Port` to `DefaultSuiNodePort` if it's empty, ensuring a default port is always used if not specified by the user.
  - Updated `newSui` function to define `containerPort` as the Sui container's internal default port (`DefaultSuiNodePort`) and use it for container port mappings. This change allows mapping the user-specified host port to the container's internal port.
  - Adjusted `HostConfigModifier` in `testcontainers.ContainerRequest` to use `nat.PortMap` for port bindings, ensuring the correct external to internal port mappings.
  - Changed `ExternalHTTPUrl` and `InternalHTTPUrl` to use `DefaultSuiNodePort` for the internal URL, providing consistency with how the container is accessed internally.
- `framework/examples/myproject/smoke_ton.toml`
  - Updated the `image` configuration for `blockchain_a` from `ghcr.io/neodix42/mylocalton-docker:latest` to `ghcr.io/neodix42/mylocalton-docker:dev`, aligning with development practices by using a development image.
