### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-#TODO: remove @smartcontractkit/test-tooling-team after github team rename
-* @smartcontractkit/test-tooling-team @smartcontractkit/devex-tooling
+* @smartcontractkit/devex-tooling


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

```
## Why
The removal of the `@smartcontractkit/test-tooling-team` from the CODEOWNERS file streamlines the review process by directing all future code reviews to the appropriate and updated GitHub team, `@smartcontractkit/devex-tooling`. This change simplifies the management of code ownership.

## What
- **CODEOWNERS**
  - Removed `@smartcontractkit/test-tooling-team` from code owners.
  - Retained `@smartcontractkit/devex-tooling` as the sole code owner. This change ensures that all code reviews are directed to the currently active and relevant team.
```
