### PR TITLE
[CLD-510]: feat: configurable faucet port for Sui

### DIFF
--- a/framework/.changeset/v0.10.15.md
+++ b/framework/.changeset/v0.10.15.md
@@ -1,0 +1,1 @@
+- Add configurable faucet port for Sui blockchain component

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -55,6 +55,9 @@ type Input struct {
 	ContainerResources *framework.ContainerResources `toml:"resources"`
 	CustomPorts        []string                      `toml:"custom_ports"`
 
+	// Sui specific: faucet port for funding accounts
+	FaucetPort string `toml:"faucet_port"`
+
 	// GAPv2 specific params
 	HostNetworkMode  bool   `toml:"host_network_mode"`
 	CertificatesPath string `toml:"certificates_path"`

--- a/framework/components/blockchain/sui.go
+++ b/framework/components/blockchain/sui.go
@@ -85,6 +85,9 @@ func defaultSui(in *Input) {
 	if in.Port == "" {
 		in.Port = DefaultSuiNodePort
 	}
+	if in.FaucetPort == "" {
+		in.FaucetPort = DefaultFaucetPortNum
+	}
 }
 
 func newSui(in *Input) (*Output, error) {
@@ -127,7 +130,7 @@ func newSui(in *Input) (*Output, error) {
 				nat.Port(DefaultFaucetPort): []nat.PortBinding{
 					{
 						HostIP:   "0.0.0.0",
-						HostPort: DefaultFaucetPortNum,
+						HostPort: in.FaucetPort,
 					},
 				},
 			}
@@ -168,7 +171,7 @@ func newSui(in *Input) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := fundAccount(fmt.Sprintf("http://%s:%s", "127.0.0.1", DefaultFaucetPortNum), suiAccount.SuiAddress); err != nil {
+	if err := fundAccount(fmt.Sprintf("http://%s:%s", "127.0.0.1", in.FaucetPort), suiAccount.SuiAddress); err != nil {
 		return nil, err
 	}
 	return &Output{


### PR DESCRIPTION
The inability for us to provide a different port for the SUI faucet port when running the SUI container means that there is a chance that the port is already being used by other process.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-510
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a configurable faucet port for the Sui blockchain component, enhancing flexibility in network configurations. This allows users to specify a custom faucet port, accommodating scenarios where the default port may conflict with other services or protocols.

## What
- **framework/.changeset/v0.10.15.md**
  - Added a changeset file indicating the addition of configurable faucet port for Sui blockchain component.
- **framework/components/blockchain/blockchain.go**
  - Added `FaucetPort` field to the `Input` struct to allow specifying a custom faucet port for Sui blockchain configurations.
- **framework/components/blockchain/sui.go**
  - Modified `defaultSui` function to set `FaucetPort` to a default value if it is not specified.
  - Updated `newSui` function to use the `FaucetPort` from `Input` struct for port bindings and account funding, enhancing flexibility for Sui network deployments.
