### PR TITLE
[CRE-739] clnode volume relative paths store

### DIFF
--- a/framework/.changeset/v0.10.16.md
+++ b/framework/.changeset/v0.10.16.md
@@ -1,1 +1,2 @@
 - Use volumes for user's home directory and `config` folder for the CL node
+- Store cached config on absolute path if the relative doesn't work

--- a/framework/.changeset/v0.10.16.md
+++ b/framework/.changeset/v0.10.16.md
@@ -1,0 +1,1 @@
+- Use volumes for user's home directory and `config` folder for the CL node

--- a/framework/config.go
+++ b/framework/config.go
@@ -293,7 +293,17 @@ func Store[T any](cfg *T) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(DefaultConfigDir, cachedOutName), d, 0600)
+
+	writePath := filepath.Join(DefaultConfigDir, cachedOutName)
+	if _, err := os.Stat(writePath); err != nil {
+		var absErr error
+		writePath, absErr = filepath.Abs(cachedOutName)
+		if absErr != nil {
+			return fmt.Errorf("error getting absolute path for config file %s: %w", cachedOutName, absErr)
+		}
+	}
+
+	return os.WriteFile(writePath, d, 0600)
 }
 
 // JSONStrDuration is JSON friendly duration that can be parsed from "1h2m0s" Go format


### PR DESCRIPTION
This pull request introduces improvements to how the Chainlink node's configuration and state are managed in the test framework. The main enhancements include using Docker volumes for persistent storage of the user's home directory and configuration folder, and improving the reliability of config file caching by falling back to an absolute path if writing to the default relative path fails.

Persistent storage for Chainlink node containers:

* Added Docker volumes for the user's home directory and the `config` folder in the Chainlink node container, ensuring persistent storage of configuration and state files (`clnode.go`, constants and container mounts). [[1]](diffhunk://#diff-f530bdc861063c4ca729b6407b58da19dc6d747e3ec9ca50673af586de3d1829R32-R33) [[2]](diffhunk://#diff-f530bdc861063c4ca729b6407b58da19dc6d747e3ec9ca50673af586de3d1829R258-R274)

Config file caching improvements:

* Updated the config caching logic to attempt storing the cached config on an absolute path if writing to the default relative path fails, improving robustness in different environments (`framework/config.go`).

Documentation:

* Updated the changeset to reflect the use of volumes for persistent storage and the improvement to config caching (`framework/.changeset/v0.10.16.md`).