### PR TITLE
fix(framework): return aptos container instance

### DIFF
--- a/framework/components/blockchain/aptos.go
+++ b/framework/components/blockchain/aptos.go
@@ -154,6 +154,7 @@ func newAptos(ctx context.Context, in *Input) (*Output, error) {
 		}
 	}
 	return &Output{
+		Container:     c,
 		UseCache:      true,
 		Type:          in.Type,
 		Family:        FamilyAptos,


### PR DESCRIPTION
This enables client code to properly cleanup the container.