### PR TITLE
Expose a function that is used to name containers in simple node set

### DIFF
--- a/framework/.changeset/v0.10.17.md
+++ b/framework/.changeset/v0.10.17.md
@@ -1,0 +1,1 @@
+- Expose a function that is used to name containers in simple node set

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -65,6 +65,10 @@ func NewSharedDBNodeSet(in *Input, bcOut *blockchain.Output) (*Output, error) {
 	return out, nil
 }
 
+func NodeNamePrefix(nodeSetName string) string {
+	return nodeSetName + "-" + "node"
+}
+
 func printURLs(out *Output) {
 	if out == nil {
 		return
@@ -113,7 +117,6 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 	mu := &sync.Mutex{}
 	for i := 0; i < in.Nodes; i++ {
 		overrideIdx := i
-		var nodeName string
 		if in.OverrideMode == "all" {
 			if len(in.NodeSpecs[overrideIdx].Node.CustomPorts) > 0 {
 				return nil, fmt.Errorf("custom_ports can be used only with override_mode = 'each'")
@@ -132,8 +135,7 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 			if in.NodeSpecs[overrideIdx].Node.TestConfigOverrides != "" {
 				net = in.NodeSpecs[overrideIdx].Node.TestConfigOverrides
 			}
-			nodeName = fmt.Sprintf("node%d", i)
-			nodeWithNodeSetPrefixName := fmt.Sprintf("%s-%s", in.Name, nodeName)
+			nodeWithNodeSetPrefixName := NodeNamePrefix(in.Name) + "-" + fmt.Sprint(i)
 
 			nodeSpec := &clnode.Input{
 				NoDNS:   in.NoDNS,

--- a/framework/components/simple_node_set/node_set.go
+++ b/framework/components/simple_node_set/node_set.go
@@ -135,7 +135,7 @@ func sharedDBSetup(in *Input, bcOut *blockchain.Output) (*Output, error) {
 			if in.NodeSpecs[overrideIdx].Node.TestConfigOverrides != "" {
 				net = in.NodeSpecs[overrideIdx].Node.TestConfigOverrides
 			}
-			nodeWithNodeSetPrefixName := NodeNamePrefix(in.Name) + "-" + fmt.Sprint(i)
+			nodeWithNodeSetPrefixName := NodeNamePrefix(in.Name) + fmt.Sprint(i)
 
 			nodeSpec := &clnode.Input{
 				NoDNS:   in.NoDNS,


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The pull request introduces a new utility function to generate node names with a consistent prefix and refactors the node naming process within the `sharedDBSetup` function to utilize this new approach. This change improves the readability and maintainability of the code by centralizing the logic for node name generation.

## What
- **framework/.changeset/v0.10.17.md**
  - Added a changeset file to document the new function exposure for naming containers in a simple node set.
- **framework/components/simple_node_set/node_set.go**
  - Introduced a new function `NodeNamePrefix` that generates a prefix for node names based on the node set name.
  - Refactored the node naming in `sharedDBSetup` to use the new `NodeNamePrefix` function, streamlining the process and improving code clarity.
