### PR TITLE
feat: victoria traces

### DIFF
--- a/framework/observability/compose-victoria-metrics/docker-compose.yml
+++ b/framework/observability/compose-victoria-metrics/docker-compose.yml
@@ -25,6 +25,24 @@ services:
       - vl-data:/vlogs
     restart: unless-stopped
 
+  # VictoriaTraces for distributed tracing
+  victoriatraces:
+    image: victoriametrics/victoria-traces:v0.9.3
+    container_name: victoriatraces
+    ports:
+      - "14317:4317" # VictoriaTraces OTLP ingestion
+      - "8443:8443" # VictoriaTraces UI
+    command:
+      - '-otlpGRPCListenAddr=:4317'
+      - '-otlpGRPC.tls=false'
+      - '--storageDataPath=/vtraces'
+      - '--retentionPeriod=7d'
+      - '--httpListenAddr=0.0.0.0:8443'
+      - '--logNewStreams'
+    volumes:
+      - vt-data:/vtraces
+    restart: unless-stopped
+
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.115.1
     container_name: otel-collector
@@ -37,6 +55,7 @@ services:
     depends_on:
       - victoriametrics
       - victorialogs
+      - victoriatraces
     restart: unless-stopped
 
   grafana:
@@ -61,9 +80,11 @@ services:
     depends_on:
       - victoriametrics
       - victorialogs
+      - victoriatraces
     restart: unless-stopped
 
 volumes:
   vm-data:
   vl-data:
+  vt-data:
   grafana-data:

--- a/framework/observability/compose-victoria-metrics/grafana/provisioning/datasources/datasources.yaml
+++ b/framework/observability/compose-victoria-metrics/grafana/provisioning/datasources/datasources.yaml
@@ -20,6 +20,7 @@ datasources:
     editable: true
 
   - name: VictoriaTraces
+    uid: victoriatraces
     type: jaeger
     access: proxy
     url: http://victoriatraces:8443/select/jaeger

--- a/framework/observability/compose-victoria-metrics/grafana/provisioning/datasources/datasources.yaml
+++ b/framework/observability/compose-victoria-metrics/grafana/provisioning/datasources/datasources.yaml
@@ -18,3 +18,9 @@ datasources:
     access: proxy
     url: http://victorialogs:9428
     editable: true
+
+  - name: VictoriaTraces
+    type: jaeger
+    access: proxy
+    url: http://victoriatraces:8443/select/jaeger
+    editable: true

--- a/framework/observability/compose-victoria-metrics/otel/otel-collector-config.yaml
+++ b/framework/observability/compose-victoria-metrics/otel/otel-collector-config.yaml
@@ -24,17 +24,27 @@ exporters:
     tls:
       insecure: true
 
+  otlp/traces:
+    endpoint: victoriatraces:4317
+    tls:
+      insecure: true
+
   debug:
     verbosity: basic
 
 service:
   pipelines:
     metrics:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [prometheusremotewrite, debug]
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ prometheusremotewrite, debug ]
 
     logs:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlphttp/logs, debug]
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ otlphttp/logs, debug ]
+
+    traces:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ otlp/traces, debug ]


### PR DESCRIPTION
## Summary

  - Add VictoriaTraces service (`v0.9.3`) to the VictoriaMetrics compose stack for distributed tracing.
  - Route OTLP traces pipeline through OTel collector to VictoriaTraces via gRPC.
  - Provision VictoriaTraces as a Jaeger datasource in Grafana.

  ## Testing

  - tested in devenv in https://github.com/smartcontractkit/chainlink-ccv/pull/1190