### PR TITLE
Revert "adding exclude files + other changes to get registration to work for me"

### DIFF
--- a/framework/components/dockercompose/chip_ingress_set/protos.go
+++ b/framework/components/dockercompose/chip_ingress_set/protos.go
@@ -29,7 +29,6 @@ type ProtoSchemaSet struct {
 	Ref           string   `toml:"ref"`            // ref or tag or commit SHA
 	Folders       []string `toml:"folders"`        // if not provided, all protos will be fetched, otherwise only protos in these folders will be fetched
 	SubjectPrefix string   `toml:"subject_prefix"` // optional prefix for subjects
-	ExcludeFiles  []string `toml:"exclude_files"`  // files to exclude from registration (e.g., ['workflows/v2/execution_status.proto'])
 }
 
 // SubjectNamingStrategyFn is a function that is used to determine the subject name for a given proto file in a given repo
@@ -51,6 +50,7 @@ func validateRepoConfiguration(repoConfig ProtoSchemaSet) error {
 		if repoConfig.Ref != "" {
 			return errors.New("ref is not supported with local protos with 'file://' prefix")
 		}
+
 		return nil
 	}
 
@@ -76,13 +76,9 @@ func DefaultRegisterAndFetchProtos(ctx context.Context, client *github.Client, p
 }
 
 func RegisterAndFetchProtos(ctx context.Context, client *github.Client, protoSchemaSets []ProtoSchemaSet, schemaRegistryURL string, repoToSubjectNamingStrategy RepositoryToSubjectNamingStrategyFn) error {
-	framework.L.Info().Msgf("Registering and fetching protos from %d repositories", len(protoSchemaSets))
+	framework.L.Debug().Msgf("Registering and fetching protos from %d repositories", len(protoSchemaSets))
 
 	for _, protoSchemaSet := range protoSchemaSets {
-		framework.L.Debug().Msgf("Processing proto schema set: %s", protoSchemaSet.URI)
-		if len(protoSchemaSet.ExcludeFiles) > 0 {
-			framework.L.Debug().Msgf("Excluding files: %s", strings.Join(protoSchemaSet.ExcludeFiles, ", "))
-		}
 		if valErr := validateRepoConfiguration(protoSchemaSet); valErr != nil {
 			return errors.Wrapf(valErr, "invalid repo configuration for schema set: %v", protoSchemaSet)
 		}
@@ -93,18 +89,22 @@ func RegisterAndFetchProtos(ctx context.Context, client *github.Client, protoSch
 			return client
 		}
 
+		var client *github.Client
+
 		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 			ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 			tc := oauth2.NewClient(ctx, ts)
-			return github.NewClient(tc)
+			client = github.NewClient(tc)
+		} else {
+			framework.L.Warn().Msg("GITHUB_TOKEN is not set, using unauthenticated GitHub client. This may cause rate limiting issues when downloading proto files")
+			client = github.NewClient(nil)
 		}
 
-		framework.L.Warn().Msg("GITHUB_TOKEN is not set, using unauthenticated GitHub client. This may cause rate limiting issues when downloading proto files")
-		return github.NewClient(nil)
+		return client
 	}
 
 	for _, protoSchemaSet := range protoSchemaSets {
-		protos, protosErr := fetchProtoFilesInFolders(ctx, ghClientFn, protoSchemaSet.URI, protoSchemaSet.Ref, protoSchemaSet.Folders, protoSchemaSet.ExcludeFiles)
+		protos, protosErr := fetchProtoFilesInFolders(ctx, ghClientFn, protoSchemaSet.URI, protoSchemaSet.Ref, protoSchemaSet.Folders)
 		if protosErr != nil {
 			return errors.Wrapf(protosErr, "failed to fetch protos from %s", protoSchemaSet.URI)
 		}
@@ -129,7 +129,7 @@ func RegisterAndFetchProtos(ctx context.Context, client *github.Client, protoSch
 			subjects[proto.Path] = subjectMessage
 		}
 
-		registerErr := registerAllWithTopologicalSorting(schemaRegistryURL, protoMap, subjects, protoSchemaSet.Folders)
+		registerErr := registerAllWithTopologicalSortingByTrial(schemaRegistryURL, protoMap, subjects)
 		if registerErr != nil {
 			return errors.Wrapf(registerErr, "failed to register protos from %s", protoSchemaSet.URI)
 		}
@@ -168,63 +168,45 @@ func extractPackageNameWithRegex(protoSrc string) (string, error) {
 	return matches[1], nil
 }
 
-// extractTopLevelMessageNamesWithRegex extracts top-level message and enum names from a proto file using regex.
+// we use simple regex to extract top-level message names from a proto file
+// so that we don't need to parse the proto file with a parser (which would require a lot of dependencies)
 func extractTopLevelMessageNamesWithRegex(protoSrc string) ([]string, error) {
-	// Extract message names
-	messageMatches := regexp.MustCompile(`(?m)^\s*message\s+(\w+)\s*{`).FindAllStringSubmatch(protoSrc, -1)
+	matches := regexp.MustCompile(`(?m)^\s*message\s+(\w+)\s*{`).FindAllStringSubmatch(protoSrc, -1)
 	var names []string
-	for _, match := range messageMatches {
-		if len(match) >= 2 {
-			names = append(names, match[1])
-		}
-	}
-
-	// Extract enum names
-	enumMatches := regexp.MustCompile(`(?m)^\s*enum\s+(\w+)\s*{`).FindAllStringSubmatch(protoSrc, -1)
-	for _, match := range enumMatches {
+	for _, match := range matches {
 		if len(match) >= 2 {
 			names = append(names, match[1])
 		}
 	}
 
 	if len(names) == 0 {
-		return nil, fmt.Errorf("no message or enum names found in proto source")
+		return nil, fmt.Errorf("no message names found in %s", protoSrc)
 	}
 
 	return names, nil
 }
 
-// extractImportStatements extracts import statements from a proto source file using regex.
-func extractImportStatements(protoSrc string) []string {
-	matches := regexp.MustCompile(`(?m)^\s*import\s+"([^"]+)"\s*;`).FindAllStringSubmatch(protoSrc, -1)
-	var imports []string
-	for _, match := range matches {
-		if len(match) >= 2 {
-			imports = append(imports, match[1])
-		}
-	}
-	return imports
-}
+// Fetches .proto files from a GitHub repo optionally scoped to specific folders. It is recommended to use `*github.Client` with auth token to avoid rate limiting.
+func fetchProtoFilesInFolders(ctx context.Context, clientFn func() *github.Client, uri, ref string, folders []string) ([]protoFile, error) {
+	framework.L.Debug().Msgf("Fetching proto files from %s in folders: %s", uri, strings.Join(folders, ", "))
 
-// fetchProtoFilesInFolders fetches .proto files from a GitHub repo optionally scoped to specific folders.
-// It is recommended to use `*github.Client` with auth token to avoid rate limiting.
-func fetchProtoFilesInFolders(ctx context.Context, clientFn func() *github.Client, uri, ref string, folders []string, excludeFiles []string) ([]protoFile, error) {
 	if strings.HasPrefix(uri, "file://") {
-		return fetchProtosFromFilesystem(uri, folders, excludeFiles)
+		return fetchProtosFromFilesystem(uri, folders)
 	}
 
 	parts := strings.Split(strings.TrimPrefix(uri, "https://"), "/")
-	return fetchProtosFromGithub(ctx, clientFn, parts[1], parts[2], ref, folders, excludeFiles)
+
+	return fetchProtosFromGithub(ctx, clientFn, parts[1], parts[2], ref, folders)
 }
 
-func fetchProtosFromGithub(ctx context.Context, clientFn func() *github.Client, owner, repository, ref string, folders []string, excludeFiles []string) ([]protoFile, error) {
-	cachedFiles, found, cacheErr := loadCachedProtoFiles(owner, repository, ref, folders, excludeFiles)
+func fetchProtosFromGithub(ctx context.Context, clientFn func() *github.Client, owner, repository, ref string, folders []string) ([]protoFile, error) {
+	cachedFiles, found, cacheErr := loadCachedProtoFiles(owner, repository, ref, folders)
+	if cacheErr != nil {
+		framework.L.Warn().Msgf("Failed to load cached proto files for %s/%s at ref %s: %v", owner, repository, ref, cacheErr)
+	}
 	if cacheErr == nil && found {
 		framework.L.Debug().Msgf("Using cached proto files for %s/%s at ref %s", owner, repository, ref)
 		return cachedFiles, nil
-	}
-	if cacheErr != nil {
-		framework.L.Warn().Msgf("Failed to load cached proto files for %s/%s at ref %s: %v", owner, repository, ref, cacheErr)
 	}
 
 	client := clientFn()
@@ -248,11 +230,13 @@ searchLoop:
 		}
 
 		// if folders are specified, check prefix match
+		var folderFound string
 		if len(folders) > 0 {
 			matched := false
 			for _, folder := range folders {
 				if strings.HasPrefix(*entry.Path, strings.TrimSuffix(folder, "/")+"/") {
 					matched = true
+					folderFound = folder
 					break
 				}
 			}
@@ -261,25 +245,10 @@ searchLoop:
 			}
 		}
 
-		// if excludeFiles are specified, check if the file should be excluded
-		if len(excludeFiles) > 0 {
-			excluded := false
-			for _, exclude := range excludeFiles {
-				if strings.HasPrefix(*entry.Path, exclude) {
-					framework.L.Debug().Msgf("Excluding proto file %s (matches exclude pattern: %s)", *entry.Path, exclude)
-					excluded = true
-					break
-				}
-			}
-			if excluded {
-				continue searchLoop
-			}
-		}
-
 		rawURL := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", owner, repository, sha, *entry.Path)
 		resp, respErr := http.Get(rawURL)
 		if respErr != nil {
-			return nil, errors.Wrapf(respErr, "failed to fetch %s", *entry.Path)
+			return nil, errors.Wrapf(respErr, "failed tofetch %s", *entry.Path)
 		}
 		defer resp.Body.Close()
 
@@ -292,18 +261,25 @@ searchLoop:
 			return nil, errors.Wrapf(bodyErr, "failed to read body for %s", *entry.Path)
 		}
 
+		// subtract the folder from the path if it was provided, because if it is imported by some other protos
+		// most probably it will be imported as a relative path, so we need to remove the folder from the path
+		protoPath := *entry.Path
+		if folderFound != "" {
+			protoPath = strings.TrimPrefix(protoPath, strings.TrimSuffix(folderFound, "/")+"/")
+		}
+
 		files = append(files, protoFile{
 			Name:    filepath.Base(*entry.Path),
-			Path:    *entry.Path,
+			Path:    protoPath,
 			Content: string(body),
 		})
 	}
 
+	framework.L.Debug().Msgf("Fetched %d proto files from Github's %s/%s", len(files), owner, repository)
+
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no proto files found in %s/%s in folders %s", owner, repository, strings.Join(folders, ", "))
 	}
