### PR TITLE
remove static OTEL collector

### DIFF
--- a/framework/.changeset/v0.16.2.md
+++ b/framework/.changeset/v0.16.2.md
@@ -1,0 +1,1 @@
+- Remnove static ctf job from Prometheus config, because now we have Docker service discovery and having two OTEL collectors results in duplicated metrics

--- a/framework/observability/compose/conf/prometheus.yml
+++ b/framework/observability/compose/conf/prometheus.yml
@@ -7,10 +7,6 @@ scrape_configs:
     scrape_interval: 2s
     static_configs:
       - targets: [ 'host.docker.internal:9112', '172.17.0.1:9112']
-  - job_name: 'otel-collector'
-    scrape_interval: 10s
-    static_configs:
-      - targets: [ 'otel-collector:8889' ]
   - job_name: 'ctf'
     metrics_path: /metrics
     docker_sd_configs:


### PR DESCRIPTION
So that we don't have two collectors:
<img width="1283" height="51" alt="image" src="https://github.com/user-attachments/assets/0ce01313-f29d-4fce-abf1-8de2d44adc7a" />
