### PR TITLE
fix(sui,aptos): skip tarring cwd when ContractsDir is empty

### DIFF
--- a/framework/.changeset/v0.15.16.md
+++ b/framework/.changeset/v0.15.16.md
@@ -1,0 +1,1 @@
+- Fix Sui/Aptos CTF providers tarring the process working directory when `ContractsDir` is empty, eliminating an `archive/tar: write too long` flake in downstream CCIP smoke tests

--- a/framework/components/blockchain/aptos.go
+++ b/framework/components/blockchain/aptos.go
@@ -55,6 +55,20 @@ func newAptos(ctx context.Context, in *Input) (*Output, error) {
 	defaultAptos(in)
 	containerName := framework.DefaultTCName("blockchain-node")
 
+	var files []testcontainers.ContainerFile
+	if in.ContractsDir != "" {
+		absPath, err := filepath.Abs(in.ContractsDir)
+		if err != nil {
+			return nil, err
+		}
+		files = []testcontainers.ContainerFile{
+			{
+				HostFilePath:      absPath,
+				ContainerFilePath: "/",
+			},
+		}
+	}
+
 	exposedPorts, bindings, err := framework.GenerateCustomPortsData(in.CustomPorts)
 	if err != nil {
 		return nil, err
@@ -103,23 +117,7 @@ func newAptos(ctx context.Context, in *Input) (*Output, error) {
 		},
 		ImagePlatform: imagePlatform,
 		Cmd:           cmd,
-	}
-
-	// Only copy host contracts into the container when the caller explicitly
-	// provides a ContractsDir. See sui.go for the full rationale — in short,
-	// filepath.Abs("") resolves to cwd, and tarring a live test working
-	// directory can flake with archive/tar: write too long.
-	if in.ContractsDir != "" {
-		absPath, err := filepath.Abs(in.ContractsDir)
-		if err != nil {
-			return nil, err
-		}
-		req.Files = []testcontainers.ContainerFile{
-			{
-				HostFilePath:      absPath,
-				ContainerFilePath: "/",
-			},
-		}
+		Files:         files,
 	}
 
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/framework/components/blockchain/aptos.go
+++ b/framework/components/blockchain/aptos.go
@@ -55,11 +55,6 @@ func newAptos(ctx context.Context, in *Input) (*Output, error) {
 	defaultAptos(in)
 	containerName := framework.DefaultTCName("blockchain-node")
 
-	absPath, err := filepath.Abs(in.ContractsDir)
-	if err != nil {
-		return nil, err
-	}
-
 	exposedPorts, bindings, err := framework.GenerateCustomPortsData(in.CustomPorts)
 	if err != nil {
 		return nil, err
@@ -108,12 +103,23 @@ func newAptos(ctx context.Context, in *Input) (*Output, error) {
 		},
 		ImagePlatform: imagePlatform,
 		Cmd:           cmd,
-		Files: []testcontainers.ContainerFile{
+	}
+
+	// Only copy host contracts into the container when the caller explicitly
+	// provides a ContractsDir. See sui.go for the full rationale — in short,
+	// filepath.Abs("") resolves to cwd, and tarring a live test working
+	// directory can flake with archive/tar: write too long.
+	if in.ContractsDir != "" {
+		absPath, err := filepath.Abs(in.ContractsDir)
+		if err != nil {
+			return nil, err
+		}
+		req.Files = []testcontainers.ContainerFile{
 			{
 				HostFilePath:      absPath,
 				ContainerFilePath: "/",
 			},
-		},
+		}
 	}
 
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/framework/components/blockchain/sui.go
+++ b/framework/components/blockchain/sui.go
@@ -95,6 +95,20 @@ func newSui(ctx context.Context, in *Input) (*Output, error) {
 	defaultSui(in)
 	containerName := framework.DefaultTCName("blockchain-node")
 
+	var files []testcontainers.ContainerFile
+	if in.ContractsDir != "" {
+		absPath, err := filepath.Abs(in.ContractsDir)
+		if err != nil {
+			return nil, err
+		}
+		files = []testcontainers.ContainerFile{
+			{
+				HostFilePath:      absPath,
+				ContainerFilePath: "/",
+			},
+		}
+	}
+
 	// Sui container always listens on port 9000 internally
 	containerPort := fmt.Sprintf("%s/tcp", DefaultSuiNodePort)
 
@@ -145,28 +159,9 @@ func newSui(ctx context.Context, in *Input) (*Output, error) {
 			"--force-regenesis",
 			"--with-faucet",
 		},
+		Files: files,
 		// we need faucet for funding
 		WaitingFor: wait.ForListeningPort(DefaultFaucetPort).WithStartupTimeout(1 * time.Minute).WithPollInterval(200 * time.Millisecond),
-	}
-
-	// Only copy host contracts into the container when the caller explicitly
-	// provides a ContractsDir. When empty, filepath.Abs("") resolves to the
-	// process working directory, which in integration tests is an actively
-	// written test working directory (logs, db dumps, artifacts). testcontainers
-	// tars that whole directory via archive/tar, and any file that grows
-	// between os.Stat (header size) and io.Copy (body) triggers
-	// archive/tar: write too long, surfacing as a flaky test.
-	if in.ContractsDir != "" {
-		absPath, err := filepath.Abs(in.ContractsDir)
-		if err != nil {
-			return nil, err
-		}
-		req.Files = []testcontainers.ContainerFile{
-			{
-				HostFilePath:      absPath,
-				ContainerFilePath: "/",
-			},
-		}
 	}
 
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/framework/components/blockchain/sui.go
+++ b/framework/components/blockchain/sui.go
@@ -95,11 +95,6 @@ func newSui(ctx context.Context, in *Input) (*Output, error) {
 	defaultSui(in)
 	containerName := framework.DefaultTCName("blockchain-node")
 
-	absPath, err := filepath.Abs(in.ContractsDir)
-	if err != nil {
-		return nil, err
-	}
-
 	// Sui container always listens on port 9000 internally
 	containerPort := fmt.Sprintf("%s/tcp", DefaultSuiNodePort)
 
@@ -150,14 +145,28 @@ func newSui(ctx context.Context, in *Input) (*Output, error) {
 			"--force-regenesis",
 			"--with-faucet",
 		},
-		Files: []testcontainers.ContainerFile{
+		// we need faucet for funding
+		WaitingFor: wait.ForListeningPort(DefaultFaucetPort).WithStartupTimeout(1 * time.Minute).WithPollInterval(200 * time.Millisecond),
+	}
+
+	// Only copy host contracts into the container when the caller explicitly
+	// provides a ContractsDir. When empty, filepath.Abs("") resolves to the
+	// process working directory, which in integration tests is an actively
+	// written test working directory (logs, db dumps, artifacts). testcontainers
+	// tars that whole directory via archive/tar, and any file that grows
+	// between os.Stat (header size) and io.Copy (body) triggers
+	// archive/tar: write too long, surfacing as a flaky test.
+	if in.ContractsDir != "" {
+		absPath, err := filepath.Abs(in.ContractsDir)
+		if err != nil {
+			return nil, err
+		}
+		req.Files = []testcontainers.ContainerFile{
 			{
 				HostFilePath:      absPath,
 				ContainerFilePath: "/",
 			},
-		},
-		// we need faucet for funding
-		WaitingFor: wait.ForListeningPort(DefaultFaucetPort).WithStartupTimeout(1 * time.Minute).WithPollInterval(200 * time.Millisecond),
+		}
 	}
 
 	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
## Summary

`newSui` and `newAptos` in `framework/components/blockchain/` unconditionally call `filepath.Abs(in.ContractsDir)` and attach the result as a `testcontainers.ContainerFile`. When the caller leaves `ContractsDir` empty (the common case for chains that do not need host contracts copied in), `filepath.Abs("")` resolves to the process **working directory**. testcontainers-go then tars that whole cwd via `archive/tar` to copy into the container.

In integration-tests the cwd is a live test working directory — log files, db dumps, artifact collectors — actively being appended to while the container starts. If a file grows between `tar.FileInfoHeader` (header size from `os.Stat`) and the subsequent `io.Copy`, stdlib's `tar.Writer` returns `ErrWriteTooLong` and testcontainers surfaces:

```
create container: created hook: can't copy <cwd> to container:
error compressing file: archive/tar: write too long
```

## Evidence — real CI failure

chainlink run [24372896623](https://github.com/smartcontractkit/chainlink/actions/runs/24372896623), job [71183740665](https://github.com/smartcontractkit/chainlink/actions/runs/24372896623/job/71183740665), test `Test_CCIPTokenTransfer_Sui2EVM_BurnMintTokenPool`:

```
ctf_provider.go:230: Attempt 1/10: Failed to start CTF Sui container:
  create container: created hook: can't copy
  /home/runner/_work/chainlink/chainlink/integration-tests/smoke/ccip to container:
  error compressing file: archive/tar: write too long
ctf_provider.go:230: Attempt 2/10: Failed to start CTF Sui container: ...
ctf_provider.go:230: Attempt 3/10: Failed to start CTF Sui container: ...
```

Cwd printed (`/home/runner/.../integration-tests/smoke/ccip`) matches the predicted race target exactly — that directory is actively written by `deployment/logger.SingleFileLogger` (relative `logs/` dir, `autoFlushWriter` syncs on every write) while the container starts.

## Cause chain (verified link-by-link)

1. **Caller passes empty `ContractsDir`** — `chainlink-deployments-framework/chain/sui/provider/ctf_provider.go:199-206` builds `blockchain.Input{Type: TypeSui, ...}` with no `ContractsDir` field. `CTFChainProviderConfig` exposes no such knob.
2. **`filepath.Abs("")` = cwd** — Go stdlib contract. `sui.go:98` on main: `absPath, err := filepath.Abs(in.ContractsDir)`.
3. **cwd attached as `ContainerFile`** — `sui.go:153-158`: `Files: []ContainerFile{{HostFilePath: absPath, ContainerFilePath: "/"}}`, unconditional.
4. **testcontainers-go tars the host dir** — `lifecycle.go:146-172` `defaultCopyFileToContainerHook` walks `HostFilePath`; Go's `archive/tar.Writer.Write` returns `ErrWriteTooLong` when body bytes exceed header `Size`.
5. **Retry absorbs most occurrences** — `chainlink-deployments-framework/chain/sui/provider/ctf_provider.go:152,226` wraps `NewBlockchainNetwork` in `retry.Do` with `retry.Attempts(10)`, `retry.Delay(1s)`. Most runs self-heal by attempt 2-3; occasional hard failures exhaust the retry budget.

## Fix

Gate the `ContainerFile` entry on `in.ContractsDir != ""`:

- Callers that explicitly pass a directory keep identical copy-to-container behaviour.
- Callers that need no host files (the current default for e.g. CCIP Sui smoke tests) no longer tar a busy cwd, eliminating the stat→stream race.

Applied to both `sui.go` and `aptos.go` — they share the identical shape and bug. Solana (`solana.go`) intentionally untouched: every Solana caller sets `ContractsDir` explicitly (Solana validator requires `.so` artifacts mounted at boot), so the race path is never exercised there.

## Safety analysis

- **Non-empty `ContractsDir` callers**: identical behaviour, same `filepath.Abs` + `ContainerFile` entry.
- **Empty `ContractsDir` callers**: `req.Files = nil`. testcontainers-go hook loops `for _, f := range files` — zero iterations on nil, no container-side state change. Verified in `testcontainers-go@v0.41.0/lifecycle.go:151`.
- **Org-wide audit of `TypeSui`/`TypeAptos` callers** returned 3: `chainlink-deployments-framework` Sui provider, `chainlink-deployments-framework` Aptos provider, `chainlink-aptos/integration-tests/ccip/ccip_deployment_test.go`. **None** pass a `ContractsDir`. The empty path isn't a documented default — the struct comment `` `toml:"contracts_dir" comment:"Solana's contracts directory"` `` explicitly scopes the field to Solana. The cwd-tarring was a latent side-effect of reusing the Solana-shaped field for Sui/Aptos, not a feature.
- Aptos/Sui containers don't consume tarred cwd contents regardless: `newSui` runs `sui start --force-regenesis --with-faucet` (stock validator + faucet), `newAptos` runs `aptos node run-local-testnet`. Neither reads files from `/` inside the container. Contract publishing happens host-side via `sui client publish` / `aptos move publish` over RPC against the running node.

## Test Plan

- [x] `go build ./components/blockchain/...` clean
- [x] `go vet ./components/blockchain/...` clean
- [x] CI green on this PR (TestAptosSmoke, TestSolanaSmoke, TestSmoke, TestChaos, lint, vuln, ~30 checks total all passing)
- [x] Downstream verification: chainlink PR [#22011](https://github.com/smartcontractkit/chainlink/pull/22011) bumps CTF to this branch's HEAD. Local `go build ./...` passes in `chainlink/deployment` and `chainlink/integration-tests`. Full chainlink CI pending post-merge bump.

## Notes

No behaviour change for anyone who was already setting `ContractsDir`. Draft until downstream chainlink verification CI confirms zero `archive/tar: write too long` retry lines in Sui CCIP smoke tests.
