### PR TITLE
TON: enable embedded http server

### DIFF
--- a/framework/.changeset/v0.10.20.md
+++ b/framework/.changeset/v0.10.20.md
@@ -1,0 +1,1 @@
+- Update TON/MyLocalTON 3.7 Default Settings

--- a/framework/components/blockchain/ton.go
+++ b/framework/components/blockchain/ton.go
@@ -65,11 +65,12 @@ func newTon(in *Input) (*Output, error) {
 	networkName := network.Name
 
 	baseEnv := map[string]string{
-		"GENESIS":              "true",
-		"NAME":                 "genesis",
-		"LITE_PORT":            ports.LiteServer,
-		"CUSTOM_PARAMETERS":    "--state-ttl 315360000 --archive-ttl 315360000",
-		"VERSION_CAPABILITIES": "11",
+		"GENESIS":                        "true",
+		"NAME":                           "genesis",
+		"LITE_PORT":                      ports.LiteServer,
+		"CUSTOM_PARAMETERS":              "--state-ttl 315360000 --archive-ttl 315360000",
+		"EMBEDDED_FILE_HTTP_SERVER":      "true",
+		"EMBEDDED_FILE_HTTP_SERVER_PORT": in.Port,
 	}
 
 	// merge with additional environment variables from input

--- a/framework/examples/myproject/smoke_ton.toml
+++ b/framework/examples/myproject/smoke_ton.toml
@@ -1,7 +1,8 @@
 [blockchain_a]
   type = "ton"
-  image = "ghcr.io/neodix42/mylocalton-docker:dev"
+  image = "ghcr.io/neodix42/mylocalton-docker:v3.7"
   port = "8000"
   
   [blockchain_a.custom_env]
-  VERSION_CAPABILITIES = "11"
+  EMBEDDED_FILE_HTTP_SERVER = "true"
+  EMBEDDED_FILE_HTTP_SERVER_PORT = "8000"

--- a/framework/examples/myproject/smoke_ton_test.go
+++ b/framework/examples/myproject/smoke_ton_test.go
@@ -28,6 +28,7 @@ func TestTonSmoke(t *testing.T) {
 	defer bc.Container.Terminate(t.Context())
 
 	var client ton.APIClientWrapped
+
 	t.Run("setup:connect", func(t *testing.T) {
 		connectionPool := liteclient.NewConnectionPool()
 		cfg, cferr := liteclient.GetConfigFromUrl(t.Context(), fmt.Sprintf("http://%s/localhost.global.config.json", bc.Nodes[0].ExternalHTTPUrl))


### PR DESCRIPTION
This PR fixes the incompatibility issue that was introduced in 3.5, by enabling embedded fileserver in genesis node

https://github.com/neodix42/mylocalton-docker/releases/tag/v3.7
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes update the TON blockchain component and the corresponding test environment to use the latest settings and docker image version (v3.7). The addition of an embedded file HTTP server in the TON component configuration enhances functionality, allowing for more versatile interaction with the blockchain network during testing.

## What
- **framework/.changeset/v0.10.20.md**
  - Added a changeset file to document the update to TON/MyLocalTON default settings to version 3.7.
- **framework/components/blockchain/ton.go**
  - Added `EMBEDDED_FILE_HTTP_SERVER` and `EMBEDDED_FILE_HTTP_SERVER_PORT` to the environment variables for the TON blockchain component, specifying the activation of an embedded file server and its port.
- **framework/examples/myproject/smoke_ton.toml**
  - Updated the TON docker image version to `v3.7` from `dev`.
  - Replaced `VERSION_CAPABILITIES` with `EMBEDDED_FILE_HTTP_SERVER` and `EMBEDDED_FILE_HTTP_SERVER_PORT` environment variables, aligning the configuration with the changes made in `ton.go`.
- **framework/examples/myproject/smoke_ton_test.go**
  - Added a newline for clarity, but no substantive changes to test logic or functionality were made.
