### PR TITLE
[CRE-739] Pass all environment variables to Docker Compose

### DIFF
--- a/framework/components/dockercompose/.changeset/v0.1.10.md
+++ b/framework/components/dockercompose/.changeset/v0.1.10.md
@@ -1,0 +1,1 @@
+- Pass all environment variables to Docker Compose

--- a/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
+++ b/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
@@ -94,11 +94,21 @@ func New(in *Input) (*Output, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
+	// Start the stackwith all environment variables from the host process
+	// set BASIC_AUTH_ENABLED and BASIC_AUTH_PREFIX to false and empty string and allow them to be overridden by the host process
+	envVars := make(map[string]string)
+	envVars["BASIC_AUTH_ENABLED"] = "false"
+	envVars["BASIC_AUTH_PREFIX"] = ""
+
+	for _, env := range os.Environ() {
+		pair := strings.SplitN(env, "=", 2)
+		if len(pair) == 2 {
+			envVars[pair[0]] = pair[1]
+		}
+	}
+
 	upErr := stack.
-		WithEnv(map[string]string{
-			"BASIC_AUTH_ENABLED": "false",
-			"BASIC_AUTH_PREFIX":  "",
-		}).
+		WithEnv(envVars).
 		Up(ctx)
 
 	if upErr != nil {


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes enhance the Docker Compose environment setup process by dynamically passing all host environment variables to the Docker Compose context. This allows for more flexible configuration of services without hardcoding or limiting environment variables, enabling external customization and potentially resolving issues where certain environment configurations are required for the services to operate correctly.

## What
- **framework/components/dockercompose/.changeset/v0.1.10.md**
  - Added a changeset file to document the new feature of passing all environment variables to Docker Compose.
- **framework/components/dockercompose/chip_ingress_set/chip_ingress.go**
  - Modified the environment variable setup logic to dynamically include all environment variables from the host process, with specific defaults for `BASIC_AUTH_ENABLED` and `BASIC_AUTH_PREFIX` that can be overridden by the host process. This change makes the service configuration more flexible and adaptable to different deployment environments.
