### PR TITLE
[CRE-1024] return cached output for Solana

### DIFF
--- a/framework/.changeset/v0.10.32.md
+++ b/framework/.changeset/v0.10.32.md
@@ -1,0 +1,1 @@
+- Return cached output for Solana

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -44,6 +44,9 @@ func defaultSolana(in *Input) {
 }
 
 func newSolana(in *Input) (*Output, error) {
+	if in.Out != nil && in.Out.UseCache {
+		return in.Out, nil
+	}
 	defaultSolana(in)
 	ctx := context.Background()
 


### PR DESCRIPTION

<!-- DON'T DELETE. add your comments above llm generated contents -->
---
**Below is a summarization created by an LLM (gpt-4-0125-preview). Be mindful of hallucinations and verify accuracy.**

## Why
The changes introduce a caching mechanism for the Solana blockchain component to improve efficiency by avoiding unnecessary re-initializations. By returning a cached output if available, it reduces the time and resources required for operations that can use previously cached data.

## What
- **framework/.changeset/v0.10.32.md**
  - Added a changeset file to document the update about returning cached output for Solana. This indicates a version update and provides information on the enhancement for users or developers.
- **framework/components/blockchain/solana.go**
  - Introduced a conditional statement to check if the output cache (`in.Out`) is not nil and if `UseCache` is true. If both conditions are met, the function returns the cached output immediately without re-initializing the Solana component. This change optimizes the performance by leveraging available cached data, thus avoiding the overhead of redundant initialization processes.
