### PR TITLE
[CRE-715] Wait for Red Panda Admin API to be up and running in ready checks

### DIFF
--- a/framework/components/dockercompose/.changeset/v0.1.8.md
+++ b/framework/components/dockercompose/.changeset/v0.1.8.md
@@ -1,0 +1,1 @@
+- Wait for Red Panda Admin API to be up and running in ready checks

--- a/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
+++ b/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
@@ -117,6 +117,7 @@ func New(in *Input) (*Output, error) {
 			wait.ForListeningPort(DEFAULT_RED_PANDA_KAFKA_PORT).WithPollInterval(100*time.Millisecond),
 			wait.NewHostPortStrategy(DEFAULT_RED_PANDA_SCHEMA_REGISTRY_PORT).WithPollInterval(100*time.Millisecond),
 			wait.NewHostPortStrategy(DEFAULT_RED_PANDA_KAFKA_PORT).WithPollInterval(100*time.Millisecond),
+			wait.ForHTTP("/v1/status/ready").WithPort("9644"), // admin API port
 		).WithDeadline(2*time.Minute),
 	).WaitForService(DEFAULT_RED_PANDA_CONSOLE_SERVICE_NAME,
 		wait.ForAll(

--- a/framework/examples/myproject/smoke_chip.toml
+++ b/framework/examples/myproject/smoke_chip.toml
@@ -1,2 +1,2 @@
 [chip_ingress]
-  compose_file='../../components/dockercompose/chip_ingress_set/docker-compose.yml'
+  compose_file='file://../../components/dockercompose/chip_ingress_set/docker-compose.yml'

--- a/framework/examples/myproject/smoke_chip_ingress_test.go
+++ b/framework/examples/myproject/smoke_chip_ingress_test.go
@@ -17,7 +17,7 @@ type ChipConfig struct {
 
 // use config file: smoke_chip.toml
 func TestChipIngressSmoke(t *testing.T) {
-	// t.Skip("skipping smoke test until we have a way to fetch Chip Ingress image")
+	t.Skip("skipping smoke test until we have a way to fetch Chip Ingress image")
 	os.Setenv("CTF_CONFIGS", "smoke_chip.toml")
 	in, err := framework.Load[ChipConfig](t)
 	require.NoError(t, err, "failed to load config")
@@ -46,6 +46,7 @@ func TestChipIngressSmoke(t *testing.T) {
 	})
 
 	t.Run("local protos can be registered", func(t *testing.T) {
+		t.Skip("we can only one run of these nested at a time, because they register the same protos")
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve reliability and functionality around the Docker Compose setup for testing components, specifically focusing on waiting for services to be fully ready before proceeding. Additionally, they adjust how compose files are referenced and manage test execution conditions to better handle the setup and execution of smoke tests.

## What
- **framework/components/dockercompose/.changeset/v0.1.8.md**
  - Added a changeset note about waiting for the Red Panda Admin API to ensure readiness.
- **framework/components/dockercompose/chip_ingress_set/chip_ingress.go**
  - Added a wait condition for Red Panda's Admin API to be up and running, enhancing the startup robustness of dependent services.
- **framework/examples/myproject/smoke_chip.toml**
  - Modified the compose file path to use a `file://` scheme, standardizing path references for better compatibility.
- **framework/examples/myproject/smoke_chip_ingress_test.go**
  - Enabled skipping a smoke test with a note on dependency for fetching Chip Ingress image, ensuring tests don't fail due to unavailable resources.
  - Added a skip condition for a nested test run to avoid conflicts with proto registration, improving test reliability.
