### PR TITLE
override chain id for Geth

### DIFF
--- a/framework/.changeset/v0.10.19.md
+++ b/framework/.changeset/v0.10.19.md
@@ -1,0 +1,1 @@
+- Configure Geth chain id

--- a/framework/components/blockchain/geth.go
+++ b/framework/components/blockchain/geth.go
@@ -17,7 +17,7 @@ const (
 	RootFundingWallet = `{"address":"f39fd6e51aad88f6f4ce6ab8827279cfffb92266","crypto":{"cipher":"aes-128-ctr","ciphertext":"c36afd6e60b82d6844530bd6ab44dbc3b85a53e826c3a7f6fc6a75ce38c1e4c6","cipherparams":{"iv":"f69d2bb8cd0cb6274535656553b61806"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"80d5f5e38ba175b6b89acfc8ea62a6f163970504af301292377ff7baafedab53"},"mac":"f2ecec2c4d05aacc10eba5235354c2fcc3776824f81ec6de98022f704efbf065"},"id":"e5c124e9-e280-4b10-a27b-d7f3e516b408","version":3}`
 	GenesisClique     = `{
   "config": {
-    "chainId": 1337,
+    "chainId": %s,
     "homesteadBlock": 0,
     "daoForkBlock": 0,
     "daoForkSupport": true,
@@ -123,7 +123,7 @@ func newGeth(in *Input) (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = genesisFile.WriteString(GenesisClique)
+	_, err = genesisFile.WriteString(fmt.Sprintf(GenesisClique, in.ChainID))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes made are aimed at enhancing the flexibility and configurability of the Geth component within a blockchain framework. Specifically, by allowing the chain ID to be dynamically configured, it can better support various testing and development scenarios.

## What
- **framework/.changeset/v0.10.19.md**  
  - Added a changeset file to document the new configuration feature for Geth chain id.
- **framework/components/blockchain/geth.go**  
  - Modified the `GenesisClique` constant to allow dynamic insertion of the chain ID via a formatted string.  
  - Updated the `newGeth` function to dynamically insert the `ChainID` into the genesis configuration, enhancing flexibility for different network setups.
