### PR TITLE
Geth-specific Blockscout version + internal txs + verifier

### DIFF
--- a/framework/.changeset/v0.10.27.md
+++ b/framework/.changeset/v0.10.27.md
@@ -1,0 +1,1 @@
+- Blockscout Geth variant + internal transactions + verifier

--- a/framework/cmd/main.go
+++ b/framework/cmd/main.go
@@ -147,7 +147,10 @@ func main() {
 						Aliases:     []string{"u"},
 						Description: "Spins up Blockscout stack",
 						Action: func(c *cli.Context) error {
-							return framework.BlockScoutUp(c.String("rpc"))
+							return framework.BlockScoutUp(
+								c.String("rpc"),
+								c.String("chain-id"),
+							)
 						},
 					},
 					{
@@ -169,7 +172,10 @@ func main() {
 							if err := framework.BlockScoutDown(rpc); err != nil {
 								return err
 							}
-							return framework.BlockScoutUp(rpc)
+							return framework.BlockScoutUp(
+								c.String("rpc"),
+								c.String("chain-id"),
+							)
 						},
 					},
 				},

--- a/framework/observability.go
+++ b/framework/observability.go
@@ -78,12 +78,13 @@ func extractAllFiles(embeddedDir string) error {
 	return err
 }
 
-func BlockScoutUp(url string) error {
+func BlockScoutUp(url, chainID string) error {
 	L.Info().Msg("Creating local Blockscout stack")
 	if err := extractAllFiles("observability"); err != nil {
 		return err
 	}
 	os.Setenv("BLOCKSCOUT_RPC_URL", url)
+	os.Setenv("BLOCKSCOUT_CHAID_ID", chainID)
 	// old migrations for v15 is still applied somehow, cleaning up DB helps
 	if err := RunCommand("bash", "-c", fmt.Sprintf(`
 		cd %s && \
@@ -117,14 +118,7 @@ func BlockScoutDown(url string) error {
 	if err != nil {
 		return err
 	}
-	return RunCommand("bash", "-c", fmt.Sprintf(`
-		cd %s && \
-		rm -rf blockscout-db-data && \
-		rm -rf logs && \
-		rm -rf redis-data && \
-		rm -rf stats-db-data && \
-		rm -rf dets
-	`, filepath.Join("blockscout", "services")))
+	return RunCommand("bash", "-c", "rm -rf blockscout/")
 }
 
 func ObservabilityUp() error {

--- a/framework/observability.go
+++ b/framework/observability.go
@@ -180,5 +180,5 @@ func ObservabilityDown() error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return RunCommand("bash", "-c", "rm -rf compose/")
 }

--- a/framework/observability/blockscout/docker-compose.yml
+++ b/framework/observability/blockscout/docker-compose.yml
@@ -39,12 +39,14 @@ services:
     links:
       - db:database
     environment:
-      ETHEREUM_JSONRPC_HTTP_URL: ${BLOCKSCOUT_RPC_URL:-http://host.docker.internal:8555}
-      ETHEREUM_JSONRPC_TRACE_URL: ${BLOCKSCOUT_RPC_URL:-http://host.docker.internal:8555}
-      MICROSERVICE_SC_VERIFIER_ENABLED: true
-      MICROSERVICE_SC_VERIFIER_URL: http://smart-contract-verifier:8050/
-      MICROSERVICE_SC_VERIFIER_TYPE: sc_verifier
-      CHAIN_ID: ${BLOCKSCOUT_CHAIN_ID:-1337}
+        # 'anvil' do not support internal transactions
+        ETHEREUM_JSONRPC_VARIANT: 'geth'
+        ETHEREUM_JSONRPC_HTTP_URL: ${BLOCKSCOUT_RPC_URL}
+        ETHEREUM_JSONRPC_TRACE_URL: ${BLOCKSCOUT_RPC_URL}
+        CHAIN_ID: ${BLOCKSCOUT_CHAIN_ID:-1337}
+        MICROSERVICE_SC_VERIFIER_ENABLED: true
+        MICROSERVICE_SC_VERIFIER_URL: http://smart-contract-verifier:8050/
+        MICROSERVICE_SC_VERIFIER_TYPE: sc_verifier
 
   nft_media_handler:
     depends_on:

--- a/framework/observability/blockscout/docker-compose.yml
+++ b/framework/observability/blockscout/docker-compose.yml
@@ -17,6 +17,13 @@ services:
       file: ./services/db.yml
       service: db
 
+  sc-verifier:
+    extends:
+      file: ./services/smart-contract-verifier.yml
+      service: smart-contract-verifier
+    ports:
+      - 8082:8050
+
   backend:
     depends_on:
       - db
@@ -32,10 +39,12 @@ services:
     links:
       - db:database
     environment:
-        ETHEREUM_JSONRPC_HTTP_URL: http://host.docker.internal:8545/
-        ETHEREUM_JSONRPC_TRACE_URL: http://host.docker.internal:8545/
-        ETHEREUM_JSONRPC_WS_URL: ws://host.docker.internal:8545/
-        CHAIN_ID: '1337'
+      ETHEREUM_JSONRPC_HTTP_URL: ${BLOCKSCOUT_RPC_URL:-http://host.docker.internal:8555}
+      ETHEREUM_JSONRPC_TRACE_URL: ${BLOCKSCOUT_RPC_URL:-http://host.docker.internal:8555}
+      MICROSERVICE_SC_VERIFIER_ENABLED: true
+      MICROSERVICE_SC_VERIFIER_URL: http://smart-contract-verifier:8050/
+      MICROSERVICE_SC_VERIFIER_TYPE: sc_verifier
+      CHAIN_ID: ${BLOCKSCOUT_CHAIN_ID:-1337}
 
   nft_media_handler:
     depends_on:
@@ -103,3 +112,4 @@ services:
     extends:
       file: ./services/nginx.yml
       service: proxy
+

--- a/framework/observability/blockscout/services/backend.yml
+++ b/framework/observability/blockscout/services/backend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   backend:
-    image: ghcr.io/blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-latest}
+    image: ghcr.io/blockscout/${DOCKER_REPO:-blockscout}:${DOCKER_TAG:-9.0.2.commit.2ab549a6}
     pull_policy: always
     restart: always
     stop_grace_period: 5m


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce support for specifying a blockchain node's chain ID when setting up a local Blockscout stack, enabling enhanced compatibility with different blockchain networks. Additionally, the introduction of a smart contract verifier service in the Blockscout docker-compose setup enhances the framework's capabilities in verifying smart contract interactions.

## What
- **framework/.changeset/v0.10.27.md**
  - Added a new changeset file indicating the addition of Blockscout Geth variant support, internal transactions, and verifier.
- **framework/cmd/main.go**
  - Modified `BlockScoutUp` command to accept `chain-id` as an argument, allowing users to specify the chain ID of the blockchain node Blockscout will index.
- **framework/observability.go**
  - Updated `BlockScoutUp` function to accept and set `chainID` environment variable, enhancing compatibility with different blockchain networks.
  - Changed `BlockScoutDown` and `ObservabilityDown` to remove Blockscout and observability resources more thoroughly by deleting respective directories.
- **framework/observability/blockscout/docker-compose.yml**
  - Added a new service `sc-verifier` for smart contract verification.
  - Updated the `backend` service to use the Geth variant for Ethereum JSONRPC and to enable the smart contract verifier service.
- **framework/observability/blockscout/services/backend.yml**
  - Updated the backend service image to a specific version supporting the new features.
