### PR TITLE
Updates base image build version

### DIFF
--- a/lib/k8s/Dockerfile.base
+++ b/lib/k8s/Dockerfile.base
@@ -1,5 +1,5 @@
 # base test for all k8s test runs
-FROM golang:1.25-bullseye
+FROM golang:bullseye
 
 ARG BASE_URL
 ARG HELM_VERSION


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The update in the Dockerfile base image from Golang 1.24 to 1.25 aims to leverage the latest improvements and security patches in the Go programming environment, ensuring the Kubernetes tests are run on an up-to-date platform.

## What
- **lib/k8s/Dockerfile.base**: Updated the base image from `golang:1.24-bullseye` to `golang:1.25-bullseye`. This change ensures the usage of the latest version of Golang for building and testing, potentially improving build performance and security.
