### PR TITLE
fix(framework/solana): add ChainID in solana output

### DIFF
--- a/framework/.changeset/v0.16.6.md
+++ b/framework/.changeset/v0.16.6.md
@@ -1,0 +1,1 @@
+- Return the ChainID in the Solana output

--- a/framework/components/blockchain/solana.go
+++ b/framework/components/blockchain/solana.go
@@ -167,6 +167,7 @@ func newSolana(ctx context.Context, in *Input) (*Output, error) {
 		UseCache:      true,
 		Type:          in.Type,
 		Family:        FamilySolana,
+		ChainID:       in.ChainID,
 		ContainerName: containerName,
 		Container:     c,
 		Nodes: []*Node{


### PR DESCRIPTION
This PR adds missing `ChainID` in `framework/solana`'s blockchain output