### PR TITLE
Add custom on chain target prom, specify container name for blockchains

### DIFF
--- a/framework/.changeset/v0.10.24.md
+++ b/framework/.changeset/v0.10.24.md
@@ -1,0 +1,2 @@
+- On chain metrics scrape targets
+- Allow to specify custom names for blockchain containers

--- a/framework/components/blockchain/blockchain.go
+++ b/framework/components/blockchain/blockchain.go
@@ -34,10 +34,11 @@ const (
 // Input is a blockchain network configuration params
 type Input struct {
 	// Common EVM fields
-	Type      string `toml:"type" validate:"required,oneof=anvil geth besu solana aptos tron sui ton" envconfig:"net_type"`
-	Image     string `toml:"image"`
-	PullImage bool   `toml:"pull_image"`
-	Port      string `toml:"port"`
+	Type          string `toml:"type" validate:"required,oneof=anvil geth besu solana aptos tron sui ton" envconfig:"net_type"`
+	Image         string `toml:"image"`
+	PullImage     bool   `toml:"pull_image"`
+	Port          string `toml:"port"`
+	ContainerName string `toml:"container_name"`
 	// Not applicable to Solana, ws port for Solana is +1 of port
 	WSPort                   string   `toml:"port_ws"`
 	ChainID                  string   `toml:"chain_id"`

--- a/framework/components/blockchain/containers.go
+++ b/framework/components/blockchain/containers.go
@@ -24,6 +24,9 @@ const (
 
 func baseRequest(in *Input, useWS ExposeWs) testcontainers.ContainerRequest {
 	containerName := framework.DefaultTCName("blockchain-node")
+	if in.ContainerName != "" {
+		containerName = in.ContainerName
+	}
 	bindPort := fmt.Sprintf("%s/tcp", in.Port)
 	exposedPorts := []string{bindPort}
 	if useWS {

--- a/framework/observability/compose/conf/prometheus.yml
+++ b/framework/observability/compose/conf/prometheus.yml
@@ -4,9 +4,9 @@ global:
 scrape_configs:
   - job_name: 'on-chain-metrics'
     metrics_path: /on-chain-metrics
-    scrape_interval: 10s
+    scrape_interval: 2s
     static_configs:
-      - targets: [ 'host.docker.internal:9112', 'on-chain-metrics:9112']
+      - targets: [ 'host.docker.internal:9112', '172.17.0.1:9112']
   - job_name: 'otel-collector'
     scrape_interval: 10s
     static_configs:

--- a/framework/observability/compose/conf/prometheus.yml
+++ b/framework/observability/compose/conf/prometheus.yml
@@ -2,6 +2,11 @@ global:
   scrape_interval: 10s
 
 scrape_configs:
+  - job_name: 'on-chain-metrics'
+    metrics_path: /on-chain-metrics
+    scrape_interval: 10s
+    static_configs:
+      - targets: [ 'host.docker.internal:9112', 'on-chain-metrics:9112']
   - job_name: 'otel-collector'
     scrape_interval: 10s
     static_configs:


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve the flexibility and observability of the blockchain framework. They allow for custom container names for blockchain nodes, enhancing the ability to organize and identify containers easily. Additionally, by introducing on-chain metrics scrape targets in Prometheus configuration, the changes enable more detailed monitoring of blockchain operations.

## What
- **`framework/.changeset/v0.10.24.md`**
  - Added release notes for v0.10.24, mentioning the introduction of on-chain metrics scrape targets and the ability to specify custom names for blockchain containers.
- **`framework/components/blockchain/blockchain.go`**
  - Added a new field `ContainerName` to the `Input` struct to allow specifying custom container names.
- **`framework/components/blockchain/containers.go`**
  - Modified `baseRequest` function to use the custom container name from `Input` if provided.
- **`framework/observability/compose/conf/prometheus.yml`**
  - Added a new scrape configuration for on-chain metrics with a scrape interval of 2 seconds and specified targets, enhancing Prometheus monitoring capabilities.