-
-	framework.L.Debug().Msgf("Fetched %d proto files from %s/%s", len(files), owner, repository)
 
 	saveErr := saveProtoFilesToCache(owner, repository, ref, files)
 	if saveErr != nil {
@@ -313,7 +289,7 @@ searchLoop:
 	return files, nil
 }
 
-func loadCachedProtoFiles(owner, repository, ref string, folders []string, excludeFiles []string) ([]protoFile, bool, error) {
+func loadCachedProtoFiles(owner, repository, ref string, _ []string) ([]protoFile, bool, error) {
 	cachePath, cacheErr := cacheFilePath(owner, repository, ref)
 	if cacheErr != nil {
 		return nil, false, errors.Wrapf(cacheErr, "failed to get cache file path for %s/%s at ref %s", owner, repository, ref)
@@ -323,7 +299,7 @@ func loadCachedProtoFiles(owner, repository, ref string, folders []string, exclu
 		return nil, false, nil // cache not found
 	}
 
-	cachedFiles, cachedErr := fetchProtosFromFilesystem("file://"+cachePath, folders, excludeFiles)
+	cachedFiles, cachedErr := fetchProtosFromFilesystem("file://"+cachePath, []string{}) // ignore folders since, we already filtered them when fetching from GitHub
 	if cachedErr != nil {
 		return nil, false, errors.Wrapf(cachedErr, "failed to load cached proto files from %s", cachePath)
 	}
@@ -340,14 +316,15 @@ func saveProtoFilesToCache(owner, repository, ref string, files []protoFile) err
 	for _, file := range files {
 		path := filepath.Join(cachePath, file.Path)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			return errors.Wrapf(err, "failed to create directory for cache file %s", path)
+			return errors.Wrapf(err, "failed to create directory for cache file %s", cachePath)
 		}
 		if writeErr := os.WriteFile(path, []byte(file.Content), 0755); writeErr != nil {
-			return errors.Wrapf(writeErr, "failed to write cached proto file to %s", path)
+			return errors.Wrapf(writeErr, "failed to write cached proto files to %s", cachePath)
 		}
 	}
 
 	framework.L.Debug().Msgf("Saved %d proto files to cache at %s", len(files), cachePath)
+
 	return nil
 }
 
@@ -359,10 +336,10 @@ func cacheFilePath(owner, repository, ref string) (string, error) {
 	return filepath.Join(homeDir, ".local", "share", "beholder", "protobufs", owner, repository, ref), nil
 }
 
-func fetchProtosFromFilesystem(uri string, folders []string, excludeFiles []string) ([]protoFile, error) {
+func fetchProtosFromFilesystem(uri string, folders []string) ([]protoFile, error) {
 	var files []protoFile
-	protoDirPath := strings.TrimPrefix(uri, "file://")
 
+	protoDirPath := strings.TrimPrefix(uri, "file://")
 	walkErr := filepath.Walk(protoDirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -372,39 +349,24 @@ func fetchProtosFromFilesystem(uri string, folders []string, excludeFiles []stri
 			return nil
 		}
 
-		if !strings.HasSuffix(path, ".proto") {
-			return nil
-		}
-
-		relativePath := strings.TrimPrefix(strings.TrimPrefix(path, protoDirPath), "/")
-
-		// if folders are specified, check prefix match
+		var folderFound string
 		if len(folders) > 0 {
 			matched := false
 			for _, folder := range folders {
-				if strings.HasPrefix(relativePath, folder) {
+				if strings.HasPrefix(strings.TrimPrefix(strings.TrimPrefix(path, protoDirPath), "/"), folder) {
 					matched = true
+					folderFound = folder
 					break
 				}
 			}
+
 			if !matched {
 				return nil
 			}
 		}
 
-		// if excludeFiles are specified, check if the file should be excluded
-		if len(excludeFiles) > 0 {
-			excluded := false
-			for _, exclude := range excludeFiles {
-				if strings.HasPrefix(relativePath, exclude) {
-					framework.L.Debug().Msgf("Excluding proto file %s (matches exclude pattern: %s)", relativePath, exclude)
-					excluded = true
-					break
-				}
-			}
-			if excluded {
-				return nil
-			}
+		if !strings.HasSuffix(path, ".proto") {
+			return nil
 		}
 
 		content, contentErr := os.ReadFile(path)
@@ -412,24 +374,32 @@ func fetchProtosFromFilesystem(uri string, folders []string, excludeFiles []stri
 			return errors.Wrapf(contentErr, "failed to read file at %s", path)
 		}
 
+		// subtract the folder from the path if it was provided, because if it is imported by some other protos
+		// most probably it will be imported as a relative path, so we need to remove the folder from the path
+		protoPath := strings.TrimPrefix(strings.TrimPrefix(path, protoDirPath), "/")
+		if folderFound != "" {
+			protoPath = strings.TrimPrefix(strings.TrimPrefix(protoPath, folderFound), strings.TrimSuffix(folderFound, "/"))
+			protoPath = strings.TrimPrefix(protoPath, "/")
+		}
+
 		files = append(files, protoFile{
 			Name:    filepath.Base(path),
-			Path:    relativePath,
+			Path:    protoPath,
 			Content: string(content),
 		})
 
 		return nil
 	})
-
 	if walkErr != nil {
 		return nil, errors.Wrapf(walkErr, "failed to walk through directory %s", protoDirPath)
 	}
+
+	framework.L.Debug().Msgf("Fetched %d proto files from local %s", len(files), protoDirPath)
 
 	if len(files) == 0 {
 		return nil, fmt.Errorf("no proto files found in '%s' in folders %s", protoDirPath, strings.Join(folders, ", "))
 	}
 
-	framework.L.Debug().Msgf("Fetched %d proto files from local %s", len(files), protoDirPath)
 	return files, nil
 }
 
@@ -452,124 +422,72 @@ type schemaStatus struct {
 	Version    int
 }
 
-// registerAllWithTopologicalSorting registers protos in dependency order using topological sorting
-func registerAllWithTopologicalSorting(
+// registerAllWithTopologicalSortingByTrial tries to register protos that have not been registered yet, and if it fails, it tries again with a different order
+// it keeps doing this until all protos are registered or it fails to register any more protos
+func registerAllWithTopologicalSortingByTrial(
 	schemaRegistryURL string,
 	protoMap map[string]string, // path -> proto source
 	subjectMap map[string]string, // path -> subject
-	folders []string, // folders configuration used to determine import prefix transformations
 ) error {
-	framework.L.Info().Msgf("Registering %d protobuf schemas", len(protoMap))
-
-	// Build dependency graph and sort topologically
-	dependencies, depErr := buildDependencyGraph(protoMap)
-	if depErr != nil {
-		return errors.Wrap(depErr, "failed to build dependency graph")
-	}
-
-	sortedFiles, sortErr := topologicalSort(dependencies)
-	if sortErr != nil {
-		return errors.Wrap(sortErr, "failed to sort files topologically")
-	}
-
-	framework.L.Debug().Msgf("Registration order (topologically sorted): %v", sortedFiles)
-
+	framework.L.Info().Msgf("🔄 registering %d protobuf schemas", len(protoMap))
 	schemas := map[string]*schemaStatus{}
 	for path, src := range protoMap {
 		schemas[path] = &schemaStatus{Source: src}
 	}
 
-	// Register files in topological order
-	for _, path := range sortedFiles {
-		schema, exists := schemas[path]
-		if !exists {
-			framework.L.Warn().Msgf("File %s not found in schemas map", path)
-			continue
-		}
+	refs := []map[string]any{}
 
-		if schema.Registered {
-			continue
-		}
+	for {
+		progress := false
+		failures := []string{}
 
-		subject, ok := subjectMap[path]
-		if !ok {
-			return fmt.Errorf("no subject found for %s", path)
-		}
-
-		// Determine which folder prefixes should be stripped based on configuration
-		prefixesToStrip := determineFolderPrefixesToStrip(folders)
-
-		// Build references only for files that have dependencies
-		var fileRefs []map[string]any
-		if deps, hasDeps := dependencies[path]; hasDeps && len(deps) > 0 {
-			for _, dep := range deps {
-				if depSubject, depExists := subjectMap[dep]; depExists {
-					// The schema registry expects import names without the configured folder prefixes
-					// So if folders=["workflows"] and the import is "workflows/v1/metadata.proto",
-					// the name should be "v1/metadata.proto"
-					importName := stripFolderPrefix(dep, prefixesToStrip)
-
-					fileRefs = append(fileRefs, map[string]any{
-						"name":    importName,
-						"subject": depSubject,
-						"version": 1,
-					})
-				}
+		for path, schema := range schemas {
+			if schema.Registered {
+				continue
 			}
-		}
 
-		// Check if schema is already registered
-		if existingID, exists := checkSchemaExists(schemaRegistryURL, subject); exists {
-			framework.L.Debug().Msgf("Schema %s already exists with ID %d, skipping registration", subject, existingID)
+			subject, ok := subjectMap[path]
+			if !ok {
+				failures = append(failures, fmt.Sprintf("%s: no subject found", path))
+				continue
+			}
+
+			singleProtoFailures := []error{}
+			framework.L.Debug().Msgf("🔄 registering %s as %s", path, subject)
+			_, registerErr := registerSingleProto(schemaRegistryURL, subject, schema.Source, refs)
+			if registerErr != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", path, registerErr))
+				singleProtoFailures = append(singleProtoFailures, registerErr)
+				continue
+			}
+
 			schema.Registered = true
-			schema.Version = existingID
-			continue
+			schema.Version = 1
+			refs = append(refs, map[string]any{
+				"name":    path,
+				"subject": subject,
+				"version": 1,
+			})
+
+			framework.L.Info().Msgf("✔ registered: %s as %s", path, subject)
+
+			progress = true
 		}
 
-		// The schema registry expects import statements without the configured folder prefixes
-		// Transform the schema content to remove these prefixes from import statements
-		modifiedSchema := transformSchemaContent(schema.Source, prefixesToStrip)
-
-		_, registerErr := registerSingleProto(schemaRegistryURL, subject, modifiedSchema, fileRefs)
-		if registerErr != nil {
-			return errors.Wrapf(registerErr, "failed to register %s as %s", path, subject)
+		if !progress {
+			if len(failures) > 0 {
+				framework.L.Error().Msg("❌ Failed to register remaining schemas:")
+				for _, msg := range failures {
+					framework.L.Error().Msg("  " + msg)
+				}
+				return fmt.Errorf("unable to register %d schemas", len(failures))
+			}
+			break
 		}
-
-		schema.Registered = true
-		schema.Version = 1
-
-		framework.L.Info().Msgf("✔ Registered: %s as %s", path, subject)
 	}
 
 	framework.L.Info().Msgf("✅ Successfully registered %d schemas", len(protoMap))
 	return nil
-}
-
-// checkSchemaExists checks if a schema already exists in the registry
-func checkSchemaExists(registryURL, subject string) (int, bool) {
-	url := fmt.Sprintf("%s/subjects/%s/versions", registryURL, subject)
-
-	resp, err := http.Get(url)
-	if err != nil {
-		framework.L.Debug().Msgf("Failed to check schema existence for %s: %v", subject, err)
-		return 0, false
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == 200 {
-		var versions []struct {
-			ID int `json:"id"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&versions); err != nil {
-			framework.L.Debug().Msgf("Failed to decode versions for %s: %v", subject, err)
-			return 0, false
-		}
-		if len(versions) > 0 {
-			return versions[len(versions)-1].ID, true
-		}
-	}
-
-	return 0, false
 }
 
 func registerSingleProto(
@@ -615,128 +533,6 @@ func registerSingleProto(
 	}
 
 	framework.L.Debug().Msgf("Registered schema %s with ID %d", subject, result.ID)
+
 	return result.ID, nil
-}
-
-// determineFolderPrefixesToStrip determines which folder prefixes should be stripped from import paths
-// based on the folders configuration. The schema registry expects import names to be relative to the
-// configured folders, so we strip these prefixes to make imports work correctly.
-func determineFolderPrefixesToStrip(folders []string) []string {
-	var prefixes []string
-	for _, folder := range folders {
-		// Ensure folder ends with / for prefix matching
-		prefix := strings.TrimSuffix(folder, "/") + "/"
-		prefixes = append(prefixes, prefix)
-	}
-	return prefixes
-}
-
-// stripFolderPrefix removes any configured folder prefixes from the given path
-func stripFolderPrefix(path string, prefixes []string) string {
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(path, prefix) {
-			return strings.TrimPrefix(path, prefix)
-		}
-	}
-	return path
-}
-
-// transformSchemaContent removes folder prefixes from import statements in protobuf source
-func transformSchemaContent(content string, prefixes []string) string {
-	modified := content
-	for _, prefix := range prefixes {
-		// Transform import statements like "workflows/v1/" to "v1/"
-		modified = strings.ReplaceAll(modified, `"`+prefix, `"`)
-	}
-	return modified
-}
-
-// buildDependencyGraph builds a dependency graph from protobuf files
-func buildDependencyGraph(protoMap map[string]string) (map[string][]string, error) {
-	dependencies := make(map[string][]string)
-
-	framework.L.Debug().Msgf("Building dependency graph for %d proto files", len(protoMap))
-
-	// Initialize dependencies map
-	for path := range protoMap {
-		dependencies[path] = []string{}
-	}
-
-	// Parse imports and build dependency graph
-	for path, content := range protoMap {
-		imports := extractImportStatements(content)
-
-		for _, importPath := range imports {
-			if strings.HasPrefix(importPath, "google/protobuf/") {
-				// Skip Google protobuf imports as they're not in our protoMap
-				continue
-			}
-
-			// Check if this import exists in our protoMap
-			if _, exists := protoMap[importPath]; exists {
-				// Check for self-reference - this indicates either an invalid proto file
-				// or a potential bug in our import/path handling
-				if importPath == path {
-					framework.L.Warn().Msgf("Self-reference detected: file %s imports itself (import: %s). This suggests either an invalid proto file or a path normalization issue. Skipping this dependency to avoid cycles.", path, importPath)
-					// Continue without adding the dependency to avoid cycles, but don't fail registration
-					// as this might be a recoverable issue or edge case
-					continue
-				}
-
-				dependencies[path] = append(dependencies[path], importPath)
-			} else {
-				framework.L.Warn().Msgf("Import %s in %s not found in protoMap", importPath, path)
-			}
-		}
-	}
-
-	return dependencies, nil
-}
-
-// topologicalSort performs topological sorting using Kahn's algorithm
-func topologicalSort(dependencies map[string][]string) ([]string, error) {
-	// Calculate in-degrees (how many files each file depends on)
-	inDegree := make(map[string]int)
-	for file := range dependencies {
-		inDegree[file] = 0
-	}
-
-	// Count dependencies for each file
-	for file, deps := range dependencies {
-		inDegree[file] = len(deps)
-	}
-
-	// Find files with no dependencies (in-degree = 0)
-	var queue []string
-	for file, degree := range inDegree {
-		if degree == 0 {
-			queue = append(queue, file)
-		}
-	}
-
-	var result []string
-	for len(queue) > 0 {
-		file := queue[0]
-		queue = queue[1:]
-		result = append(result, file)
-
-		// Reduce in-degree for files that depend on the current file
-		for dependent, deps := range dependencies {
-			for _, dep := range deps {
-				if dep == file {
-					inDegree[dependent]--
-					if inDegree[dependent] == 0 {
-						queue = append(queue, dependent)
-					}
-				}
-			}
-		}
-	}
-
-	// Check for cycles
-	if len(result) != len(dependencies) {
-		return nil, fmt.Errorf("circular dependency detected in protobuf files")
-	}
-
-	return result, nil
 }


### PR DESCRIPTION
Reverts smartcontractkit/chainlink-testing-framework#2036

Doesn't fully work:
```
9:45AM INF Registering and fetching protos from 1 repositories
9:45AM WRN GITHUB_TOKEN is not set, using unauthenticated GitHub client. This may cause rate limiting issues when downloading proto files
9:45AM INF Registering 12 protobuf schemas
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/user_logs.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/workflow_status_changed.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/capability_finished.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/capability_started.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/metering.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/workflow_finished.proto not found in protoMap
9:45AM WRN Import workflows/v1/metadata.proto in workflows/workflows/v1/workflow_started.proto not found in protoMap
9:45AM INF ✔ Registered: workflows/common/v1/base_message.proto as cre-common.v1.BaseMessage
```
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the configuration and error handling for fetching and registering protobuf schemas from GitHub repositories. They simplify the process by removing unnecessary configurations and enhancing the logging mechanism to give more detailed feedback during the process.

## What
- **framework/components/dockercompose/chip_ingress_set/protos.go**
  - Removed `ExcludeFiles` field from `ProtoSchemaSet` struct to simplify configuration.
  - Added detailed debug logging to enhance visibility during proto fetching and registration processes.
  - Simplified GitHub token check and client creation logic to make it more readable.
  - Removed exclusion logic for files during proto fetching to simplify the process.
  - Improved error messages and added debug logs for better troubleshooting.
  - Changed the registration function name to `registerAllWithTopologicalSortingByTrial` and updated its logic to try registering protos in different orders if necessary, improving robustness.
  - Streamlined the proto fetching function to enhance clarity and maintainability.
  - Removed unused code related to dependency graph building and topological sorting, simplifying the registration process.
  - Updated comments and logging messages to reflect the simplified approach to proto registration.
