### PR TITLE
Add port option to Sui

### DIFF
--- a/framework/components/blockchain/sui.go
+++ b/framework/components/blockchain/sui.go
@@ -142,6 +142,7 @@ func newSui(in *Input) (*Output, error) {
 			"start",
 			"--force-regenesis",
 			"--with-faucet",
+			"--fullnode-rpc-port", in.Port,
 		},
 		Files: []testcontainers.ContainerFile{
 			{


### PR DESCRIPTION
- Considers the `Input.Port` option for Sui. Keeps falling back to default port in case of undefined
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes ensure that the Sui component correctly sets the default node port if one is not specified by the user, and it now explicitly sets the `--fullnode-rpc-port` argument when starting the Sui node to enforce the use of the specified port for RPC connections. This improves usability by ensuring the node is accessible on a predictable port and enhances clarity in the node's configuration.

## What
- **framework/components/blockchain/sui.go**
  - Modified `defaultSui` function to set `in.Port` to `DefaultSuiNodePort` if `in.Port` is empty. This makes sure the default port is used when no port is specified.
  - Added `--fullnode-rpc-port` flag with `in.Port` value to the command used to start the Sui node. This explicitly sets the RPC port, ensuring the node listens on the correct port.
