### PR TITLE
[COP-1751] more red panda flakyness fixes

### DIFF
--- a/framework/components/dockercompose/.changeset/v0.1.14.md
+++ b/framework/components/dockercompose/.changeset/v0.1.14.md
@@ -1,0 +1,1 @@
+- Red Panda Schema Registry: require 3x consecutive responses with 2xx status code, always use ipv4, when registering protos, retry on `EOF` response


### PR DESCRIPTION
- require 3 consecutive 2xx responses from schema registry to treat it as ready
- retry proto registration on `EOF` response
- always use ipv4 for proto registration
<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes improve reliability and compatibility in the Docker Compose setup for the Chip Ingress component, particularly focusing on enhancing the schema registry interaction. Adjustments were made to ensure more robust handling of network connections and responses from the schema registry. This includes requiring multiple consecutive successful responses, preferring IPv4 for connections, and adding retry logic for specific error responses, which overall enhances the stability and predictability of operations involving the schema registry.

## What
- **framework/components/dockercompose/.changeset/v0.1.14.md**
  - Added a changelog entry describing enhancements to the Red Panda Schema Registry interaction.
- **framework/components/dockercompose/chip_ingress_set/chip_ingress.go**
  - Removed waiting for Red Panda Kafka port in the startup sequence, focusing on schema registry readiness.
  - Integrated a new function, `checkSchemaRegistryReadiness`, to ensure the schema registry responds with 2xx status codes consecutively before proceeding, indicating readiness more reliably.
- **framework/components/dockercompose/chip_ingress_set/protos.go**
  - Modified the `registerAllWithTopologicalSorting` function, removing the unused `folders` parameter.
  - Improved HTTP client configuration for registering schemas, including disabling keep-alives and preferring IPv4, to mitigate potential network-related issues.
  - Adjusted error handling in the retry logic for schema registration to include EOF errors, aligning with changes aimed at enhancing stability in communication with the schema registry.
  - Added `isRetryableError` utility function to centralize retry logic based on specific network error messages.
