### PR TITLE
[CRE-739] one more time with beholder's ready check

### DIFF
--- a/.github/workflows/framework-dockercompose-tests.yml
+++ b/.github/workflows/framework-dockercompose-tests.yml
@@ -1,0 +1,82 @@
+name: Framework Docker Compose Tests
+on:
+  push:
+
+jobs:
+  test:
+    defaults:
+      run:
+        working-directory: framework/examples/myproject
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: TestChipIngressSmoke
+            config: smoke_chip.toml
+            count: 1
+            timeout: 10m
+    name: ${{ matrix.test.name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_CTF_READ_ACCESS_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr-private
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: ${{ format('{0},{1}', secrets.AWS_ACCOUNT_ID_SDLC, secrets.AWS_ACCOUNT_ID_PROD) }}
+        env:
+          AWS_REGION: us-west-2
+
+      - name: Check for changes in Docker Components
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'framework/components/dockercompose/**'
+              - '.github/workflows/framework-components-tests.yml'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.0'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: go-modules-${{ hashFiles('framework/examples/myproject/go.sum') }}-${{ runner.os }}-framework-golden-examples
+          restore-keys: |
+            go-modules-${{ runner.os }}-framework-golden-examples
+            go-modules-${{ runner.os }}
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run System Tests
+        if: steps.changes.outputs.src == 'true'
+        env:
+          CTF_CONFIGS: ${{ matrix.test.config }}
+        run: |
+          go test -timeout ${{ matrix.test.timeout }} -v -count ${{ matrix.test.count }} -run ${{ matrix.test.name }}
+
+      - name: Upload Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-logs-${{ matrix.test.name }}
+          path: framework/examples/myproject/logs
+          retention-days: 1

--- a/.github/workflows/framework-dockercompose-tests.yml
+++ b/.github/workflows/framework-dockercompose-tests.yml
@@ -70,6 +70,7 @@ jobs:
         if: steps.changes.outputs.src == 'true'
         env:
           CTF_CONFIGS: ${{ matrix.test.config }}
+          CHIP_INGRESS_IMAGE: ${{ secrets.AWS_ACCOUNT_ID_PROD }}.dkr.ecr.us-west-2.amazonaws.com/atlas-chip-ingress:qa-latest
         run: |
           go test -timeout ${{ matrix.test.timeout }} -v -count ${{ matrix.test.count }} -run ${{ matrix.test.name }}
 

--- a/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
+++ b/framework/components/dockercompose/chip_ingress_set/chip_ingress.go
@@ -128,6 +128,8 @@ func New(in *Input) (*Output, error) {
 			wait.NewHostPortStrategy(DEFAULT_RED_PANDA_SCHEMA_REGISTRY_PORT).WithPollInterval(100*time.Millisecond),
 			wait.NewHostPortStrategy(DEFAULT_RED_PANDA_KAFKA_PORT).WithPollInterval(100*time.Millisecond),
 			wait.ForHTTP("/v1/status/ready").WithPort("9644"), // admin API port
+			// Critical: Use the official schema registry health endpoint
+			wait.ForHTTP("/status/ready").WithPort(DEFAULT_RED_PANDA_SCHEMA_REGISTRY_PORT).WithPollInterval(100*time.Millisecond),
 		).WithDeadline(2*time.Minute),
 	).WaitForService(DEFAULT_RED_PANDA_CONSOLE_SERVICE_NAME,
 		wait.ForAll(

--- a/framework/components/dockercompose/chip_ingress_set/protos.go
+++ b/framework/components/dockercompose/chip_ingress_set/protos.go
@@ -548,6 +548,8 @@ func registerAllWithTopologicalSorting(
 // checkSchemaExists checks if a schema already exists in the registry
 func checkSchemaExists(registryURL, subject string) (int, bool) {
 	url := fmt.Sprintf("%s/subjects/%s/versions", registryURL, subject)
+	// Force IPv4 to avoid Docker IPv6 port forwarding issues
+	url = strings.Replace(url, "localhost", "127.0.0.1", 1)
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -592,6 +594,9 @@ func registerSingleProto(
 	}
 
 	url := fmt.Sprintf("%s/subjects/%s/versions", registryURL, subject)
+	// Force IPv4 to avoid Docker IPv6 port forwarding issues
+	url = strings.Replace(url, "localhost", "127.0.0.1", 1)
+	framework.L.Debug().Msgf("Registering schema to URL: %s", url)
 
 	resp, respErr := http.Post(url, "application/vnd.schemaregistry.v1+json", bytes.NewReader(payload))
 	if respErr != nil {

--- a/framework/examples/myproject/smoke_chip_ingress_test.go
+++ b/framework/examples/myproject/smoke_chip_ingress_test.go
@@ -2,7 +2,6 @@ package examples
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -17,8 +16,6 @@ type ChipConfig struct {
 
 // use config file: smoke_chip.toml
 func TestChipIngressSmoke(t *testing.T) {
-	t.Skip("skipping smoke test until we have a way to fetch Chip Ingress image")
-	os.Setenv("CTF_CONFIGS", "smoke_chip.toml")
 	in, err := framework.Load[ChipConfig](t)
 	require.NoError(t, err, "failed to load config")
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The pull request updates the health check endpoint for the Red Panda schema registry service within the Docker Compose setup. This change aims to ensure that the health check uses the official schema registry health endpoint, improving the reliability and correctness of the service's health monitoring.

## What
- **framework/components/dockercompose/chip_ingress_set/chip_ingress.go**
  - Added a new health check endpoint for the Red Panda schema registry service using the official `/status/ready` path with the appropriate port and poll interval. This enhances the accuracy of service health status monitoring.
