### PR TITLE
TON: fix http server port mapping

### DIFF
--- a/framework/.changeset/v0.10.23.md
+++ b/framework/.changeset/v0.10.23.md
@@ -1,0 +1,1 @@
+- Fixes TON port mappping, update examples and docs

--- a/framework/components/blockchain/ton.go
+++ b/framework/components/blockchain/ton.go
@@ -2,10 +2,7 @@ package blockchain
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -28,62 +25,6 @@ const (
 	defaultLiteServerPublicKey = "E7XwFSQzNkcRepUC23J2nRpASXpnsEKmyyHYV4u/FZY="
 	liteServerPortOffset       = 100 // arbitrary offset for lite server port
 )
-
-// TON config structures (e.g.: ton-blockchain.github.io/testnet-global.config.json)
-type tonLiteServer struct {
-	IP   int64 `json:"ip"`
-	Port int   `json:"port"`
-	ID   struct {
-		Key  string `json:"key"`
-		Type string `json:"@type"`
-	} `json:"id"`
-}
-
-type tonConfig struct {
-	LiteServers []tonLiteServer `json:"liteservers"`
-}
-
-// convert int64 IP to string format (matches https://github.com/xssnick/tonutils-go/liteclient/connection.go/intToIP4)
-func intToIP4(ip int64) string {
-	uip := uint32(ip) //nolint:gosec // IP conversion is safe for TON format
-	return fmt.Sprintf("%d.%d.%d.%d",
-		(uip>>24)&0xFF,
-		(uip>>16)&0xFF,
-		(uip>>8)&0xFF,
-		uip&0xFF)
-}
-
-// fetch and parse TON config to generate liteserver URLs
-func fetchTonConfig(configURL string) ([]string, error) {
-	parsedURL, err := url.Parse(configURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid config URL: %w", err)
-	}
-	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		return nil, fmt.Errorf("invalid URL scheme: %s", parsedURL.Scheme)
-	}
-
-	resp, err := http.Get(configURL) //nolint:gosec // URL is validated above
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch config: %w", err)
-	}
-	defer resp.Body.Close()
-	defer resp.Body.Close()
-
-	var config tonConfig
-	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
-		return nil, fmt.Errorf("failed to decode config: %w", err)
-	}
-
-	var liteServerURLs []string
-	for _, ls := range config.LiteServers {
-		ipStr := intToIP4(ls.IP)
-		url := fmt.Sprintf("liteserver://%s@%s:%d", ls.ID.Key, ipStr, ls.Port)
-		liteServerURLs = append(liteServerURLs, url)
-	}
-
-	return liteServerURLs, nil
-}
 
 type portMapping struct {
 	HTTPServer string
@@ -194,18 +135,6 @@ func newTon(in *Input) (*Output, error) {
 	name, err := c.Name(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	// fetch config and generate liteserver URLs from actual config
-	configURL := fmt.Sprintf("http://localhost:%s/localhost.global.config.json", ports.SimpleServer)
-
-	liteServerURLs, err := fetchTonConfig(configURL)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(liteServerURLs) == 0 {
-		return nil, fmt.Errorf("no liteservers found in config")
 	}
 
 	return &Output{

--- a/framework/examples/myproject/smoke_ton.toml
+++ b/framework/examples/myproject/smoke_ton.toml
@@ -1,6 +1,6 @@
 [blockchain_a]
   type = "ton"
   image = "ghcr.io/neodix42/mylocalton-docker:v3.7"
-  port = "8000"
+  port = "9000"
   
   [blockchain_a.custom_env]


### PR DESCRIPTION
This PR 
* Fixes misconfigured MyLocalTON http server port mapping
* Removes complex config fetch - parsing logic
* Update examples and docs
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes streamline the interaction with TON blockchain in the testing framework by simplifying the network configuration and connection process. This includes automatic port mapping and ready-to-use liteserver connection URLs, enhancing the ease of connecting to TON liteservers without manual configuration parsing.

## What
- **book/src/framework/components/blockchains/ton.md**
  - Updated documentation to reflect changes in network configuration and default ports, emphasizing direct liteserver connections and automatic port mapping.
- **framework/.changeset/v0.10.23.md**
  - Added a changeset file indicating fixes to TON port mapping and updates to examples and documentation.
- **framework/components/blockchain/ton.go**
  - Simplified TON container setup by removing unnecessary config fetching and parsing. Now directly uses pre-defined liteserver URLs and handles port mappings internally.
  - Introduced `defaultLiteServerPort` and `defaultLiteServerPublicKey` constants for simplified liteserver connection setup.
- **framework/examples/myproject/smoke_ton.toml**
  - Updated the default port in the TOML configuration file to reflect changes in port handling for TON blockchain setup.
